### PR TITLE
Add KEGG pathway mappings

### DIFF
--- a/scripts/kegg_mappings.py
+++ b/scripts/kegg_mappings.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+"""Generate mappings to Gilda from given PyOBO prefixes."""
+
+from typing import Iterable, Tuple
+
+import gilda
+import gilda.grounder
+from pyobo.sources.kegg.api import ensure_list_pathways
+from tqdm import tqdm
+
+from biomappings.resources import append_prediction_tuples
+from biomappings.utils import get_script_url
+
+
+def iterate_kegg_matches() -> Iterable[Tuple[str, ...]]:
+    """Iterate over predictions from KEGG Pathways to GO and MeSH."""
+    provenance = get_script_url(__file__)
+    id_name_mapping = ensure_list_pathways()
+    for identifier, name in tqdm(id_name_mapping.items(), desc='Mapping KEGG Pathways'):
+        for scored_match in gilda.ground(name):
+            if scored_match.term.db.lower() not in {'go', 'mesh'}:
+                continue
+
+            yield (
+                'kegg.pathway',
+                identifier,
+                name,
+                'skos:exactMatch',
+                scored_match.term.db.lower(),
+                scored_match.term.id,
+                scored_match.term.entry_name,
+                'lexical',
+                scored_match.score,
+                provenance,
+            )
+
+
+if __name__ == '__main__':
+    append_prediction_tuples(iterate_kegg_matches())

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -121,3 +121,90 @@ mesh	D000203	Activities of Daily Living	skos:exactMatch	efo	0008451	activities o
 mesh	D001792	Blood Platelets	skos:exactMatch	efo	0009237	Estimated Platelets Measurement	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D009504	Neutrophils	skos:exactMatch	efo	0009252	Segmented Neutrophils to Neutrophils Ratio Measurement	manually_reviewed	orcid:0000-0003-4423-4370
 mesh	D053483	Eye Movement Measurements	skos:exactMatch	efo	0007699	eye movement measurement	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07025	Quinolines	skos:exactMatch	mesh	C037219	quinoline	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07057	Antiparkinsonian agents	skos:exactMatch	mesh	D000978	Antiparkinson Agents	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03050	Proteasome	skos:exactMatch	go	GO:0000502	proteasome complex	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07044	Antiviral agents	skos:exactMatch	mesh	D000998	Antiviral Agents	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07039	Opioid analgesics	skos:exactMatch	mesh	D000701	Analgesics, Opioid	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07037	Antiarrhythmic drugs	skos:exactMatch	mesh	D000889	Anti-Arrhythmia Agents	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07035	Prostaglandins	skos:exactMatch	mesh	D011453	Prostaglandins	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07033	Anticonvulsants	skos:exactMatch	mesh	D000927	Anticonvulsants	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map07024	HMG-CoA reductase inhibitors	skos:exactMatch	mesh	D019161	Hydroxymethylglutaryl-CoA Reductase Inhibitors	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04145	Phagosome	skos:exactMatch	mesh	D010588	Phagosomes	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04514	Cell adhesion molecules	skos:exactMatch	mesh	D015815	Cell Adhesion Molecules	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03040	Spliceosome	skos:exactMatch	mesh	D017381	Spliceosomes	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03020	RNA polymerase	skos:exactMatch	mesh	D012321	DNA-Directed RNA Polymerases	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map02010	ABC transporters	skos:exactMatch	mesh	D018528	ATP-Binding Cassette Transporters	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03010	Ribosome	skos:exactMatch	go	GO:0005840	ribosome	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04142	Lysosome	skos:exactMatch	go	GO:0005764	lysosome	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map02010	ABC transporters	skos:exactMatch	go	GO:0140359	ABC-type transmembrane transporter activity	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04520	Adherens junction	skos:exactMatch	go	GO:0005912	adherens junction	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04724	Glutamatergic synapse	skos:exactMatch	go	GO:0098978	glutamatergic synapse	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04725	Cholinergic synapse	skos:exactMatch	go	GO:0098981	cholinergic synapse	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04530	Tight junction	skos:exactMatch	go	GO:0070160	tight junction	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04510	Focal adhesion	skos:exactMatch	go	GO:0005925	focal adhesion	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04146	Peroxisome	skos:exactMatch	go	GO:0005777	peroxisome	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04145	Phagosome	skos:exactMatch	go	GO:0045335	phagocytic vesicle	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04540	Gap junction	skos:exactMatch	go	GO:0005921	gap junction	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04728	Dopaminergic synapse	skos:exactMatch	go	GO:0098691	dopaminergic synapse	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04727	GABAergic synapse	skos:exactMatch	go	GO:0098982	GABA-ergic synapse	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04726	Serotonergic synapse	skos:exactMatch	go	GO:0099154	serotonergic synapse	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04514	Cell adhesion molecules	skos:exactMatch	go	GO:0098631	cell adhesion mediator activity	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04932	Non-alcoholic fatty liver disease	skos:exactMatch	mesh	D065626	Non-alcoholic Fatty Liver Disease	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05010	Alzheimer disease	skos:exactMatch	mesh	D000544	Alzheimer Disease	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05012	Parkinson disease	skos:exactMatch	mesh	D010300	Parkinson Disease	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05016	Huntington disease	skos:exactMatch	mesh	D006816	Huntington Disease	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05020	Prion disease	skos:exactMatch	mesh	D017096	Prion Diseases	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05142	Chagas disease	skos:exactMatch	mesh	D014355	Chagas Disease	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05320	Autoimmune thyroid disease	skos:exactMatch	mesh	D013967	Thyroiditis, Autoimmune	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05321	Inflammatory bowel disease	skos:exactMatch	mesh	D015212	Inflammatory Bowel Diseases	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05332	Graft-versus-host disease	skos:exactMatch	mesh	D006086	Graft vs Host Disease	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04930	Type II diabetes mellitus	skos:exactMatch	mesh	D003924	Diabetes Mellitus, Type 2	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04940	Type I diabetes mellitus	skos:exactMatch	mesh	D003922	Diabetes Mellitus, Type 1	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05014	Amyotrophic lateral sclerosis	skos:exactMatch	mesh	D000690	Amyotrophic Lateral Sclerosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05152	Tuberculosis	skos:exactMatch	mesh	D014376	Tuberculosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05226	Gastric cancer	skos:exactMatch	mesh	D013274	Stomach Neoplasms	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05160	Hepatitis C	skos:exactMatch	mesh	D006526	Hepatitis C	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05161	Hepatitis B	skos:exactMatch	mesh	D006509	Hepatitis B	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05162	Measles	skos:exactMatch	mesh	D008457	Measles	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05144	Malaria	skos:exactMatch	mesh	D008288	Malaria	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05218	Melanoma	skos:exactMatch	mesh	D008545	Melanoma	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05210	Colorectal cancer	skos:exactMatch	mesh	D015179	Colorectal Neoplasms	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05212	Pancreatic cancer	skos:exactMatch	mesh	D010190	Pancreatic Neoplasms	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05214	Glioma	skos:exactMatch	mesh	D016543	Central Nervous System Neoplasms	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05215	Prostate cancer	skos:exactMatch	mesh	D011471	Prostatic Neoplasms	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05219	Bladder cancer	skos:exactMatch	mesh	D001749	Urinary Bladder Neoplasms	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05224	Breast cancer	skos:exactMatch	mesh	D001943	Breast Neoplasms	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04934	Cushing syndrome	skos:exactMatch	mesh	D003480	Cushing Syndrome	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04934	Cushing syndrome	skos:exactMatch	mesh	D000308	Adrenocortical Hyperfunction	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04934	Cushing syndrome	skos:exactMatch	mesh	D006929	Hyperaldosteronism	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05017	Spinocerebellar ataxia	skos:exactMatch	mesh	D020754	Spinocerebellar Ataxias	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05034	Alcoholism	skos:exactMatch	mesh	D000437	Alcoholism	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05034	Alcoholism	skos:exactMatch	mesh	D020751	Alcohol-Induced Disorders	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05220	Chronic myeloid leukemia	skos:exactMatch	mesh	D015464	Leukemia, Myelogenous, Chronic, BCR-ABL Positive	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05220	Chronic myeloid leukemia	skos:exactMatch	mesh	D015466	Leukemia, Myeloid, Chronic-Phase	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05221	Acute myeloid leukemia	skos:exactMatch	mesh	D015470	Leukemia, Myeloid, Acute	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05211	Renal cell carcinoma	skos:exactMatch	mesh	D002292	Carcinoma, Renal Cell	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05217	Basal cell carcinoma	skos:exactMatch	mesh	D002280	Carcinoma, Basal Cell	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05222	Small cell lung cancer	skos:exactMatch	mesh	D055752	Small Cell Lung Carcinoma	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05223	Non-small cell lung cancer	skos:exactMatch	mesh	D002289	Carcinoma, Non-Small-Cell Lung	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05225	Hepatocellular carcinoma	skos:exactMatch	mesh	D006528	Carcinoma, Hepatocellular	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03070	Bacterial secretion system	skos:exactMatch	mesh	D058947	Bacterial Secretion Systems	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04614	Renin-angiotensin system	skos:exactMatch	mesh	D012084	Renin-Angiotensin System	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05322	Systemic lupus erythematosus	skos:exactMatch	mesh	D008180	Lupus Erythematosus, Systemic	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05110	Vibrio cholerae infection	skos:exactMatch	mesh	D002771	Cholera	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05132	Salmonella infection	skos:exactMatch	mesh	D012480	Salmonella Infections	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05135	Yersinia infection	skos:exactMatch	mesh	D015009	Yersinia Infections	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05150	Staphylococcus aureus infection	skos:exactMatch	mesh	D013203	Staphylococcal Infections	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05165	Human papillomavirus infection	skos:exactMatch	mesh	D030361	Papillomavirus Infections	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05169	Epstein-Barr virus infection	skos:exactMatch	mesh	D020031	Epstein-Barr Virus Infections	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05032	Morphine addiction	skos:exactMatch	mesh	D009021	Morphine Dependence	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05033	Nicotine addiction	skos:exactMatch	mesh	D014029	Tobacco Use Disorder	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05131	Shigellosis	skos:exactMatch	mesh	D004405	Dysentery, Bacillary	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05133	Pertussis	skos:exactMatch	mesh	D014917	Whooping Cough	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05134	Legionellosis	skos:exactMatch	mesh	D007876	Legionellosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05140	Leishmaniasis	skos:exactMatch	mesh	D007896	Leishmaniasis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05143	African trypanosomiasis	skos:exactMatch	mesh	D014353	Trypanosomiasis, African	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05214	Glioma	skos:exactMatch	mesh	D005910	Glioma	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05310	Asthma	skos:exactMatch	mesh	D001249	Asthma	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05323	Rheumatoid arthritis	skos:exactMatch	mesh	D001172	Arthritis, Rheumatoid	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -208,3 +208,9 @@ kegg.pathway	map05143	African trypanosomiasis	skos:exactMatch	mesh	D014353	Trypa
 kegg.pathway	map05214	Glioma	skos:exactMatch	mesh	D005910	Glioma	manually_reviewed	orcid:0000-0003-4423-4370
 kegg.pathway	map05310	Asthma	skos:exactMatch	mesh	D001249	Asthma	manually_reviewed	orcid:0000-0003-4423-4370
 kegg.pathway	map05323	Rheumatoid arthritis	skos:exactMatch	mesh	D001172	Arthritis, Rheumatoid	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05146	Amoebiasis	skos:exactMatch	mesh	D000562	Amebiasis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05213	Endometrial cancer	skos:exactMatch	mesh	D004030	Dientamoebiasis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05145	Toxoplasmosis	skos:exactMatch	mesh	D014123	Toxoplasmosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05410	Hypertrophic cardiomyopathy	skos:exactMatch	mesh	D002312	Cardiomyopathy, Hypertrophic	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05412	Arrhythmogenic right ventricular cardiomyopathy	skos:exactMatch	mesh	D019571	Arrhythmogenic Right Ventricular Dysplasia	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map05414	Dilated cardiomyopathy	skos:exactMatch	mesh	D002311	Cardiomyopathy, Dilated	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -1366,3 +1366,118 @@ mesh	D055312	Cystatin A	skos:exactMatch	hgnc	2481	CSTA	manually_reviewed	orcid:0
 mesh	D055313	Cystatin B	skos:exactMatch	hgnc	2482	CSTB	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D055316	Cystatin C	skos:exactMatch	hgnc	2475	CST3	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D055332	Cystatin M	skos:exactMatch	hgnc	2478	CST6	manually_reviewed	orcid:0000-0001-9439-5346
