### PR TITLE
Add prefix filter

### DIFF
--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -13,3 +13,5 @@ mesh	D063807	Dandruff	skos:exactMatch	doid	DOID:8941	seborrheic infantile dermat
 mesh	D063847	Mean Platelet Volume	skos:exactMatch	ncit	C74730	Mean Platelet Volume Measurement	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D063948	Enslaved Persons	skos:exactMatch	ncit	C153898	Slavey Language	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D058570	TOR Serine-Threonine Kinases	skos:exactMatch	hgnc	3942	MTOR	manually_reviewed	orcid:0000-0001-9439-5346
+pr	PR:000036824	NS1	skos:exactMatch	uniprot.chain	PRO_0000449635	Non-structural protein 1	manually_reviewed	orcid:0000-0003-4423-4370
+pr	PR:000036828	NS3	skos:exactMatch	uniprot.chain	PRO_0000449621	Non-structural protein 3	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -15,3 +15,7 @@ mesh	D063948	Enslaved Persons	skos:exactMatch	ncit	C153898	Slavey Language	manua
 mesh	D058570	TOR Serine-Threonine Kinases	skos:exactMatch	hgnc	3942	MTOR	manually_reviewed	orcid:0000-0001-9439-5346
 pr	PR:000036824	NS1	skos:exactMatch	uniprot.chain	PRO_0000449635	Non-structural protein 1	manually_reviewed	orcid:0000-0003-4423-4370
 pr	PR:000036828	NS3	skos:exactMatch	uniprot.chain	PRO_0000449621	Non-structural protein 3	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C023514	2,6-dinitrotoluene	skos:exactMatch	doid	DOID:2679	dysembryoplastic neuroepithelial tumor	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C041398	7,7'-dimethoxy-(4,4'-bi-1,3-benzodioxole)-5,5'-dicarboxylic acid dimethyl ester	skos:exactMatch	doid	DOID:0110971	brachydactyly type D	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C053540	4-phenyl-1,2,4-triazoline-3,5-dione	skos:exactMatch	doid	DOID:3829	pituitary adenoma	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C005941	3-acetylpyridine adenine dinucleotide	skos:exactMatch	doid	DOID:3608	appendix adenocarcinoma	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -866,3 +866,20 @@ mesh	C000706947	FGF21 protein, human	skos:exactMatch	uniprot	Q9NSA1	FGF21	manual
 mesh	D016222	Fibroblast Growth Factor 2	skos:exactMatch	hgnc	3676	FGF2	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D016220	Fibroblast Growth Factor 1	skos:exactMatch	hgnc	3665	FGF1	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D042863	Cyclin-Dependent Kinase 9	skos:exactMatch	hgnc	1780	CDK9	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000598645	Spheroid body myopathy	skos:exactMatch	doid	DOID:0080091	spheroid body myopathy	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000596385	Jalili syndrome	skos:exactMatch	doid	DOID:0111404	Jalili syndrome	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000626124	NGLY1 deficiency	skos:exactMatch	doid	DOID:0060728	NGLY1-deficiency	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000656784	adiaspiromycosis	skos:exactMatch	doid	DOID:0050072	adiaspiromycosis	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000656825	tinea barbae	skos:exactMatch	doid	DOID:0050096	tinea barbae	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C000656904	tinea nigra	skos:exactMatch	doid	DOID:8912	tinea nigra	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535334	ABCD syndrome	skos:exactMatch	doid	DOID:0050600	ABCD syndrome	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535358	Choroidal sclerosis	skos:exactMatch	doid	DOID:980	choroidal sclerosis	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535388	Arts syndrome	skos:exactMatch	doid	DOID:0050647	Arts syndrome	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535330	Aagenaes syndrome	skos:exactMatch	doid	DOID:6691	Aagenaes syndrome	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535328	Homocarnosinosis	skos:exactMatch	doid	DOID:0060177	homocarnosinosis	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535416	Charcot-Marie-Tooth disease, Type 2I	skos:exactMatch	doid	DOID:0110158	Charcot-Marie-Tooth disease type 2I	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535420	Charcot-Marie-Tooth disease, Type 4B1	skos:exactMatch	doid	DOID:0110191	Charcot-Marie-Tooth disease type 4B1	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535421	Charcot-Marie-Tooth disease, Type 4B2	skos:exactMatch	doid	DOID:0110190	Charcot-Marie-Tooth disease type 4B2	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535436	Bethlem myopathy	skos:exactMatch	doid	DOID:0050663	Bethlem myopathy	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535440	Bietti Crystalline Dystrophy	skos:exactMatch	doid	DOID:0050664	Bietti crystalline corneoretinal dystrophy	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C535549	Pelvic lipomatosis	skos:exactMatch	doid	DOID:3927	pelvic lipomatosis	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/templates/home.html
