### PR TITLE
Add flask-wtf requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ charts =
 web =
     flask
     bootstrap-flask
+    flask-wtf
 ndex =
     ndex2
 


### PR DESCRIPTION
I think `flask-wtf` is required as a separate install requirement, I had to install it in a clean virtualenv in addition to flask and bootstrap-flask to make the webapp run.