+kegg.pathway	map00030	Pentose phosphate pathway	skos:exactMatch	go	GO:0006098	pentose-phosphate shunt	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00052	Galactose metabolism	skos:exactMatch	go	GO:0006012	galactose metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00061	Fatty acid biosynthesis	skos:exactMatch	go	GO:0006633	fatty acid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00062	Fatty acid elongation	skos:exactMatch	go	GO:0030497	fatty acid elongation	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00071	Fatty acid degradation	skos:exactMatch	go	GO:0009062	fatty acid catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00100	Steroid biosynthesis	skos:exactMatch	go	GO:0006694	steroid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00190	Oxidative phosphorylation	skos:exactMatch	go	GO:0006119	oxidative phosphorylation	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00195	Photosynthesis	skos:exactMatch	go	GO:0015979	photosynthesis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00220	Arginine biosynthesis	skos:exactMatch	go	GO:0006526	arginine biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00240	Pyrimidine metabolism	skos:exactMatch	go	GO:0006206	pyrimidine nucleobase metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00254	Aflatoxin biosynthesis	skos:exactMatch	go	GO:0045122	aflatoxin biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00281	Geraniol degradation	skos:exactMatch	go	GO:1903447	geraniol catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00300	Lysine biosynthesis	skos:exactMatch	go	GO:0009085	lysine biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00310	Lysine degradation	skos:exactMatch	go	GO:0006554	lysine catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00331	Clavulanic acid biosynthesis	skos:exactMatch	go	GO:0033050	clavulanic acid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00332	Carbapenem biosynthesis	skos:exactMatch	go	GO:1901769	carbapenem biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00340	Histidine metabolism	skos:exactMatch	go	GO:0006547	histidine metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00350	Tyrosine metabolism	skos:exactMatch	go	GO:0006570	tyrosine metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00362	Benzoate degradation	skos:exactMatch	go	GO:0043639	benzoate catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00380	Tryptophan metabolism	skos:exactMatch	go	GO:0006568	tryptophan metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00410	beta-Alanine metabolism	skos:exactMatch	go	GO:0019482	beta-alanine metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00460	Cyanoamino acid metabolism	skos:exactMatch	go	GO:0033052	cyanoamino acid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00473	D-Alanine metabolism	skos:exactMatch	go	GO:0046436	D-alanine metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00480	Glutathione metabolism	skos:exactMatch	go	GO:0006749	glutathione metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00510	N-Glycan biosynthesis	skos:exactMatch	go	GO:0006487	protein N-linked glycosylation	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00521	Streptomycin biosynthesis	skos:exactMatch	go	GO:0019872	streptomycin biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00531	Glycosaminoglycan degradation	skos:exactMatch	go	GO:0006027	glycosaminoglycan catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00540	Lipopolysaccharide biosynthesis	skos:exactMatch	go	GO:0009103	lipopolysaccharide biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00550	Peptidoglycan biosynthesis	skos:exactMatch	go	GO:0009252	peptidoglycan biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04110	Cell cycle	skos:exactMatch	go	GO:0007049	cell cycle	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04144	Endocytosis	skos:exactMatch	go	GO:0006897	endocytosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00561	Glycerolipid metabolism	skos:exactMatch	go	GO:0046486	glycerolipid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00562	Inositol phosphate metabolism	skos:exactMatch	go	GO:0043647	inositol phosphate metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00564	Glycerophospholipid metabolism	skos:exactMatch	go	GO:0006650	glycerophospholipid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00565	Ether lipid metabolism	skos:exactMatch	go	GO:0046485	ether lipid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00590	Arachidonic acid metabolism	skos:exactMatch	go	GO:0019369	arachidonic acid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00591	Linoleic acid metabolism	skos:exactMatch	go	GO:0043651	linoleic acid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00592	alpha-Linolenic acid metabolism	skos:exactMatch	go	GO:0036109	alpha-linolenic acid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00600	Sphingolipid metabolism	skos:exactMatch	go	GO:0006665	sphingolipid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00620	Pyruvate metabolism	skos:exactMatch	go	GO:0006090	pyruvate metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00622	Xylene degradation	skos:exactMatch	go	GO:0042184	xylene catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00623	Toluene degradation	skos:exactMatch	go	GO:0042203	toluene catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00626	Naphthalene degradation	skos:exactMatch	go	GO:1901170	naphthalene catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00633	Nitrotoluene degradation	skos:exactMatch	go	GO:0046263	nitrotoluene catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00640	Propanoate metabolism	skos:exactMatch	go	GO:0019541	propionate metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00643	Styrene degradation	skos:exactMatch	go	GO:0042207	styrene catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00680	Methane metabolism	skos:exactMatch	go	GO:0015947	methane metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00730	Thiamine metabolism	skos:exactMatch	go	GO:0006772	thiamine metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00740	Riboflavin metabolism	skos:exactMatch	go	GO:0006771	riboflavin metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00750	Vitamin B6 metabolism	skos:exactMatch	go	GO:0042816	vitamin B6 metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00780	Biotin metabolism	skos:exactMatch	go	GO:0006768	biotin metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00785	Lipoic acid metabolism	skos:exactMatch	go	GO:0009106	lipoate metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00790	Folate biosynthesis	skos:exactMatch	go	GO:0046656	folic acid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00791	Atrazine degradation	skos:exactMatch	go	GO:0019381	atrazine catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00830	Retinol metabolism	skos:exactMatch	go	GO:0042572	retinol metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00901	Indole alkaloid biosynthesis	skos:exactMatch	go	GO:0035835	indole alkaloid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00902	Monoterpenoid biosynthesis	skos:exactMatch	go	GO:0016099	monoterpenoid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00904	Diterpenoid biosynthesis	skos:exactMatch	go	GO:0016102	diterpenoid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00905	Brassinosteroid biosynthesis	skos:exactMatch	go	GO:0016132	brassinosteroid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00906	Carotenoid biosynthesis	skos:exactMatch	go	GO:0016117	carotenoid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00908	Zeatin biosynthesis	skos:exactMatch	go	GO:0033398	zeatin biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00920	Sulfur metabolism	skos:exactMatch	go	GO:0006790	sulfur compound metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00930	Caprolactam degradation	skos:exactMatch	go	GO:0019384	caprolactam catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00940	Phenylpropanoid biosynthesis	skos:exactMatch	go	GO:0009699	phenylpropanoid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00941	Flavonoid biosynthesis	skos:exactMatch	go	GO:0009813	flavonoid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00942	Anthocyanin biosynthesis	skos:exactMatch	go	GO:0009718	anthocyanin-containing compound biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00943	Isoflavonoid biosynthesis	skos:exactMatch	go	GO:0009717	isoflavonoid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00950	Isoquinoline alkaloid biosynthesis	skos:exactMatch	go	GO:0033075	isoquinoline alkaloid biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00966	Glucosinolate biosynthesis	skos:exactMatch	go	GO:0019761	glucosinolate biosynthetic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00984	Steroid degradation	skos:exactMatch	go	GO:0006706	steroid catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map01212	Fatty acid metabolism	skos:exactMatch	go	GO:0006631	fatty acid metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04920	Adipocytokine signaling pathway	skos:exactMatch	go	GO:0033210	leptin-mediated signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map02024	Quorum sensing	skos:exactMatch	go	GO:0009372	quorum sensing	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03030	DNA replication	skos:exactMatch	go	GO:0006260	DNA replication	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03320	PPAR signaling pathway	skos:exactMatch	go	GO:0035357	peroxisome proliferator activated receptor signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04071	Sphingolipid signaling pathway	skos:exactMatch	go	GO:0090520	sphingolipid mediated signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04012	ErbB signaling pathway	skos:exactMatch	go	GO:0038127	ERBB signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04218	Cellular senescence	skos:exactMatch	go	GO:0090398	cellular senescence	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04917	Prolactin signaling pathway	skos:exactMatch	go	GO:0038161	prolactin signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04310	Wnt signaling pathway	skos:exactMatch	go	GO:0016055	Wnt signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03440	Homologous recombination	skos:exactMatch	go	GO:0035825	homologous recombination	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04390	Hippo signaling pathway	skos:exactMatch	go	GO:0035329	hippo signaling	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04210	Apoptosis	skos:exactMatch	go	GO:0006915	apoptotic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04217	Necroptosis	skos:exactMatch	go	GO:0070266	necroptotic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04217	Necroptosis	skos:exactMatch	mesh	D000079302	Necroptosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04216	Ferroptosis	skos:exactMatch	mesh	D000079403	Ferroptosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04216	Ferroptosis	skos:exactMatch	go	GO:0097707	ferroptosis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map00970	Aminoacyl-tRNA biosynthesis	skos:exactMatch	go	GO:0043039	tRNA aminoacylation	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03013	RNA transport	skos:exactMatch	go	GO:0050658	RNA transport	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03018	RNA degradation	skos:exactMatch	go	GO:0006401	RNA catabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04115	p53 signaling pathway	skos:exactMatch	go	GO:0030330	DNA damage response, signal transduction by p53 class mediator	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04260	Cardiac muscle contraction	skos:exactMatch	go	GO:0060048	cardiac muscle contraction	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04270	Vascular smooth muscle contraction	skos:exactMatch	go	GO:0014829	vascular smooth muscle contraction	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04330	Notch signaling pathway	skos:exactMatch	go	GO:0007219	Notch signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04340	Hedgehog signaling pathway	skos:exactMatch	go	GO:0007224	smoothened signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04360	Axon guidance	skos:exactMatch	go	GO:0007411	axon guidance	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04361	Axon regeneration	skos:exactMatch	go	GO:0031103	axon regeneration	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04380	Osteoclast differentiation	skos:exactMatch	go	GO:0030316	osteoclast differentiation	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04611	Platelet activation	skos:exactMatch	go	GO:0030168	platelet activation	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04612	Antigen processing and presentation	skos:exactMatch	go	GO:0019882	antigen processing and presentation	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map03430	Mismatch repair	skos:exactMatch	go	GO:0006298	mismatch repair	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04620	Toll-like receptor signaling pathway	skos:exactMatch	go	GO:0002224	toll-like receptor signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04621	NOD-like receptor signaling pathway	skos:exactMatch	go	GO:0035872	nucleotide-binding domain, leucine rich repeat containing receptor signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04650	Natural killer cell mediated cytotoxicity	skos:exactMatch	go	GO:0042267	natural killer cell mediated cytotoxicity	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04660	T cell receptor signaling pathway	skos:exactMatch	go	GO:0050852	T cell receptor signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04662	B cell receptor signaling pathway	skos:exactMatch	go	GO:0050853	B cell receptor signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04710	Circadian rhythm	skos:exactMatch	go	GO:0007623	circadian rhythm	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04721	Synaptic vesicle cycle	skos:exactMatch	go	GO:0099504	synaptic vesicle cycle	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04722	Neurotrophin signaling pathway	skos:exactMatch	go	GO:0038179	neurotrophin signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04744	Phototransduction	skos:exactMatch	go	GO:0007602	phototransduction	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04911	Insulin secretion	skos:exactMatch	go	GO:0030073	insulin secretion	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04920	Adipocytokine signaling pathway	skos:exactMatch	go	GO:0033209	tumor necrosis factor-mediated signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04920	Adipocytokine signaling pathway	skos:exactMatch	go	GO:0033211	adiponectin-activated signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04979	Cholesterol metabolism	skos:exactMatch	go	GO:0008203	cholesterol metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04971	Gastric acid secretion	skos:exactMatch	go	GO:0001696	gastric acid secretion	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -1481,3 +1481,5 @@ kegg.pathway	map04920	Adipocytokine signaling pathway	skos:exactMatch	go	GO:0033
 kegg.pathway	map04920	Adipocytokine signaling pathway	skos:exactMatch	go	GO:0033211	adiponectin-activated signaling pathway	manually_reviewed	orcid:0000-0003-4423-4370
 kegg.pathway	map04979	Cholesterol metabolism	skos:exactMatch	go	GO:0008203	cholesterol metabolic process	manually_reviewed	orcid:0000-0003-4423-4370
 kegg.pathway	map04971	Gastric acid secretion	skos:exactMatch	go	GO:0001696	gastric acid secretion	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04714	Thermogenesis	skos:exactMatch	mesh	D022722	Thermogenesis	manually_reviewed	orcid:0000-0003-4423-4370
+kegg.pathway	map04720	Long-term potentiation	skos:exactMatch	mesh	D017774	Long-Term Potentiation	manually_reviewed	orcid:0000-0003-4423-4370


### PR DESCRIPTION
This PR adds mappings from KEGG Pathway to GO and MeSH when possible. GO terms corresponding to cellular components and activities were automatically marked as incorrect, even in cases when the pathway was about that as a topic. For example, KEGG has a peroxisomes pathway and there is a cellular component in GO for peroxisomes, but these are not the same thing. KEGG also has many disease-specific pathways that mapped to MeSH names, but these are not the same either. Later, other ontological relationships could be assigned to map these together.