### PR TITLE
Add input form for adding mappings

### DIFF
--- a/src/biomappings/templates/home.html
+++ b/src/biomappings/templates/home.html
@@ -6,6 +6,7 @@
 
 {% block content %}
     <div class="container" style="margin-top: 50px">
+        {{ util.flashed_messages(dismissible=True, container=False) }}
         <div class="col-md-offset-2 col-md-8 col-sm-offset-2 col-sm-8">
             <div class="panel panel-info">
                 <div class="panel-heading">

--- a/src/biomappings/templates/home.html
+++ b/src/biomappings/templates/home.html
@@ -59,6 +59,21 @@
                     {% endfor %}
                     </tbody>
                 </table>
+
+                <table>
+                    <tr>
+                        <form class="form" method="GET" role="form">
+                        <td>{{ wtf.form_field(form.source_prefix) }}</td>
+                        <td>{{ wtf.form_field(form.source_id) }}</td>
+                        <td>{{ wtf.form_field(form.source_name) }}</td>
+                        <td>{{ wtf.form_field(form.target_prefix) }}</td>
+                        <td>{{ wtf.form_field(form.target_id) }}</td>
+                        <td>{{ wtf.form_field(form.target_name) }}</td>
+                        <td>{{ wtf.form_field(form.submit, class="btn btn-primary")}}</td>
+                        </form>
+                    </tr>
+                </table>
+
                 <div class="panel-footer">
                     <a href="{{ url_for('home', limit=limit, offset=0) }}">First</a> |
                     {% if 0 <= offset - limit %}

--- a/src/biomappings/templates/home.html
+++ b/src/biomappings/templates/home.html
@@ -62,7 +62,7 @@
 
                 <table>
                     <tr>
-                        <form class="form" method="GET" role="form">
+                        <form class="form" method="POST" role="form" action="add_mapping">
                         <td>{{ wtf.form_field(form.source_prefix) }}</td>
                         <td>{{ wtf.form_field(form.source_id) }}</td>
                         <td>{{ wtf.form_field(form.source_name) }}</td>

--- a/src/biomappings/templates/home.html
+++ b/src/biomappings/templates/home.html
@@ -60,19 +60,21 @@
                     </tbody>
                 </table>
 
-                <table>
-                    <tr>
-                        <form class="form" method="POST" role="form" action="add_mapping">
-                        <td>{{ wtf.form_field(form.source_prefix) }}</td>
-                        <td>{{ wtf.form_field(form.source_id) }}</td>
-                        <td>{{ wtf.form_field(form.source_name) }}</td>
-                        <td>{{ wtf.form_field(form.target_prefix) }}</td>
-                        <td>{{ wtf.form_field(form.target_id) }}</td>
-                        <td>{{ wtf.form_field(form.target_name) }}</td>
-                        <td>{{ wtf.form_field(form.submit, class="btn btn-primary")}}</td>
-                        </form>
-                    </tr>
-                </table>
+                <form class="form" method="POST" role="form" action="{{ url_for('add_mapping') }}">
+                    <table class="table" style="margin-bottom: 0">
+                        <tr>
+                            <td>{{ wtf.form_field(form.source_prefix) }}</td>
+                            <td>{{ wtf.form_field(form.source_id) }}</td>
+                            <td>{{ wtf.form_field(form.source_name) }}</td>
+                            <td>{{ wtf.form_field(form.target_prefix) }}</td>
+                            <td>{{ wtf.form_field(form.target_id) }}</td>
+                            <td>{{ wtf.form_field(form.target_name) }}</td>
+                            <td style="padding-bottom: 24px; vertical-align: bottom">
+                                {{ wtf.form_field(form.submit, class="btn btn-primary") }}
+                            </td>
+                        </tr>
+                    </table>
+                </form>
 
                 <div class="panel-footer">
                     <a href="{{ url_for('home', limit=limit, offset=0) }}">First</a> |

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -144,10 +144,6 @@ class MappingForm(FlaskForm):
 def home():
     """Serve the home page."""
     form = MappingForm()
-    if form.data:
-        controller.add_mapping(form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
-                               form.data['target_prefix'], form.data['target_id'], form.data['target_name'])
-
     limit = flask.request.args.get('limit', type=int, default=10)
     offset = flask.request.args.get('offset', type=int, default=0)
     return flask.render_template(
@@ -157,6 +153,21 @@ def home():
         limit=limit,
         offset=offset,
     )
+
+
+@app.route('/add_mapping', methods=['POST'])
+def add_mapping():
+    """Add a new mapping manually."""
+    form = MappingForm()
+    print(flask.request.args)
+    controller.add_mapping(form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
+                           form.data['target_prefix'], form.data['target_id'], form.data['target_name'])
+    controller.persist()
+    return flask.redirect(flask.url_for(
+        'home',
+        limit=flask.request.args.get('limit', type=int),
+        offset=flask.request.args.get('offset', type=int),
+    ))
 
 
 @app.route('/commit')

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -100,7 +100,7 @@ class Controller:
                 'type': 'manual',
             }
         )
