### PR TITLE
Remove redundant FamPlex-MeSH predictions and mappings

### DIFF
--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -353,7 +353,6 @@ mesh	D064209	Phytochemicals	skos:exactMatch	ncit	C28269	Phytochemical	manually_r
 mesh	D064208	Aggregatibacter segnis	skos:exactMatch	ncit	C86135	Aggregatibacter segnis	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D064206	Aggregatibacter	skos:exactMatch	ncit	C86132	Aggregatibacter	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D064207	Aggregatibacter aphrophilus	skos:exactMatch	ncit	C86134	Aggregatibacter aphrophilus	manually_reviewed	orcid:0000-0001-9439-5346
-mesh	D064233	Sulfonylurea Receptors	skos:exactMatch	fplx	Sulfonylurea_receptor	Sulfonylurea_receptor	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D064166	Vaccine Potency	skos:exactMatch	ncit	C69183	Vaccine Potency	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D064048	Spindle Pole Bodies	skos:exactMatch	ncit	C13365	Spindle Pole Body	manually_reviewed	orcid:0000-0001-9439-5346
 mesh	D064047	Spindle Poles	skos:exactMatch	go	GO:0000922	spindle pole	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2098,3 +2098,103 @@ reactome	R-HSA-72086	mRNA Capping	speciesSpecific	go	GO:0006370	7-methylguanosin
 reactome	R-HSA-72312	rRNA processing	speciesSpecific	go	GO:0006364	rRNA processing	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-HSA-379724	tRNA Aminoacylation	speciesSpecific	go	GO:0043039	tRNA aminoacylation	manually_reviewed	orcid:0000-0003-4423-4370
 reactome	R-HSA-72306	tRNA processing	speciesSpecific	go	GO:0008033	tRNA processing	manually_reviewed	orcid:0000-0003-4423-4370
