### PR TITLE
Curated 384 GO mappings

### DIFF
--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -19,3 +19,73 @@ mesh	C023514	2,6-dinitrotoluene	skos:exactMatch	doid	DOID:2679	dysembryoplastic 
 mesh	C041398	7,7'-dimethoxy-(4,4'-bi-1,3-benzodioxole)-5,5'-dicarboxylic acid dimethyl ester	skos:exactMatch	doid	DOID:0110971	brachydactyly type D	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C053540	4-phenyl-1,2,4-triazoline-3,5-dione	skos:exactMatch	doid	DOID:3829	pituitary adenoma	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C005941	3-acetylpyridine adenine dinucleotide	skos:exactMatch	doid	DOID:3608	appendix adenocarcinoma	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	C019618	adenylylsulfate reductase	skos:exactMatch	go	GO:0009973	adenylyl-sulfate reductase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C019328	deoxyribonuclease A	skos:exactMatch	go	GO:0004530	deoxyribonuclease I activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C021380	L-2-hydroxyacid oxidase	skos:exactMatch	go	GO:0003973	(S)-2-hydroxy-acid oxidase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C016532	maltoporins	skos:exactMatch	go	GO:0015481	maltose transporting porin activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C014801	alpha-sarcin	skos:exactMatch	go	GO:0033902	rRNA endonuclease activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C019963	cyclomaltodextrin glucanotransferase	skos:exactMatch	go	GO:0043895	cyclomaltodextrin glucanotransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C020659	glutaminyl-tRNA synthetase	skos:exactMatch	go	GO:0004819	glutamine-tRNA ligase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C020947	trophoblastin	skos:exactMatch	go	GO:0004167	dopachrome isomerase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C021464	3-keto-5-aminohexanoate cleavage enzyme	skos:exactMatch	go	GO:0043720	3-keto-5-aminohexanoate cleavage activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C021928	2-oxoaldehyde dehydrogenase (NAD+)	skos:exactMatch	go	GO:0047551	2-oxoaldehyde dehydrogenase (NAD+) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C022535	exoribonuclease II	skos:exactMatch	go	GO:0008859	exoribonuclease II activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C022642	shikimate kinase	skos:exactMatch	go	GO:0004765	shikimate kinase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C036053	VLDL receptor	skos:exactMatch	go	GO:0030229	very-low-density lipoprotein particle receptor activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C035571	endodeoxyribonuclease VII	skos:exactMatch	go	GO:0008855	exodeoxyribonuclease VII activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C034544	D-malate dehydrogenase (decarboxylating)	skos:exactMatch	go	GO:0046553	D-malate dehydrogenase (decarboxylating) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C055160	sphingomyelin phosphodiesterase D	skos:exactMatch	go	GO:0050290	sphingomyelin phosphodiesterase D activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C046090	mannosyl-oligosaccharide 1,2-alpha-mannosidase	skos:exactMatch	go	GO:0004571	mannosyl-oligosaccharide 1,2-alpha-mannosidase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C042059	glucosidase I	skos:exactMatch	go	GO:0004573	mannosyl-oligosaccharide glucosidase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C071543	cytochrome P450 CYP3A10 (hamster)	skos:exactMatch	go	GO:0033777	lithocholate 6beta-hydroxylase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C066234	enterobactin synthetase	skos:exactMatch	go	GO:0009239	enterobactin biosynthetic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C081975	protein kinase C eta	skos:exactMatch	go	GO:0004697	protein kinase C activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C092274	melanin-concentrating hormone receptor	skos:exactMatch	go	GO:0030273	melanin-concentrating hormone receptor activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C093132	glyceraldehyde-3-phosphate ferredoxin oxidoreductase	skos:exactMatch	go	GO:0043797	glyceraldehyde-3-phosphate dehydrogenase (ferredoxin) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C093584	gluconate 5-dehydrogenase	skos:exactMatch	go	GO:0008874	gluconate 5-dehydrogenase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C104385	non-ribosomal peptide synthase	skos:exactMatch	go	GO:0019184	nonribosomal peptide biosynthetic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C116435	lipoic acid synthase	skos:exactMatch	go	GO:0016992	lipoate synthase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C449880	O-GlcNAc transferase	skos:exactMatch	go	GO:0097363	protein O-GlcNAc transferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C026044	deoxyribonuclease V	skos:exactMatch	go	GO:0043737	deoxyribonuclease V activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001024	Aortic Valve Stenosis	skos:exactMatch	go	GO:0004066	asparagine synthase (glutamine-hydrolyzing) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001731	Bisphosphoglycerate Mutase	skos:exactMatch	go	GO:0004619	phosphoglycerate mutase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006593	Hexokinase	skos:exactMatch	go	GO:0004396	hexokinase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009252	NADPH Dehydrogenase	skos:exactMatch	go	GO:0003959	NADPH dehydrogenase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011490	Protein Disulfide Reductase (Glutathione)	skos:exactMatch	go	GO:0019153	protein-disulfide reductase (glutathione) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011497	Protein O-Methyltransferase	skos:exactMatch	go	GO:0008983	protein-glutamate O-methyltransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020929	Mitogen-Activated Protein Kinase Kinases	skos:exactMatch	go	GO:0004708	MAP kinase kinase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D043262	Ribonuclease P	skos:exactMatch	go	GO:0004526	ribonuclease P activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C025665	glyoxylate reductase (NADP+)	skos:exactMatch	go	GO:0030267	glyoxylate reductase (NADP) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C023440	anthranilate 2,3-dioxygenase(deaminating)	skos:exactMatch	go	GO:0018618	anthranilate 1,2-dioxygenase (deaminating, decarboxylating) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C010073	chemotactic factor inactivator	skos:exactMatch	go	GO:0034029	2-oxoglutarate carboxylase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C001502	7-keto-8-aminopelargonic acid	skos:exactMatch	go	GO:0004015	adenosylmethionine-8-amino-7-oxononanoate transaminase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C000632245	steapsin	skos:exactMatch	go	GO:0004806	triglyceride lipase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C038829	mannosyl-oligosaccharide 1,3 - 1,6-alpha-mannosidase	skos:exactMatch	go	GO:0004572	mannosyl-oligosaccharide 1,3-1,6-alpha-mannosidase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C037247	phosphatidylglycerol - membrane-oligosaccharide glycerophosphotransferase	skos:exactMatch	go	GO:0008960	phosphatidylglycerol-membrane-oligosaccharide glycerophosphotransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C031616	high density lipoprotein receptors	skos:exactMatch	go	GO:0070506	high-density lipoprotein particle receptor activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C029757	phosphogluconate dehydrogenase (decarboxylating)	skos:exactMatch	go	GO:0004616	phosphogluconate dehydrogenase (decarboxylating) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C026677	9 alpha,11 alpha,15 alpha-trihydroxy-16-phenoxy-17,18,19,20-tetranorprosta-4,5,13-trienoic acid	skos:exactMatch	go	GO:0009670	triose-phosphate:phosphate antiporter activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C072825	4-hexyloxyaniline	skos:exactMatch	go	GO:0008701	4-hydroxy-2-oxovalerate aldolase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C063522	NAD+ synthase (glutamine-hydrolysing)	skos:exactMatch	go	GO:0003952	NAD+ synthase (glutamine-hydrolyzing) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C078267	2,3-dihydroxy-4-cumate-3,4-dioxygenase	skos:exactMatch	go	GO:0018571	2,3-dihydroxy-p-cumate dioxygenase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C076131	DNA-3-methyladenine glycosidase II	skos:exactMatch	go	GO:0003905	alkylbase DNA N-glycosylase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C056957	1-(4-carbethoxyphenyl)-3-hydroxymethyl-3-methyltriazene	skos:exactMatch	go	GO:0033802	isoliquiritigenin 2'-O-methyltransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C084023	2-hydroxyhepta-2,4-diene-1,7-dioate isomerase	skos:exactMatch	go	GO:0008704	5-carboxymethyl-2-hydroxymuconate delta-isomerase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C087831	triaosylceramide 1,4-galactosyltransferase	skos:exactMatch	go	GO:0047275	glucosaminylgalactosylglucosylceramide beta-galactosyltransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C094343	interleukin-14 receptor	skos:exactMatch	go	GO:0030373	high molecular weight B cell growth factor receptor activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C095246	taurochenodeoxycholic acid 6-alpha-hydroxylase	skos:exactMatch	go	GO:0033780	taurochenodeoxycholate 6alpha-hydroxylase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C082662	phosphopantetheinyl transferase	skos:exactMatch	go	GO:0008897	holo-[acyl-carrier-protein] synthase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C100091	cardiolipin synthetase	skos:exactMatch	go	GO:0090483	phosphatidylglycerol-phosphatidylethanolamine phosphatidyltransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C115412	cytochrome P-450 CYP81E1 (Glycyrrhiza echinata)	skos:exactMatch	go	GO:0033773	isoflavone 2'-hydroxylase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C415369	interleukin-22 receptor	skos:exactMatch	go	GO:0042018	interleukin-22 receptor activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C416670	N-acetylgalactosamine 4-sulfate 6-O-sulfotransferase	skos:exactMatch	go	GO:0050659	N-acetylgalactosamine 4-sulfate 6-O-sulfotransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C120640	DNA ligase (NAD)	skos:exactMatch	go	GO:0003911	DNA ligase (NAD+) activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C422952	telomerase RNA	skos:exactMatch	go	GO:0000332	template for synthesis of G-rich strand of telomere DNA activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C428384	MLK-like mitogen-activated protein triple kinase	skos:exactMatch	go	GO:0004709	MAP kinase kinase kinase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C445314	malonyl-CoA anthocyanin 5-O-glucoside-6'''-O-malonyltransferase	skos:exactMatch	go	GO:0033810	anthocyanin 5-O-glucoside 6'''-O-malonyltransferase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C427385	4-hydroxyacetophenone monooxygenase	skos:exactMatch	go	GO:0033767	4-hydroxyacetophenone monooxygenase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C419642	NRH - quinone oxidoreductase2	skos:exactMatch	go	GO:0001512	dihydronicotinamide riboside quinone reductase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C477269	3 beta-hydroxy-delta 5-steroid dehydrogenase, rat	skos:exactMatch	go	GO:0003854	3-beta-hydroxy-delta5-steroid dehydrogenase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C509674	marinocine protein, Marinomonas mediterranea	skos:exactMatch	go	GO:0033736	L-lysine 6-oxidase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C548841	Parasitic infection caused by Dracunculus medinensis	skos:exactMatch	go	GO:0050521	alpha-glucan, water dikinase activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C566113	Progressive Encephalomyelitis with Rigidity	skos:exactMatch	go	GO:0046524	sucrose-phosphate synthase activity	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -883,3 +883,317 @@ mesh	C535421	Charcot-Marie-Tooth disease, Type 4B2	skos:exactMatch	doid	DOID:011
 mesh	C535436	Bethlem myopathy	skos:exactMatch	doid	DOID:0050663	Bethlem myopathy	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535440	Bietti Crystalline Dystrophy	skos:exactMatch	doid	DOID:0050664	Bietti crystalline corneoretinal dystrophy	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	C535549	Pelvic lipomatosis	skos:exactMatch	doid	DOID:3927	pelvic lipomatosis	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	D066146	Cell Body	skos:exactMatch	go	GO:0044297	cell body	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C019919	CoA-synthesizing protein complex	skos:exactMatch	go	GO:1990143	CoA-synthesizing protein complex	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C035492	haptoglobin-hemoglobin complex	skos:exactMatch	go	GO:0031838	haptoglobin-hemoglobin complex	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C033727	fumarate reductase complex	skos:exactMatch	go	GO:0045283	fumarate reductase complex	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000071218	Ultradian Rhythm	skos:exactMatch	go	GO:0007624	ultradian rhythm	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000071437	Axon Guidance	skos:exactMatch	go	GO:0007411	axon guidance	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000071444	Phototaxis	skos:exactMatch	go	GO:0042331	phototaxis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000071448	Axon Fasciculation	skos:exactMatch	go	GO:0007413	axonal fasciculation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000072159	Dynactin Complex	skos:exactMatch	go	GO:0005869	dynactin complex	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000072777	Host-Seeking Behavior	skos:exactMatch	go	GO:0032537	host-seeking behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000073398	Demethylation	skos:exactMatch	go	GO:0070988	demethylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000073399	DNA Demethylation	skos:exactMatch	go	GO:0080111	DNA demethylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000079403	Ferroptosis	skos:exactMatch	go	GO:0097707	ferroptosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000078790	Insulin Secretion	skos:exactMatch	go	GO:0030073	insulin secretion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000077320	Biomineralization	skos:exactMatch	go	GO:0110148	biomineralization	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000205	Actomyosin	skos:exactMatch	go	GO:0042641	actomyosin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000200	Action Potentials	skos:exactMatch	go	GO:0001508	action potential	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000566	Amelogenesis	skos:exactMatch	go	GO:0097186	amelogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000077743	Diterpene Alkaloids	skos:exactMatch	chebi	CHEBI:23847	diterpene alkaloid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000738	Androsterone	skos:exactMatch	chebi	CHEBI:16032	androsterone	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000688	Amylose	skos:exactMatch	chebi	CHEBI:28102	amylose	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000687	Amylopectin	skos:exactMatch	chebi	CHEBI:28057	amylopectin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000080549	Autophagic Cell Death	skos:exactMatch	go	GO:0048102	autophagic cell death	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000940	Antigenic Variation	skos:exactMatch	go	GO:0020033	antigenic variation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001370	Axonal Transport	skos:exactMatch	go	GO:0098930	axonal transport	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001777	Blood Coagulation	skos:exactMatch	go	GO:0007596	blood coagulation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002448	Cell Adhesion	skos:exactMatch	go	GO:0007155	cell adhesion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002449	Cell Aggregation	skos:exactMatch	go	GO:0098743	cell aggregation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002450	Cell Communication	skos:exactMatch	go	GO:0007154	cell communication	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002453	Cell Cycle	skos:exactMatch	go	GO:0007049	cell cycle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002455	Cell Division	skos:exactMatch	go	GO:0051301	cell division	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002473	Cell Wall	skos:exactMatch	go	GO:0005618	cell wall	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002634	Chemotaxis, Leukocyte	skos:exactMatch	go	GO:0030595	leukocyte chemotaxis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002837	Chromaffin Granules	skos:exactMatch	go	GO:0042583	chromaffin granule	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003216	Conditioning, Operant	skos:exactMatch	go	GO:0035106	operant conditioning	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003260	Contact Inhibition	skos:exactMatch	go	GO:0060242	contact inhibition	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003307	Copulation	skos:exactMatch	go	GO:0007620	copulation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003341	Luteolysis	skos:exactMatch	go	GO:0001554	luteolysis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003595	Cytoplasmic Streaming	skos:exactMatch	go	GO:0099636	cytoplasmic streaming	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003623	Dark Adaptation	skos:exactMatch	go	GO:1990603	dark adaptation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003810	Dentinogenesis	skos:exactMatch	go	GO:0097187	dentinogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004031	Diestrus	skos:exactMatch	go	GO:0060207	diestrus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004063	Digestion	skos:exactMatch	go	GO:0007586	digestion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004327	Drinking Behavior	skos:exactMatch	go	GO:0042756	drinking behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004455	Echolocation	skos:exactMatch	go	GO:0050959	echolocation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004705	Endocytosis	skos:exactMatch	go	GO:0006897	endocytosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004903	Erythrocyte Aggregation	skos:exactMatch	go	GO:0034117	erythrocyte aggregation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004956	Estivation	skos:exactMatch	go	GO:0042751	estivation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005247	Feeding Behavior	skos:exactMatch	go	GO:0007631	feeding behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005342	Fibrinolysis	skos:exactMatch	go	GO:0042730	fibrinolysis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005427	Flocculation	skos:exactMatch	go	GO:0000128	flocculation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005785	Gene Conversion	skos:exactMatch	go	GO:0035822	gene conversion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005786	Gene Expression Regulation	skos:exactMatch	go	GO:0010468	regulation of gene expression	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005790	General Adaptation Syndrome	skos:exactMatch	go	GO:0051866	general adaptation syndrome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006031	Glycosylation	skos:exactMatch	go	GO:0070085	glycosylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006605	Hibernation	skos:exactMatch	go	GO:0042750	hibernation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007314	Insemination	skos:exactMatch	go	GO:0007320	insemination	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007408	Intestinal Absorption	skos:exactMatch	go	GO:0050892	intestinal absorption	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007698	Kinesis	skos:exactMatch	go	GO:0042465	kinesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007774	Lactation	skos:exactMatch	go	GO:0007595	lactation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008115	Liver Regeneration	skos:exactMatch	go	GO:0097421	liver regeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008247	Lysosomes	skos:exactMatch	go	GO:0005764	lysosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008262	Macrophage Activation	skos:exactMatch	go	GO:0042116	macrophage activation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008425	Maternal Behavior	skos:exactMatch	go	GO:0042711	maternal behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008561	Membrane Fusion	skos:exactMatch	go	GO:0061025	membrane fusion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008566	Membranes	skos:exactMatch	go	GO:0016020	membrane	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008686	Metestrus	skos:exactMatch	go	GO:0060210	metestrus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008745	Methylation	skos:exactMatch	go	GO:0032259	methylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009043	Motor Activity	skos:exactMatch	go	GO:0003774	motor activity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009079	Mucociliary Clearance	skos:exactMatch	go	GO:0120197	mucociliary clearance	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009210	Myofibrils	skos:exactMatch	go	GO:0030016	myofibril	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009469	Neuromuscular Junction	skos:exactMatch	go	GO:0031594	neuromuscular junction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009586	Nitrogen Fixation	skos:exactMatch	go	GO:0009399	nitrogen fixation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009697	Nucleolus Organizer Region	skos:exactMatch	go	GO:0005731	nucleolus organizer region	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010058	Oviposition	skos:exactMatch	go	GO:0018991	oviposition	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010064	Embryo Implantation	skos:exactMatch	go	GO:0007566	embryo implantation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010332	Paternal Behavior	skos:exactMatch	go	GO:0042712	paternal behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010410	Penile Erection	skos:exactMatch	go	GO:0043084	penile erection	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010452	Peptide Biosynthesis	skos:exactMatch	go	GO:0043043	peptide biosynthetic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010873	Pinocytosis	skos:exactMatch	go	GO:0006907	pinocytosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010974	Platelet Aggregation	skos:exactMatch	go	GO:0070527	platelet aggregation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010766	Phosphorylation	skos:exactMatch	go	GO:0016310	phosphorylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011359	Proestrus	skos:exactMatch	go	GO:0060208	proestrus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011434	Proprioception	skos:exactMatch	go	GO:0019230	proprioception	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011485	Protein Binding	skos:exactMatch	go	GO:0005515	protein binding	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011489	Protein Denaturation	skos:exactMatch	go	GO:0030164	protein denaturation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011554	Pseudopodia	skos:exactMatch	go	GO:0031143	pseudopodium	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012270	Ribosomes	skos:exactMatch	go	GO:0005840	ribosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012472	Salivation	skos:exactMatch	go	GO:0046541	saliva secretion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012728	Sex Chromatin	skos:exactMatch	go	GO:0001739	sex chromatin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012733	Sex Differentiation	skos:exactMatch	go	GO:0007548	sex differentiation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012919	Social Behavior	skos:exactMatch	go	GO:0035176	social behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013049	Spectrin	skos:exactMatch	go	GO:0008091	spectrin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013075	Sperm Capacitation	skos:exactMatch	go	GO:0048240	sperm capacitation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013077	Sperm Head	skos:exactMatch	go	GO:0061827	sperm head	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013394	Sucrase-Isomaltase Complex	skos:exactMatch	go	GO:0070014	sucrase-isomaltase complex	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013559	Symbiosis	skos:exactMatch	go	GO:0044403	symbiotic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013570	Synaptic Membranes	skos:exactMatch	go	GO:0097060	synaptic membrane	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013572	Synaptic Vesicles	skos:exactMatch	go	GO:0008021	synaptic vesicle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013573	Synaptonemal Complex	skos:exactMatch	go	GO:0000795	synaptonemal complex	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014661	Vasoconstriction	skos:exactMatch	go	GO:0042310	vasoconstriction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014818	Vitellogenesis	skos:exactMatch	go	GO:0007296	vitellogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016631	Lewy Bodies	skos:exactMatch	go	GO:0097413	Lewy body	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016874	Neurofibrillary Tangles	skos:exactMatch	go	GO:0097418	neurofibrillary tangle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D017368	Protein Prenylation	skos:exactMatch	go	GO:0018342	protein prenylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D015870	Gene Expression	skos:exactMatch	go	GO:0010467	gene expression	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018087	Plastids	skos:exactMatch	go	GO:0009536	plastid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018271	Signal Recognition Particle	skos:exactMatch	go	GO:0048500	signal recognition particle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018386	Kinetochores	skos:exactMatch	go	GO:0000776	kinetochore	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018522	Gravitropism	skos:exactMatch	go	GO:0009630	gravitropism	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018523	Tropism	skos:exactMatch	go	GO:0009606	tropism	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018524	Phototropism	skos:exactMatch	go	GO:0009638	phototropism	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019175	DNA Methylation	skos:exactMatch	go	GO:0006306	DNA methylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019599	Mossy Fibers, Hippocampal	skos:exactMatch	go	GO:0097457	hippocampal mossy fiber	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019706	Excitatory Postsynaptic Potentials	skos:exactMatch	go	GO:0060079	excitatory postsynaptic potential	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019898	Autocrine Communication	skos:exactMatch	go	GO:0035425	autocrine signaling	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019899	Paracrine Communication	skos:exactMatch	go	GO:0038001	paracrine signaling	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020101	Acrosome Reaction	skos:exactMatch	go	GO:0007340	acrosome reaction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020439	Growth Cones	skos:exactMatch	go	GO:0030426	growth cone	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020460	Melanosomes	skos:exactMatch	go	GO:0042470	melanosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020524	Thylakoids	skos:exactMatch	go	GO:0009579	thylakoid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020675	Peroxisomes	skos:exactMatch	go	GO:0005777	peroxisome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020676	Glyoxysomes	skos:exactMatch	go	GO:0009514	glyoxysome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020868	Gene Silencing	skos:exactMatch	go	GO:0016458	gene silencing	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D021381	Protein Transport	skos:exactMatch	go	GO:0015031	protein transport	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D021601	trans-Golgi Network	skos:exactMatch	go	GO:0005802	trans-Golgi network	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022162	Cytoplasmic Vesicles	skos:exactMatch	go	GO:0031410	cytoplasmic vesicle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022163	Clathrin-Coated Vesicles	skos:exactMatch	go	GO:0030136	clathrin-coated vesicle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022502	Stress Fibers	skos:exactMatch	go	GO:0001725	stress fiber	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D030762	Estrous Cycle	skos:exactMatch	go	GO:0044849	estrous cycle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D026721	RNA 3' End Processing	skos:exactMatch	go	GO:0031123	RNA 3'-end processing	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D031425	Plasmodesmata	skos:exactMatch	go	GO:0009506	plasmodesma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D032961	Sperm Midpiece	skos:exactMatch	go	GO:0097225	sperm midpiece	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D034461	Luteinization	skos:exactMatch	go	GO:0001553	luteinization	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D036881	Long-Term Synaptic Depression	skos:exactMatch	go	GO:0060292	long-term synaptic depression	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D042003	DNA Packaging	skos:exactMatch	go	GO:0006323	DNA packaging	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D021962	Membrane Microdomains	skos:exactMatch	go	GO:0098857	membrane microdomain	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D043762	Reproductive Behavior	skos:exactMatch	go	GO:0019098	reproductive behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D044603	Cellulosomes	skos:exactMatch	go	GO:0043263	cellulosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D045524	Phycobilisomes	skos:exactMatch	go	GO:0030089	phycobilisome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D046148	Donor Selection	skos:exactMatch	go	GO:0007535	donor selection	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048648	Macronucleus	skos:exactMatch	go	GO:0031039	macronucleus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D049229	Dendritic Spines	skos:exactMatch	go	GO:0043197	dendritic spine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D049469	Meiotic Prophase I	skos:exactMatch	go	GO:0007128	meiotic prophase I	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D046249	Transfer RNA Aminoacylation	skos:exactMatch	go	GO:0043039	tRNA aminoacylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D050356	Lipid Metabolism	skos:exactMatch	go	GO:0006629	lipid metabolic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D053478	Apoptosomes	skos:exactMatch	go	GO:0043293	apoptosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054262	Gastrulation	skos:exactMatch	go	GO:0007369	gastrulation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054337	Cell Dedifferentiation	skos:exactMatch	go	GO:0043697	cell dedifferentiation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054468	Axoneme	skos:exactMatch	go	GO:0005930	axoneme	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054657	Ribosome Subunits	skos:exactMatch	go	GO:0044391	ribosomal subunit	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054658	Ribosome Subunits, Large	skos:exactMatch	go	GO:0015934	large ribosomal subunit	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054679	Ribosome Subunits, Small	skos:exactMatch	go	GO:0015935	small ribosomal subunit	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054817	Pollination	skos:exactMatch	go	GO:0009856	pollination	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054974	Costameres	skos:exactMatch	go	GO:0043034	costamere	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D054992	Immunological Synapses	skos:exactMatch	go	GO:0001772	immunological synapse	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D057897	Reflex, Righting	skos:exactMatch	go	GO:0060013	righting reflex	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D057900	Transcytosis	skos:exactMatch	go	GO:0045056	transcytosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D057907	Post-Synaptic Density	skos:exactMatch	go	GO:0014069	postsynaptic density	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D058767	Protein Unfolding	skos:exactMatch	go	GO:0043335	protein unfolding	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D058849	Protein Refolding	skos:exactMatch	go	GO:0042026	protein refolding	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D058894	Nematocyst	skos:exactMatch	go	GO:0042151	nematocyst	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D059007	Polytene Chromosomes	skos:exactMatch	go	GO:0005700	polytene chromosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D060049	Asymmetric Cell Division	skos:exactMatch	go	GO:0008356	asymmetric cell division	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D060449	Wnt Signaling Pathway	skos:exactMatch	go	GO:0016055	Wnt signaling pathway	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D065608	Renal Reabsorption	skos:exactMatch	go	GO:0070293	renal absorption	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000067128	Extracellular Vesicles	skos:exactMatch	go	GO:1903561	extracellular vesicle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000069292	Pyroptosis	skos:exactMatch	go	GO:0070269	pyroptosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000071182	Autophagosomes	skos:exactMatch	go	GO:0005776	autophagosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000705	Anaphase	skos:exactMatch	go	GO:0051322	anaphase	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001329	Autolysis	skos:exactMatch	go	GO:0001896	autolysis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001343	Autophagy	skos:exactMatch	go	GO:0006914	autophagy	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001485	Basement Membrane	skos:exactMatch	go	GO:0005604	basement membrane	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001519	Behavior	skos:exactMatch	go	GO:0007610	behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001775	Blood Circulation	skos:exactMatch	go	GO:0008015	blood circulation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002454	Cell Differentiation	skos:exactMatch	go	GO:0030154	cell differentiation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002462	Cell Membrane	skos:exactMatch	go	GO:0005886	plasma membrane	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002479	Inclusion Bodies	skos:exactMatch	go	GO:0016234	inclusion body	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002502	Centrioles	skos:exactMatch	go	GO:0005814	centriole	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002633	Chemotaxis	skos:exactMatch	go	GO:0006935	chemotaxis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002736	Chloroplasts	skos:exactMatch	go	GO:0009507	chloroplast	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002823	Chorion	skos:exactMatch	go	GO:0042600	chorion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002843	Chromatin	skos:exactMatch	go	GO:0000785	chromatin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002875	Chromosomes	skos:exactMatch	go	GO:0005694	chromosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002940	Circadian Rhythm	skos:exactMatch	go	GO:0007623	circadian rhythm	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003071	Cognition	skos:exactMatch	go	GO:0050890	cognition	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003167	Complement Activation	skos:exactMatch	go	GO:0006956	complement activation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003593	Cytoplasm	skos:exactMatch	go	GO:0005737	cytoplasm	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003599	Cytoskeleton	skos:exactMatch	go	GO:0005856	cytoskeleton	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003600	Cytosol	skos:exactMatch	go	GO:0005829	cytosol	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003672	Defecation	skos:exactMatch	go	GO:0030421	defecation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003712	Dendrites	skos:exactMatch	go	GO:0030425	dendrite	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003896	Desmosomes	skos:exactMatch	go	GO:0030057	desmosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004260	DNA Repair	skos:exactMatch	go	GO:0006281	DNA repair	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004261	DNA Replication	skos:exactMatch	go	GO:0006260	DNA replication	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D004721	Endoplasmic Reticulum	skos:exactMatch	go	GO:0005783	endoplasmic reticulum	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005089	Exocytosis	skos:exactMatch	go	GO:0006887	exocytosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005109	Extracellular Matrix	skos:exactMatch	go	GO:0031012	extracellular matrix	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005110	Extracellular Space	skos:exactMatch	go	GO:0005615	extracellular space	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005285	Fermentation	skos:exactMatch	go	GO:0006113	fermentation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005306	Fertilization	skos:exactMatch	go	GO:0009566	fertilization	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D005943	Gluconeogenesis	skos:exactMatch	go	GO:0006094	gluconeogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006019	Glycolysis	skos:exactMatch	go	GO:0006096	glycolytic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006056	Golgi Apparatus	skos:exactMatch	go	GO:0005794	Golgi apparatus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006487	Hemostasis	skos:exactMatch	go	GO:0007599	hemostasis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006570	Heterochromatin	skos:exactMatch	go	GO:0000792	heterochromatin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D006967	Hypersensitivity	skos:exactMatch	go	GO:0002524	hypersensitivity	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007249	Inflammation	skos:exactMatch	go	GO:0006954	inflammatory response	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007399	Interphase	skos:exactMatch	go	GO:0051325	interphase	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007858	Learning	skos:exactMatch	go	GO:0007612	learning	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008213	Lymphocyte Activation	skos:exactMatch	go	GO:0046649	lymphocyte activation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008409	Mastication	skos:exactMatch	go	GO:0071626	mastication	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008572	Menarche	skos:exactMatch	go	GO:0042696	menarche	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008593	Menopause	skos:exactMatch	go	GO:0042697	menopause	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008597	Menstrual Cycle	skos:exactMatch	go	GO:0044850	menstrual cycle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008598	Menstruation	skos:exactMatch	go	GO:0042703	menstruation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008660	Metabolism	skos:exactMatch	go	GO:0008152	metabolic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008677	Metaphase	skos:exactMatch	go	GO:0051323	metaphase	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008830	Microbodies	skos:exactMatch	go	GO:0042579	microbody	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008841	Actin Cytoskeleton	skos:exactMatch	go	GO:0015629	actin cytoskeleton	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008870	Microtubules	skos:exactMatch	go	GO:0005874	microtubule	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008928	Mitochondria	skos:exactMatch	go	GO:0005739	mitochondrion	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009119	Muscle Contraction	skos:exactMatch	go	GO:0006936	muscle contraction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009186	Myelin Sheath	skos:exactMatch	go	GO:0043209	myelin sheath	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009336	Necrosis	skos:exactMatch	go	GO:0070265	necrotic cell death	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009685	Nuclear Envelope	skos:exactMatch	go	GO:0005635	nuclear envelope	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009707	Nucleosomes	skos:exactMatch	go	GO:0000786	nucleosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009805	Odontogenesis	skos:exactMatch	go	GO:0042476	odontogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D009866	Oogenesis	skos:exactMatch	go	GO:0048477	oogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010060	Ovulation	skos:exactMatch	go	GO:0030728	ovulation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010085	Oxidative Phosphorylation	skos:exactMatch	go	GO:0006119	oxidative phosphorylation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010528	Peristalsis	skos:exactMatch	go	GO:0030432	peristalsis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010587	Phagocytosis	skos:exactMatch	go	GO:0006909	phagocytosis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010788	Photosynthesis	skos:exactMatch	go	GO:0015979	photosynthesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D010858	Pigmentation	skos:exactMatch	go	GO:0043473	pigmentation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011235	Predatory Behavior	skos:exactMatch	go	GO:0002120	predatory behavior	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011418	Prophase	skos:exactMatch	go	GO:0051324	prophase	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D011992	Endosomes	skos:exactMatch	go	GO:0005768	endosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012038	Regeneration	skos:exactMatch	go	GO:0031099	regeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012098	Reproduction	skos:exactMatch	go	GO:0000003	reproduction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012100	Reproduction, Asexual	skos:exactMatch	go	GO:0019954	asexual reproduction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012326	RNA Splicing	skos:exactMatch	go	GO:0008380	RNA splicing	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012508	Sarcolemma	skos:exactMatch	go	GO:0042383	sarcolemma	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012518	Sarcomeres	skos:exactMatch	go	GO:0030017	sarcomere	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012519	Sarcoplasmic Reticulum	skos:exactMatch	go	GO:0016529	sarcoplasmic reticulum	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D012730	Sex Chromosomes	skos:exactMatch	go	GO:0000803	sex chromosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013081	Sperm Motility	skos:exactMatch	go	GO:0097722	sperm motility	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013091	Spermatogenesis	skos:exactMatch	go	GO:0007283	spermatogenesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013550	Swimming	skos:exactMatch	go	GO:0036268	swimming	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013569	Synapses	skos:exactMatch	go	GO:0045202	synapse	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D013692	Telophase	skos:exactMatch	go	GO:0051326	telophase	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014078	Tooth Eruption	skos:exactMatch	go	GO:0044691	tooth eruption	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014617	Vacuoles	skos:exactMatch	go	GO:0005773	vacuole	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014664	Vasodilation	skos:exactMatch	go	GO:0042311	vasodilation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014796	Visual Perception	skos:exactMatch	go	GO:0007601	visual perception	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014945	Wound Healing	skos:exactMatch	go	GO:0042060	wound healing	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014960	X Chromosome	skos:exactMatch	go	GO:0000805	X chromosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D014998	Y Chromosome	skos:exactMatch	go	GO:0000806	Y chromosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D015388	Organelles	skos:exactMatch	go	GO:0043226	organelle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D015398	Signal Transduction	skos:exactMatch	go	GO:0007165	signal transduction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D015530	Nuclear Matrix	skos:exactMatch	go	GO:0016363	nuclear matrix	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D015539	Platelet Activation	skos:exactMatch	go	GO:0030168	platelet activation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016193	G1 Phase	skos:exactMatch	go	GO:0051318	G1 phase	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016196	S Phase	skos:exactMatch	go	GO:0051320	S phase	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016723	Bone Remodeling	skos:exactMatch	go	GO:0046849	bone remodeling	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016897	Respiratory Burst	skos:exactMatch	go	GO:0045730	respiratory burst	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D016922	Cellular Senescence	skos:exactMatch	go	GO:0090398	cellular senescence	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D017209	Apoptosis	skos:exactMatch	go	GO:0006915	apoptotic process	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D017510	Protein Folding	skos:exactMatch	go	GO:0006457	protein folding	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D017629	Gap Junctions	skos:exactMatch	go	GO:0005921	gap junction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018375	Neutrophil Activation	skos:exactMatch	go	GO:0042119	neutrophil activation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018385	Centrosome	skos:exactMatch	go	GO:0005813	centrosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018392	Genomic Imprinting	skos:exactMatch	go	GO:0071514	genetic imprinting	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018699	Coated Vesicles	skos:exactMatch	go	GO:0030135	coated vesicle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018870	Endoplasmic Reticulum, Rough	skos:exactMatch	go	GO:0005791	rough endoplasmic reticulum	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D018871	Endoplasmic Reticulum, Smooth	skos:exactMatch	go	GO:0005790	smooth endoplasmic reticulum	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019069	Cell Respiration	skos:exactMatch	go	GO:0045333	cellular respiration	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019108	Tight Junctions	skos:exactMatch	go	GO:0070160	tight junction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019154	Protein Splicing	skos:exactMatch	go	GO:0030908	protein splicing	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019276	Glycocalyx	skos:exactMatch	go	GO:0030112	glycocalyx	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D019457	Chromosome Breakage	skos:exactMatch	go	GO:0031052	chromosome breakage	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020090	Chromosome Segregation	skos:exactMatch	go	GO:0007059	chromosome segregation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D020894	Microfibrils	skos:exactMatch	go	GO:0001527	microfibril	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D021941	Caveolae	skos:exactMatch	go	GO:0005901	caveola	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022002	Hemidesmosomes	skos:exactMatch	go	GO:0030056	hemidesmosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022005	Adherens Junctions	skos:exactMatch	go	GO:0005912	adherens junction	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022022	Nuclear Pore	skos:exactMatch	go	GO:0005643	nuclear pore	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022041	Euchromatin	skos:exactMatch	go	GO:0000791	euchromatin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D022161	Transport Vesicles	skos:exactMatch	go	GO:0030133	transport vesicle	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D023102	Anoikis	skos:exactMatch	go	GO:0043276	anoikis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D034443	RNA Transport	skos:exactMatch	go	GO:0050658	RNA transport	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D034622	RNA Interference	skos:exactMatch	go	GO:0016246	RNA interference	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D034881	Nuclear Lamina	skos:exactMatch	go	GO:0005652	nuclear lamina	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D036801	Parturition	skos:exactMatch	go	GO:0007567	parturition	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048348	Reverse Transcription	skos:exactMatch	go	GO:0001171	reverse transcription	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D048749	Cytokinesis	skos:exactMatch	go	GO:0000910	cytokinesis	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D049109	Cell Proliferation	skos:exactMatch	go	GO:0008283	cell population proliferation	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D051336	Mitochondrial Membranes	skos:exactMatch	go	GO:0031966	mitochondrial membrane	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D059447	Cell Cycle Checkpoints	skos:exactMatch	go	GO:0000075	cell cycle checkpoint	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D059547	Stereocilia	skos:exactMatch	go	GO:0032420	stereocilium	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D060152	V(D)J Recombination	skos:exactMatch	go	GO:0033151	V(D)J recombination	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D007382	Intermediate Filaments	skos:exactMatch	go	GO:0005882	intermediate filament	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D008871	Microvilli	skos:exactMatch	go	GO:0005902	microvillus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D055944	Magnetosomes	skos:exactMatch	go	GO:0110143	magnetosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D057646	Virus Uncoating	skos:exactMatch	go	GO:0019061	uncoating of virus	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D057465	Catabolite Repression	skos:exactMatch	go	GO:0061984	catabolite repression	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D055212	Photoreceptor Connecting Cilium	skos:exactMatch	go	GO:0032391	photoreceptor connecting cilium	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000069396	Mitochondrial Ribosomes	skos:exactMatch	go	GO:0005761	mitochondrial ribosome	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000071040	Axon Initial Segment	skos:exactMatch	go	GO:0043194	axon initial segment	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000080642	Chaperone-Mediated Autophagy	skos:exactMatch	go	GO:0061684	chaperone-mediated autophagy	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000081363	Occlusion Bodies, Viral	skos:exactMatch	go	GO:0039679	viral occlusion body	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001846	Bone Development	skos:exactMatch	go	GO:0060348	bone development	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001861	Bone Regeneration	skos:exactMatch	go	GO:1990523	bone regeneration	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001862	Bone Resorption	skos:exactMatch	go	GO:0045453	bone resorption	manually_reviewed	orcid:0000-0001-9439-5346


### PR DESCRIPTION
In this PR I curated a good chunk of the predicted GO mappings. There are lots of new confirmed matches (314) but also a large number of ones that I marked as incorrect (70). The main reason certain matches were incorrect was a mismatch where a MeSH term represents an entity, e.g., `adenylylsulfate reductase`, and the corresponding GO term represents an activity, e.g., `adenylyl-sulfate reductase activity`. Certainly, there is a strong ontological connection between these but `skos:exactMatch` is probably not appropriate here.

The remaining GO mappings are more tricky to evaluate and would require looking more deeply at the individual entries.