-        self.total += 1
+        self.total_curated += 1
 
     def persist(self):
         """Save the current markings to the source files."""

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -98,7 +98,7 @@ class Controller:
                 'target name': target_name,
                 'source': f'orcid:{known_user}' if known_user else 'web',
                 'type': 'manual',
-            }
+            },
         )
         self.total_curated += 1
 
@@ -131,6 +131,7 @@ controller = Controller()
 
 
 class MappingForm(FlaskForm):
+    """Form for entering new mappings."""
     source_prefix = StringField('Source prefix', id='source_prefix')
     source_id = StringField('Source ID', id='source_id')
     source_name = StringField('Source name', id='source_name')

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -84,22 +84,28 @@ class Controller:
             self.total_curated += 1
         self._marked[line] = correct
 
-    def add_mapping(self, source_prefix, source_id, source_name, target_prefix, target_id, target_name):
+    def add_mapping(
+        self,
+        source_prefix: str,
+        source_id: str,
+        source_name: str,
+        target_prefix: str,
+        target_id: str,
+        target_name: str,
+    ) -> None:
         """Add manually curated new mappings."""
         known_user = KNOWN_USERS.get(getpass.getuser())
-        self._added_mappings.append(
-            {
-                'source prefix': source_prefix,
-                'source identifier': source_id,
-                'source name': source_name,
-                'relation': 'skos:exactMatch',
-                'target prefix': target_prefix,
-                'target identifier': target_id,
-                'target name': target_name,
-                'source': f'orcid:{known_user}' if known_user else 'web',
-                'type': 'manual',
-            },
-        )
+        self._added_mappings.append({
+            'source prefix': source_prefix,
+            'source identifier': source_id,
+            'source name': source_name,
+            'relation': 'skos:exactMatch',
+            'target prefix': target_prefix,
+            'target identifier': target_id,
+            'target name': target_name,
+            'source': f'orcid:{known_user}' if known_user else 'web',
+            'type': 'manual',
+        })
         self.total_curated += 1
 
     def persist(self):

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -139,12 +139,12 @@ controller = Controller()
 class MappingForm(FlaskForm):
     """Form for entering new mappings."""
 
-    source_prefix = StringField('Source prefix', id='source_prefix')
+    source_prefix = StringField('Source Prefix', id='source_prefix')
     source_id = StringField('Source ID', id='source_id')
-    source_name = StringField('Source name', id='source_name')
-    target_prefix = StringField('Target prefix', id='target_prefix')
+    source_name = StringField('Source Name', id='source_name')
+    target_prefix = StringField('Target Prefix', id='target_prefix')
     target_id = StringField('Target ID', id='target_id')
-    target_name = StringField('Target name', id='target_name')
+    target_name = StringField('Target Name', id='target_name')
     submit = SubmitField('Add')
 
 

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -167,7 +167,6 @@ def home():
 def add_mapping():
     """Add a new mapping manually."""
     form = MappingForm()
-    print(flask.request.args)
     controller.add_mapping(form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
                            form.data['target_prefix'], form.data['target_id'], form.data['target_name'])
     controller.persist()

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -3,6 +3,7 @@
 """Web curation interface for :mod:`biomappings`."""
 
 import getpass
+import os
 from typing import Any, Iterable, Mapping, Optional, Tuple
 
 import flask
@@ -15,7 +16,7 @@ from biomappings.utils import MiriamValidator, commit
 
 app = flask.Flask(__name__)
 app.config['WTF_CSRF_ENABLED'] = False
-app.config['SECRET_KEY'] = 'salsa'
+app.config['SECRET_KEY'] = os.urandom(8)
 flask_bootstrap.Bootstrap(app)
 
 # A mapping from your computer's user, returned by getuser.getpass()

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -132,6 +132,7 @@ controller = Controller()
 
 class MappingForm(FlaskForm):
     """Form for entering new mappings."""
+
     source_prefix = StringField('Source prefix', id='source_prefix')
     source_id = StringField('Source ID', id='source_id')
     source_name = StringField('Source name', id='source_name')

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -171,11 +171,7 @@ def add_mapping():
     controller.add_mapping(form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
                            form.data['target_prefix'], form.data['target_id'], form.data['target_name'])
     controller.persist()
-    return flask.redirect(flask.url_for(
-        'home',
-        limit=flask.request.args.get('limit', type=int),
-        offset=flask.request.args.get('offset', type=int),
-    ))
+    return _go_home()
 
 
 @app.route('/commit')

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -167,8 +167,10 @@ def home():
 def add_mapping():
     """Add a new mapping manually."""
     form = MappingForm()
-    controller.add_mapping(form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
-                           form.data['target_prefix'], form.data['target_id'], form.data['target_name'])
+    controller.add_mapping(
+        form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
+        form.data['target_prefix'], form.data['target_id'], form.data['target_name'],
+    )
     controller.persist()
     return _go_home()
 

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -187,11 +187,14 @@ def home():
 def add_mapping():
     """Add a new mapping manually."""
     form = MappingForm()