+mesh	D000080242	8-Hydroxy-2'-Deoxyguanosine	skos:exactMatch	chebi	CHEBI:40304	8-hydroxy-2'-deoxyguanosine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000317	Adrenergic alpha-Antagonists	skos:exactMatch	chebi	CHEBI:37890	alpha-adrenergic antagonist	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000316	Adrenergic alpha-Agonists	skos:exactMatch	chebi	CHEBI:35569	alpha-adrenergic agonist	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000318	Adrenergic beta-Agonists	skos:exactMatch	chebi	CHEBI:35522	beta-adrenergic agonist	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000319	Adrenergic beta-Antagonists	skos:exactMatch	chebi	CHEBI:35530	beta-adrenergic antagonist	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000433	1-Propanol	skos:exactMatch	chebi	CHEBI:28831	propan-1-ol	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000803	Angiotensin I	skos:exactMatch	chebi	CHEBI:2718	Angiotensin I	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000805	Angiotensin III	skos:exactMatch	chebi	CHEBI:89666	Angiotensin III	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000779	Anesthetics, Local	skos:exactMatch	chebi	CHEBI:36333	local anaesthetic	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000894	Anti-Inflammatory Agents, Non-Steroidal	skos:exactMatch	chebi	CHEBI:35475	non-steroidal anti-inflammatory drug	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000988	Antispermatogenic Agents	skos:exactMatch	chebi	CHEBI:145047	antispermatogenic agent	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D000993	Antitreponemal Agents	skos:exactMatch	chebi	CHEBI:36050	antitreponemal drug	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001378	Azasteroids	skos:exactMatch	chebi	CHEBI:35726	aza-steroid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001455	Bambermycins	skos:exactMatch	chebi	CHEBI:28908	bambermycin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001603	Berkelium	skos:exactMatch	chebi	CHEBI:33391	berkelium atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001608	Beryllium	skos:exactMatch	chebi	CHEBI:30501	beryllium atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001615	beta-Endorphin	skos:exactMatch	chebi	CHEBI:10415	beta-endorphin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001895	Boron	skos:exactMatch	chebi	CHEBI:27560	boron atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001969	Bromobenzenes	skos:exactMatch	chebi	CHEBI:37149	bromobenzenes	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001971	Bromocriptine	skos:exactMatch	chebi	CHEBI:3181	bromocriptine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001977	Brompheniramine	skos:exactMatch	chebi	CHEBI:3183	brompheniramine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001978	Bromphenol Blue	skos:exactMatch	chebi	CHEBI:59424	bromophenol blue	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D001993	Bronchodilator Agents	skos:exactMatch	chebi	CHEBI:35523	bronchodilator agent	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002118	Calcium	skos:exactMatch	chebi	CHEBI:22984	calcium atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002120	Calcium Channel Agonists	skos:exactMatch	chebi	CHEBI:38807	calcium channel agonist	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002125	Calcium Gluconate	skos:exactMatch	chebi	CHEBI:3309	Calcium Gluconate	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002142	Californium	skos:exactMatch	chebi	CHEBI:33392	californium atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002227	Carbazoles	skos:exactMatch	chebi	CHEBI:48513	carbazoles	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002235	Carbofuran	skos:exactMatch	chebi	CHEBI:34611	carbofuran	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002244	Carbon	skos:exactMatch	chebi	CHEBI:27594	carbon atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002245	Carbon Dioxide	skos:exactMatch	chebi	CHEBI:16526	carbon dioxide	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002254	Carbonates	skos:exactMatch	chebi	CHEBI:23016	carbonates	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002308	Cardiolipins	skos:exactMatch	chebi	CHEBI:28494	cardiolipin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002301	Cardiac Glycosides	skos:exactMatch	chebi	CHEBI:83970	cardiac glycoside	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002298	Cardenolides	skos:exactMatch	chebi	CHEBI:74634	cardenolides	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002273	Carcinogens	skos:exactMatch	chebi	CHEBI:50903	carcinogenic agent	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002740	Chlorothiazide	skos:exactMatch	chebi	CHEBI:3640	chlorothiazide	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002745	Chlorphentermine	skos:exactMatch	chebi	CHEBI:3646	Chlorphentermine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002491	Central Nervous System Agents	skos:exactMatch	chebi	CHEBI:35470	central nervous system drug	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002784	Cholesterol	skos:exactMatch	chebi	CHEBI:16113	cholesterol	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002794	Choline	skos:exactMatch	chebi	CHEBI:15354	choline	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002857	Chromium	skos:exactMatch	chebi	CHEBI:28073	chromium atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002867	Chromones	skos:exactMatch	chebi	CHEBI:23238	chromones	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002863	Chromogenic Compounds	skos:exactMatch	chebi	CHEBI:75050	chromogenic compound	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002801	Cholinesterase Reactivators	skos:exactMatch	chebi	CHEBI:50241	cholinesterase reactivator	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002939	Ciprofloxacin	skos:exactMatch	chebi	CHEBI:100241	ciprofloxacin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002934	Cinnamates	skos:exactMatch	chebi	CHEBI:36091	cinnamates	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002930	Cinchona Alkaloids	skos:exactMatch	chebi	CHEBI:51323	cinchona alkaloid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003006	Clopenthixol	skos:exactMatch	chebi	CHEBI:59115	clopenthixol	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002997	Clomipramine	skos:exactMatch	chebi	CHEBI:47780	clomipramine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002996	Clomiphene	skos:exactMatch	chebi	CHEBI:3752	clomiphene	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D002994	Clofibrate	skos:exactMatch	chebi	CHEBI:3750	clofibrate	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003022	Clotrimazole	skos:exactMatch	chebi	CHEBI:3764	clotrimazole	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003023	Cloxacillin	skos:exactMatch	chebi	CHEBI:49566	cloxacillin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003024	Clozapine	skos:exactMatch	chebi	CHEBI:3766	clozapine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003038	Cobamides	skos:exactMatch	chebi	CHEBI:23341	cobamides	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003042	Cocaine	skos:exactMatch	chebi	CHEBI:27958	cocaine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003049	Coccidiostats	skos:exactMatch	chebi	CHEBI:35818	coccidiostat	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003061	Codeine	skos:exactMatch	chebi	CHEBI:16714	codeine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003065	Coenzyme A	skos:exactMatch	chebi	CHEBI:15346	coenzyme A	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003067	Coenzymes	skos:exactMatch	chebi	CHEBI:23354	coenzyme	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003070	Coformycin	skos:exactMatch	chebi	CHEBI:16213	coformycin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003084	Colestipol	skos:exactMatch	chebi	CHEBI:3814	colestipol	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003094	Collagen	skos:exactMatch	chebi	CHEBI:3815	Collagen	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003224	Congo Red	skos:exactMatch	chebi	CHEBI:34653	Congo Red	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003300	Copper	skos:exactMatch	chebi	CHEBI:28694	copper atom	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003345	Corticosterone	skos:exactMatch	chebi	CHEBI:16827	corticosterone	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003348	Cortisone	skos:exactMatch	chebi	CHEBI:16962	cortisone	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003358	Cosmetics	skos:exactMatch	chebi	CHEBI:64857	cosmetic	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003366	Cosyntropin	skos:exactMatch	chebi	CHEBI:3901	cosyntropin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003372	Coumaphos	skos:exactMatch	chebi	CHEBI:3903	coumaphos	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003374	Coumarins	skos:exactMatch	chebi	CHEBI:23403	coumarins	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003375	Coumestrol	skos:exactMatch	chebi	CHEBI:3908	coumestrol	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003401	Creatine	skos:exactMatch	chebi	CHEBI:16919	creatine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003404	Creatinine	skos:exactMatch	chebi	CHEBI:16737	creatinine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003408	Cresols	skos:exactMatch	chebi	CHEBI:25399	cresol	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003484	Cyanamide	skos:exactMatch	chebi	CHEBI:16698	cyanamide	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003485	Cyanates	skos:exactMatch	chebi	CHEBI:23420	cyanates	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003486	Cyanides	skos:exactMatch	chebi	CHEBI:23424	cyanides	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003492	Cycasin	skos:exactMatch	chebi	CHEBI:17074	cycasin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003494	Cyclamates	skos:exactMatch	chebi	CHEBI:82431	Cyclamate	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003501	Cyclizine	skos:exactMatch	chebi	CHEBI:3994	cyclizine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003505	Cyclodextrins	skos:exactMatch	chebi	CHEBI:23456	cyclodextrin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003506	Cyclofenil	skos:exactMatch	chebi	CHEBI:31446	Cyclofenil	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003511	Cyclohexanols	skos:exactMatch	chebi	CHEBI:23480	cyclohexanols	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003512	Cyclohexanones	skos:exactMatch	chebi	CHEBI:23482	cyclohexanones	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003513	Cycloheximide	skos:exactMatch	chebi	CHEBI:27641	cycloheximide	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003517	Cyclopentanes	skos:exactMatch	chebi	CHEBI:23493	cyclopentanes	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003519	Cyclopentolate	skos:exactMatch	chebi	CHEBI:4024	cyclopentolate	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003521	Cyclopropanes	skos:exactMatch	chebi	CHEBI:51454	cyclopropanes	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003533	Cyproheptadine	skos:exactMatch	chebi	CHEBI:4046	cyproheptadine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003540	Cystathionine	skos:exactMatch	chebi	CHEBI:17755	cystathionine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003544	Cysteic Acid	skos:exactMatch	chebi	CHEBI:21260	cysteic acid	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003545	Cysteine	skos:exactMatch	chebi	CHEBI:15356	cysteine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003548	Cysteinyldopa	skos:exactMatch	chebi	CHEBI:81392	Cysteinyldopa	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003553	Cystine	skos:exactMatch	chebi	CHEBI:17376	cystine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003562	Cytidine	skos:exactMatch	chebi	CHEBI:17562	cytidine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003571	Cytochalasin B	skos:exactMatch	chebi	CHEBI:23527	cytochalasin B	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003596	Cytosine	skos:exactMatch	chebi	CHEBI:16040	cytosine	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D003620	Dantrolene	skos:exactMatch	chebi	CHEBI:4317	dantrolene	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -33,7 +33,6 @@ def commit(message: str) -> Optional[str]:
 
 def push() -> Optional[str]:
     """Push the git repo."""
-    breakpoint()
     return _git('push')
 
 

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -33,6 +33,7 @@ def commit(message: str) -> Optional[str]:
 
 def push() -> Optional[str]:
     """Push the git repo."""
+    breakpoint()
     return _git('push')
 
 


### PR DESCRIPTION
This PR removes FamPlex-MeSH predictions and mappings that are available via FamPlex directly (as a "primary" source) and should therefore not be duplicated here. It also adds some CHEBI-MeSH curations. Fixes #28.