### PR TITLE
Update redundancy test

### DIFF
--- a/src/biomappings/tests/test_validity.py
+++ b/src/biomappings/tests/test_validity.py
@@ -69,21 +69,11 @@ def test_redundancy():
     """Test the redundancy of manually curated mappings and predicted mappings."""
     cnt = []
     for mapping in itt.chain(mappings, predictions):
-        cnt.append(
-            (
-                mapping['source prefix'],
-                mapping['source identifier'],
-                mapping['target prefix'],
-                mapping['target identifier'],
-            )
-            if mapping['source prefix'] < mapping['target prefix'] else
-            (
-                mapping['target prefix'],
-                mapping['target identifier'],
-                mapping['source prefix'],
-                mapping['source identifier'],
-            )
-        )
+        source = mapping['source prefix'], mapping['source identifier']
+        target = mapping['target prefix'], mapping['target identifier']
+        if source > target:
+            source, target = target, source
+        cnt.append((*source, *target))
         redundant = [k for k, v in Counter(cnt).items() if v > 1]
         if redundant:
             raise ValueError(f'Redundant: {redundant}')

--- a/src/biomappings/tests/test_validity.py
+++ b/src/biomappings/tests/test_validity.py
@@ -69,12 +69,21 @@ def test_redundancy():
     """Test the redundancy of manually curated mappings and predicted mappings."""
     cnt = []
     for mapping in itt.chain(mappings, predictions):
-        cnt.append((
-            mapping['source prefix'],
-            mapping['source identifier'],
-            mapping['target prefix'],
-            mapping['target identifier'],
-        ))
-    redundant = [k for k, v in Counter(cnt).items() if v > 1]
-    if redundant:
-        raise ValueError(f'Redundant: {redundant}')
+        cnt.append(
+            (
+                mapping['source prefix'],
+                mapping['source identifier'],
+                mapping['target prefix'],
+                mapping['target identifier'],
+            )
+            if mapping['source prefix'] < mapping['target prefix'] else
+            (
+                mapping['target prefix'],
+                mapping['target identifier'],
+                mapping['source prefix'],
+                mapping['source identifier'],
+            )
+        )
+        redundant = [k for k, v in Counter(cnt).items() if v > 1]
+        if redundant:
+            raise ValueError(f'Redundant: {redundant}')

--- a/src/biomappings/tests/test_validity.py
+++ b/src/biomappings/tests/test_validity.py
@@ -74,6 +74,6 @@ def test_redundancy():
         if source > target:
             source, target = target, source
         cnt.append((*source, *target))
-        redundant = [k for k, v in Counter(cnt).items() if v > 1]
-        if redundant:
-            raise ValueError(f'Redundant: {redundant}')
+    redundant = [k for k, v in Counter(cnt).items() if v > 1]
+    if redundant:
+        raise ValueError(f'Redundant: {redundant}')


### PR DESCRIPTION
The current redundancy check doesn't catch if the same equivalency shows up, but in the opposite order. This code sorts each equivalence into a "canonical" order where the first prefix should be earlier in sort order.

Caveats:
- ~What if two things are equivalent with same prefix? That's kind of silly, but it definitely happens in wikipathways!~ (solved in https://github.com/biomappings/biomappings/pull/10/commits/158e5c97b634cec55b9752b6341d47e37ccb36a6)
- Reporting will only show one direction