-    controller.add_mapping(
-        form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
-        form.data['target_prefix'], form.data['target_id'], form.data['target_name'],
-    )
-    controller.persist()
+    if form.is_submitted():
+        controller.add_mapping(
+            form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
+            form.data['target_prefix'], form.data['target_id'], form.data['target_name'],
+        )
+        controller.persist()
+    else:
+        flask.flash('missing form data', category='warning')
     return _go_home()
 
 

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -24,6 +24,14 @@ KNOWN_USERS = {
     'ben': '0000-0001-9439-5346',
 }
 
+
+def _manual_source():
+    known_user = KNOWN_USERS.get(getpass.getuser())
+    if known_user:
+        return f'orcid:{known_user}'
+    return 'web'
+
+
 miriam_validator = MiriamValidator()
 
 
@@ -95,8 +103,6 @@ class Controller:
         target_name: str,
     ) -> None:
         """Add manually curated new mappings."""
-        known_user = KNOWN_USERS.get(getpass.getuser())
-
         try:
             miriam_validator.check_valid_prefix_id(source_prefix, source_id)
         except ValueError as e:
@@ -123,7 +129,7 @@ class Controller:
             'target prefix': target_prefix,
             'target identifier': target_id,
             'target name': target_name,
-            'source': f'orcid:{known_user}' if known_user else 'web',
+            'source': _manual_source(),
             'type': 'manual',
         })
         self.total_curated += 1
@@ -135,8 +141,7 @@ class Controller:
 
         for line, correct in sorted(self._marked.items(), reverse=True):
             prediction = self._predictions.pop(line)
-            known_user = KNOWN_USERS.get(getpass.getuser())
-            prediction['source'] = f'orcid:{known_user}' if known_user else 'web'
+            prediction['source'] = _manual_source()
             prediction['type'] = 'manually_reviewed'
             if correct:
                 curated_true_entries.append(prediction)

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -100,6 +100,7 @@ class Controller:
                 'type': 'manual',
             }
         )
+        self.total += 1
 
     def persist(self):
         """Save the current markings to the source files."""
@@ -123,19 +124,19 @@ class Controller:
 
         # Now add manually curated mappings
         append_true_mappings(self._added_mappings)
-        self._predictions = []
+        self._added_mappings = []
 
 
 controller = Controller()
 
 
 class MappingForm(FlaskForm):
-    source_prefix = StringField(None, id='source_prefix')
-    source_id = StringField(None, id='source_id')
-    source_name = StringField(None, id='source_name')
-    target_prefix = StringField(None, id='target_prefix')
-    target_id = StringField(None, id='target_id')
-    target_name = StringField(None, id='target_name')
+    source_prefix = StringField('Source prefix', id='source_prefix')
+    source_id = StringField('Source ID', id='source_id')
+    source_name = StringField('Source name', id='source_name')
+    target_prefix = StringField('Target prefix', id='target_prefix')
+    target_id = StringField('Target ID', id='target_id')
+    target_name = StringField('Target name', id='target_name')
     submit = SubmitField('Add')
 
 
@@ -143,9 +144,9 @@ class MappingForm(FlaskForm):
 def home():
     """Serve the home page."""
     form = MappingForm()
-    if form.validate_on_submit():
-        controller.add_mapping(form.source_prefix.data, form.source_id.data, form.source_name.data,
-                               form.target_prefix.data, form.target_id.data, form.target_name.data)
+    if form.data:
+        controller.add_mapping(form.data['source_prefix'], form.data['source_id'], form.data['source_name'],
+                               form.data['target_prefix'], form.data['target_id'], form.data['target_name'])
 
     limit = flask.request.args.get('limit', type=int, default=10)
     offset = flask.request.args.get('offset', type=int, default=0)

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -15,6 +15,7 @@ from biomappings.utils import MiriamValidator, commit
 
 app = flask.Flask(__name__)
 app.config['WTF_CSRF_ENABLED'] = False
+app.config['SECRET_KEY'] = 'salsa'
 flask_bootstrap.Bootstrap(app)
 
 # A mapping from your computer's user, returned by getuser.getpass()
@@ -95,6 +96,25 @@ class Controller:
     ) -> None:
         """Add manually curated new mappings."""
         known_user = KNOWN_USERS.get(getpass.getuser())
+
+        try:
+            miriam_validator.check_valid_prefix_id(source_prefix, source_id)
+        except ValueError as e:
+            flask.flash(
+                f'Problem with source CURIE {source_prefix}:{source_id}: {e.__class__.__name__}',
+                category='warning',
+            )
+            return
+
+        try:
+            miriam_validator.check_valid_prefix_id(target_prefix, target_id)
+        except ValueError as e:
+            flask.flash(
+                f'Problem with target CURIE {target_prefix}:{target_id}: {e.__class__.__name__}',
+                category='warning',
+            )
+            return
+
         self._added_mappings.append({
             'source prefix': source_prefix,
             'source identifier': source_id,


### PR DESCRIPTION
This PR adds a very minimal input form to allow adding new mappings on the web interface. These can then be automatically committed along with any other curations.