### PR TITLE
Add scripts for generating ortholog relations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,5 +24,6 @@ max-complexity = 20
 import-order-style = pycharm
 application-import-names =
     biomappings
+    scripts
     tests
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s

--- a/scripts/generate_kegg_orthologs.py
+++ b/scripts/generate_kegg_orthologs.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+"""Generate orthologous relations between KEGG pathways."""
+
+import itertools as itt
+from collections import defaultdict
+from typing import Callable, Iterable, List, Mapping
+
+import pyobo
+from tqdm import tqdm
+
+from biomappings.resources import MappingTuple, append_true_mapping_tuples
+from biomappings.utils import get_script_url
+
+
+def iterate_orthologous_lexical_matches() -> Iterable[MappingTuple]:
+    """Generate orthologous relations between KEGG pathways."""
+    prefix = 'kegg.pathway'
+    yield from iterate_orthologs(prefix, _get_species_to_identifiers)
+
+
+def _get_species_to_identifiers(names: Mapping[str, str]) -> Mapping[str, List[str]]:
+    species_to_identifiers = defaultdict(list)
+    for identifier in names:
+        if identifier.startswith('map'):
+            continue
+        species_to_identifiers[_get_kegg_id(identifier)].append(identifier)
+    return species_to_identifiers
+
+
+def _get_kegg_id(identifier: str) -> str:
+    pos = min(i for i, c in enumerate(identifier) if c.isnumeric())
+    return identifier[pos:]
+
+
+def iterate_orthologs(
+    prefix: str,
+    f: Callable[[Mapping[str, str]], Mapping[str, List[str]]],
+) -> Iterable[MappingTuple]:
+    """Iterate over orthologs based on identifier matching."""
+    provenance = get_script_url(__file__)
+    names = pyobo.get_id_name_mapping(prefix)
+    species_to_identifiers = f(names)
+    count = 0
+    for identifiers in tqdm(species_to_identifiers.values()):
+        for source_id, target_id in itt.product(identifiers, identifiers):
+            if source_id >= target_id:
+                continue
+            count += 1
+            yield MappingTuple(
+                prefix,
+                source_id,
+                names[source_id],
+                'orthologous',
+                prefix,
+                target_id,
+                names[target_id],
+                'calculated',
+                provenance,
+            )
+    print(f'Identified {count} orthologs')
+
+
+if __name__ == '__main__':
+    append_true_mapping_tuples(iterate_orthologous_lexical_matches())

--- a/scripts/generate_reactome_orthologs.py
+++ b/scripts/generate_reactome_orthologs.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+"""Generate orthologous relations between Reactome pathways."""
+
+from collections import defaultdict
+from typing import Iterable, List, Mapping
+
+from biomappings.resources import MappingTuple, append_true_mapping_tuples
+from scripts.generate_kegg_orthologs import iterate_orthologs
+
+
+def _get_species_to_identifiers(names: Mapping[str, str]) -> Mapping[str, List[str]]:
+    species_to_identifiers = defaultdict(list)
+    for identifier in names:
+        species_to_identifiers[identifier.split('-')[-1]].append(identifier)
+    return species_to_identifiers
+
+
+def iterate_orthologous_lexical_matches() -> Iterable[MappingTuple]:
+    """Generate orthologous relations between Reactome pathways."""
+    prefix = 'reactome'
+    yield from iterate_orthologs(prefix, _get_species_to_identifiers)
+
+
+if __name__ == '__main__':
+    append_true_mapping_tuples(iterate_orthologous_lexical_matches())

--- a/scripts/generate_wikipathways_orthologs.py
+++ b/scripts/generate_wikipathways_orthologs.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""Generate orthologous relations between WikiPathways."""
+
+from typing import Iterable
+
+import pyobo
+from gilda.process import normalize
+from tqdm.contrib.itertools import product
+
+from biomappings.resources import PredictionTuple, append_prediction_tuples
+from biomappings.utils import get_script_url
+
+
+def _lexical_exact_match(name1: str, name2: str) -> bool:
+    return normalize(name1) == normalize(name2)
+
+
+def iterate_orthologous_lexical_matches(prefix: str = 'wikipathways') -> Iterable[PredictionTuple]:
+    """Generate orthologous relations between lexical matches from different species."""
+    names = pyobo.get_id_name_mapping(prefix)
+    species = pyobo.get_id_species_mapping(prefix)
+    provenance = get_script_url(__file__)
+
+    count = 0
+    for (source_id, source_name), (target_id, target_name) in product(names.items(), names.items(), unit_scale=True):
+        if species[source_id] == species[target_id]:
+            continue
+        if source_id > target_id:  # make canonical order
+            continue
+        if _lexical_exact_match(source_name, target_name):
+            count += 1
+            yield PredictionTuple(
+                prefix, source_id, source_name,
+                'orthologous',
+                prefix, target_id, target_name,
+                'lexical',
+                0.99,
+                provenance,
+            )
+    print(f'Identified {count} orthologs')
+
+
+if __name__ == '__main__':
+    append_prediction_tuples(iterate_orthologous_lexical_matches())


### PR DESCRIPTION
This PR adds three scripts for generating orthology relations

1. KEGG - based on identifier matching
2. Reactome - based on identifier matching
3. WikiPathways - based on lexical matching

The KEGG and Reactome matching are correct by definition, but do not exist in any primary source, so could be added directly. This PR doesn't (yet) contain the results because I'm not really sure if this should be in scope of the repo. There are quite a few (30K+) to add.

The WikiPathways ones are highly likely to be correct, but should still go through a round of curation. Since there could be tons of variability in names in WikiPathways, it might be good to also predict mappings through paths like ```WP1 speciesSpecific X speciesSpecific WP2```