+++ b/src/biomappings/templates/home.html
@@ -55,13 +55,13 @@
                             <td>{{ 1 + line }}</td>
                             <td>
                                 <a href="{{ controller.get_url(p['source prefix'], p['source identifier']) }}">
-                                    {{ p['source prefix'] }}:{{ p['source identifier'] }}
+                                    {{ controller.get_curie(p['source prefix'], p['source identifier']) }}
                                 </a>
                             </td>
                             <td>{{ p['source name'] }}</td>
                             <td>
                                 <a href="{{ controller.get_url(p['target prefix'], p['target identifier']) }}">
-                                    {{ p['target prefix'] }}:{{ p['target identifier'] }}
+                                    {{ controller.get_curie(p['target prefix'], p['target identifier']) }}
                                 </a>
                             </td>
                             <td>{{ p['target name'] }}</td>

--- a/src/biomappings/templates/home.html
+++ b/src/biomappings/templates/home.html
@@ -12,7 +12,7 @@
                 <div class="panel-heading">
                     <h2 class="text-center">Biomappings Curation Interface</h2>
                     {% if controller.total_curated %}
-                        <a href="{{ url_for('run_commit', limit=limit, offset=offset) }}">
+                        <a href="{{ url_for('run_commit', limit=limit, offset=offset, prefix=prefix) }}">
                             <button class="btn btn-default">Commit ({{ controller.total_curated }}) and Push
                                 <span class="glyphicon glyphicon-arrow-up" aria-hidden="true"></span>
                             </button>
@@ -20,16 +20,19 @@
                     {% endif %}
                     {% if query %}
                         <span class="btn btn-default">Query: <code>{{ query }}</code></span>
-                        <a href="{{ url_for('home', limit=limit, offset=offset) }}">
+                        <a href="{{ url_for('home', limit=limit, offset=offset, prefix=prefix) }}">
                             <button class="btn btn-default">Clear</button>
                         </a>
                     {% else %}
-                        <form class="form" method="GET" role="form" action="{{ url_for('home') }}">
+                        <form class="form" method="GET" role="form" action="{{ url_for('home', prefix=prefix) }}">
                             <div class="input-group">
                                 <span class="input-group-btn">
                                    <button type="submit" class="btn btn-default">Go!</button>
                                 </span>
                                 <input type="text" class="form-control" placeholder="Search for..." name="query">
+                                {% if prefix %}
+                                    <input type="hidden" name="prefix" value="{{ prefix }}">
+                                {% endif %}
                             </div>
                         </form>
                     {% endif %}
@@ -47,7 +50,7 @@
                     </tr>
                     </thead>
                     <tbody>
-                    {% for line, p in controller.predictions(query=query, offset=offset, limit=limit) %}
+                    {% for line, p in controller.predictions(query=query, offset=offset, limit=limit, prefix=prefix) %}
                         <tr>
                             <td>{{ 1 + line }}</td>
                             <td>
@@ -63,12 +66,12 @@
                             </td>
                             <td>{{ p['target name'] }}</td>
                             <td>
-                                <a href="{{ url_for('mark', line=line, value='yup', limit=limit, offset=offset, query=query) }}">
+                                <a href="{{ url_for('mark', line=line, value='yup', limit=limit, offset=offset, query=query, prefix=prefix) }}">
                                     <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span>
                                 </a>
                             </td>
                             <td>
-                                <a href="{{ url_for('mark', line=line, value='nope', limit=limit, offset=offset, query=query) }}">
+                                <a href="{{ url_for('mark', line=line, value='nope', limit=limit, offset=offset, query=query, prefix=prefix) }}">
                                     <span class="glyphicon glyphicon-thumbs-down" aria-hidden="true"></span>
                                 </a>
                             </td>
@@ -94,18 +97,18 @@
                 </form>
 
                 <div class="panel-footer">
