### PR TITLE
Extend Python version compatibility

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.6
       - name: Install dependencies
         run: pip install tox
       - name: Check manifest
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.6
     - name: Install dependencies
       run: pip install tox
     - name: Run checks

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,8 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
 
 zip_safe = false
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.6
 
 # Where is my code
 packages = find:


### PR DESCRIPTION
Looks like everything is working down to Python 3.6+ so we might as well extend compatibility to facilitate integration (with e.g., INDRA).