-                    <a href="{{ url_for('home', limit=limit, offset=0, query=query) }}">First</a> |
+                    <a href="{{ url_for('home', limit=limit, offset=0, query=query, prefix=prefix) }}">First</a> |
                     {% if 0 <= offset - limit %}
-                        <a href="{{ url_for('home', limit=limit, offset=offset - limit, query=query) }}">
+                        <a href="{{ url_for('home', limit=limit, offset=offset - limit, query=query, prefix=prefix) }}">
                             Previous {{ limit }}
                         </a> |
                     {% endif %}
                     {% if offset <= controller.total_predictions - limit %}
-                        <a href="{{ url_for('home', limit=limit, offset=offset + limit, query=query) }}">
+                        <a href="{{ url_for('home', limit=limit, offset=offset + limit, query=query, prefix=prefix) }}">
                             Next {{ limit }}
                         </a> |
                     {% endif %}
-                    <a href="{{ url_for('home', limit=limit, offset=controller.total_predictions - limit, query=query) }}">
+                    <a href="{{ url_for('home', limit=limit, offset=controller.total_predictions - limit, query=query, prefix=prefix) }}">
                         Last
                     </a>
                 </div>

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -51,12 +51,14 @@ class Controller:
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         query: Optional[str] = None,
+        prefix: Optional[str] = None,
     ) -> Iterable[Tuple[int, Mapping[str, Any]]]:
         """Iterate over predictions.
 
         :param offset: If given, offset the iteration by this number
         :param limit: If given, only iterate this number of predictions.
         :param query: If given, show only equivalences that have it appearing as a substring in one of the fields
+        :param prefix: If given, show only equivalences that have it appearing as a substring in one of the prefixes
         :yields: Pairs of positions and prediction dictionaries
         """
         it = enumerate(self._predictions)
@@ -68,6 +70,16 @@ class Controller:
                 if any(
                     query in prediction[x].casefold()
                     for x in ('source identifier', 'source name', 'target identifier', 'target name')
+                )
+            )
+        if prefix is not None:
+            prefix = prefix.casefold()
+            it = (
+                (line, prediction)
+                for line, prediction in it
+                if any(
+                    prefix in prediction[x].casefold()
+                    for x in ('source prefix', 'target prefix')
                 )
             )
 
@@ -200,6 +212,7 @@ def home():
     limit = flask.request.args.get('limit', type=int, default=10)
     offset = flask.request.args.get('offset', type=int, default=0)
     query = flask.request.args.get('query')
+    prefix = flask.request.args.get('prefix')
     return flask.render_template(
         'home.html',
         controller=controller,
@@ -207,6 +220,7 @@ def home():
         limit=limit,
         offset=offset,
         query=query,
+        prefix=prefix,
     )
 
 
@@ -252,6 +266,7 @@ def _go_home():
         limit=flask.request.args.get('limit', type=int),
         offset=flask.request.args.get('offset', type=int),
         query=flask.request.args.get('query'),
+        prefix=flask.request.args.get('prefix'),
     ))
 
 

--- a/src/biomappings/wsgi.py
+++ b/src/biomappings/wsgi.py
@@ -103,12 +103,17 @@ class Controller:
                 yield line_prediction
 
     @staticmethod
-    def get_url(prefix: str, identifier: str) -> str:
-        """Return URL for a given prefix and identifier."""
+    def get_curie(prefix: str, identifier: str) -> str:
+        """Return CURIE for a given prefix and identifier."""
         if miriam_validator.namespace_embedded(prefix):
-            return f'https://identifiers.org/{identifier}'
+            return identifier
         else:
-            return f'https://identifiers.org/{prefix}:{identifier}'
+            return f'{prefix}:{identifier}'
+
+    @classmethod
+    def get_url(cls, prefix: str, identifier: str) -> str:
+        """Return URL for a given prefix and identifier."""
+        return f'https://identifiers.org/{cls.get_curie(prefix, identifier)}'
 
     @property
     def total_predictions(self) -> int:


### PR DESCRIPTION
If you add `?prefix=mesh` into the URL, it will filter based on that. It's not showing it in the UI right now.

I implemented this because I wanted to finish up some of the smaller lists, like `uniprot.chain`. I curated the last two and found that mapping to protein ontology should be done very carefully, since protein ontology's entries are species-specific and it mapped Dengue proteins in PRO to SARS-CoV-2 proteins in UniProt