### PR TITLE
Add ncbiprotein-uniprot.chain mappings for SARS-CoV-2

### DIFF
--- a/src/biomappings/resources/incorrect.tsv
+++ b/src/biomappings/resources/incorrect.tsv
@@ -710,3 +710,8 @@ reactome	R-XTR-419771	Opsins	speciesSpecific	go	GO:0007602	phototransduction	man
 wikipathways	WP2369	Histone Modifications	speciesSpecific	mesh	D042421	Histone Code	manually_reviewed	orcid:0000-0003-4423-4370
 wikipathways	WP3123	Histone Modifications	speciesSpecific	mesh	D042421	Histone Code	manually_reviewed	orcid:0000-0003-4423-4370
 wikipathways	WP300	Histone modifications	speciesSpecific	mesh	D042421	Histone Code	manually_reviewed	orcid:0000-0003-4423-4370
+pr	PR:000035728	ubiquitin	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
+pr	PR:000035716	ubiquitin (RPS27A)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
+pr	PR:000035722	ubiquitin (UBA52)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
+pr	PR:000035720	ubiquitin (UBC)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	D044764	Ubiquitin-Activating Enzymes	skos:exactMatch	hgnc	12469	UBA1	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2223,3 +2223,4 @@ kegg.pathway	map02024	Quorum sensing	skos:exactMatch	mesh	D053038	Quorum Sensing
 kegg.pathway	map03430	Mismatch repair	skos:exactMatch	mesh	D053843	DNA Mismatch Repair	manual	orcid:0000-0003-4423-4370
 go	GO:0070266	necroptotic process	skos:exactMatch	mesh	D000079302	Necroptosis	manual	orcid:0000-0003-4423-4370
 kegg.pathway	map00970	Aminoacyl-tRNA biosynthesis	skos:exactMatch	mesh	D046249	Transfer RNA Aminoacylation	manual	orcid:0000-0003-4423-4370
+mesh	D000086382	COVID-19	skos:exactMatch	doid	DOID:0080600	COVID-19	manual	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2272,18 +2272,28 @@ mesh	C463459	GPRASP1 protein, human	skos:exactMatch	uniprot	Q5JY77	GPRASP1	manua
 mesh	C417919	GPRC5C protein, human	skos:exactMatch	uniprot	Q9NQ84	GPRC5C	manually_reviewed	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449619	Host translation inhibitor nsp1	skos:exactMatch	ncbiprotein	YP_009725297	leader protein	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449620	Non-structural protein 2	skos:exactMatch	ncbiprotein	YP_009725298	nsp2	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449621	Non-structural protein 3	skos:exactMatch	ncbiprotein	YP_009742610	nsp3	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449622	Non-structural protein 4	skos:exactMatch	ncbiprotein	YP_009742611	nsp4	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449623	3C-like proteinase	skos:exactMatch	ncbiprotein	YP_009742612	3C-like proteinase	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449624	Non-structural protein 6	skos:exactMatch	ncbiprotein	YP_009742613	nsp6	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449625	Non-structural protein 7	skos:exactMatch	ncbiprotein	YP_009742614	nsp7	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449626	Non-structural protein 8	skos:exactMatch	ncbiprotein	YP_009742615	nsp8	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449627	Non-structural protein 9	skos:exactMatch	ncbiprotein	YP_009742616	nsp9	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449628	Non-structural protein 10	skos:exactMatch	ncbiprotein	YP_009742617	nsp10	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449645	Non-structural protein 11	skos:exactMatch	ncbiprotein	YP_009725312	nsp11	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449621	Non-structural protein 3	skos:exactMatch	ncbiprotein	YP_009725299	nsp3	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449622	Non-structural protein 4	skos:exactMatch	ncbiprotein	YP_009725300	nsp4	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449623	3C-like proteinase	skos:exactMatch	ncbiprotein	YP_009725301	3C-like proteinase	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449624	Non-structural protein 6	skos:exactMatch	ncbiprotein	YP_009725302	nsp6	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449625	Non-structural protein 7	skos:exactMatch	ncbiprotein	YP_009725303	nsp7	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449626	Non-structural protein 8	skos:exactMatch	ncbiprotein	YP_009725304	nsp8	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449627	Non-structural protein 9	skos:exactMatch	ncbiprotein	YP_009725305	nsp9	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449628	Non-structural protein 10	skos:exactMatch	ncbiprotein	YP_009725306	nsp10	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449629	RNA-directed RNA polymerase	skos:exactMatch	ncbiprotein	YP_009725307	RNA-dependent RNA polymerase	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449630	Helicase	skos:exactMatch	ncbiprotein	YP_009725308	helicase	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449631	Proofreading exoribonuclease	skos:exactMatch	ncbiprotein	YP_009725309	3'-to-5' exonuclease	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449632	Uridylate-specific endoribonuclease	skos:exactMatch	ncbiprotein	YP_009725310	endoRNAse	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449633	2'-O-methyltransferase	skos:exactMatch	ncbiprotein	YP_009725311	2'-O-ribose methyltransferase	manual	orcid:0000-0001-9439-5346
 pr	PR:000035726	ubiquitin (UBB)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449635	Host translation inhibitor nsp1	skos:exactMatch	ncbiprotein	YP_009742608	leader protein	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449636	Non-structural protein 2	skos:exactMatch	ncbiprotein	YP_009742609	nsp2	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449637	Non-structural protein 3	skos:exactMatch	ncbiprotein	YP_009742610	nsp3	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449638	Non-structural protein 4	skos:exactMatch	ncbiprotein	YP_009742611	nsp4	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449639	3C-like proteinase	skos:exactMatch	ncbiprotein	YP_009742612	3C-like proteinase	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449640	Non-structural protein 6	skos:exactMatch	ncbiprotein	YP_009742613	nsp6	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449641	Non-structural protein 7	skos:exactMatch	ncbiprotein	YP_009742614	nsp7	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449642	Non-structural protein 8	skos:exactMatch	ncbiprotein	YP_009742615	nsp8	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449643	Non-structural protein 9	skos:exactMatch	ncbiprotein	YP_009742616	nsp9	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449644	Non-structural protein 10	skos:exactMatch	ncbiprotein	YP_009742617	nsp10	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449645	Non-structural protein 11	skos:exactMatch	ncbiprotein	YP_009725312	nsp11	manual	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2276,4 +2276,13 @@ uniprot.chain	PRO_0000449621	Non-structural protein 3	skos:exactMatch	ncbiprotei
 uniprot.chain	PRO_0000449622	Non-structural protein 4	skos:exactMatch	ncbiprotein	YP_009742611	nsp4	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449623	3C-like proteinase	skos:exactMatch	ncbiprotein	YP_009742612	3C-like proteinase	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449624	Non-structural protein 6	skos:exactMatch	ncbiprotein	YP_009742613	nsp6	manual	orcid:0000-0001-9439-5346
-uniprot.chain	PRO_0000449624	Non-structural protein 6	skos:exactMatch	ncbiprotein	YP_009742614	nsp7	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449625	Non-structural protein 7	skos:exactMatch	ncbiprotein	YP_009742614	nsp7	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449626	Non-structural protein 8	skos:exactMatch	ncbiprotein	YP_009742615	nsp8	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449627	Non-structural protein 9	skos:exactMatch	ncbiprotein	YP_009742616	nsp9	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449628	Non-structural protein 10	skos:exactMatch	ncbiprotein	YP_009742617	nsp10	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449645	Non-structural protein 11	skos:exactMatch	ncbiprotein	YP_009725312	nsp11	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449629	RNA-directed RNA polymerase	skos:exactMatch	ncbiprotein	YP_009725307	RNA-dependent RNA polymerase	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449630	Helicase	skos:exactMatch	ncbiprotein	YP_009725308	helicase	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449631	Proofreading exoribonuclease	skos:exactMatch	ncbiprotein	YP_009725309	3'-to-5' exonuclease	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449632	Uridylate-specific endoribonuclease	skos:exactMatch	ncbiprotein	YP_009725310	endoRNAse	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449633	2'-O-methyltransferase	skos:exactMatch	ncbiprotein	YP_009725311	2'-O-ribose methyltransferase	manual	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2286,3 +2286,4 @@ uniprot.chain	PRO_0000449630	Helicase	skos:exactMatch	ncbiprotein	YP_009725308	h
 uniprot.chain	PRO_0000449631	Proofreading exoribonuclease	skos:exactMatch	ncbiprotein	YP_009725309	3'-to-5' exonuclease	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449632	Uridylate-specific endoribonuclease	skos:exactMatch	ncbiprotein	YP_009725310	endoRNAse	manual	orcid:0000-0001-9439-5346
 uniprot.chain	PRO_0000449633	2'-O-methyltransferase	skos:exactMatch	ncbiprotein	YP_009725311	2'-O-ribose methyltransferase	manual	orcid:0000-0001-9439-5346
+pr	PR:000035726	ubiquitin (UBB)	skos:exactMatch	uniprot.chain	PRO_0000396174	Ubiquitin	manually_reviewed	orcid:0000-0001-9439-5346

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -2224,3 +2224,56 @@ kegg.pathway	map03430	Mismatch repair	skos:exactMatch	mesh	D053843	DNA Mismatch 
 go	GO:0070266	necroptotic process	skos:exactMatch	mesh	D000079302	Necroptosis	manual	orcid:0000-0003-4423-4370
 kegg.pathway	map00970	Aminoacyl-tRNA biosynthesis	skos:exactMatch	mesh	D046249	Transfer RNA Aminoacylation	manual	orcid:0000-0003-4423-4370
 mesh	D000086382	COVID-19	skos:exactMatch	doid	DOID:0080600	COVID-19	manual	orcid:0000-0001-9439-5346
+mesh	C437905	DEFB118 protein, human	skos:exactMatch	uniprot	Q96PH6	DEFB118	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C112641	DENR protein, human	skos:exactMatch	uniprot	O43583	DENR	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C494208	SNAP25 protein, human	skos:exactMatch	uniprot	P60880	SNAP25	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C494482	TRPV1 protein, human	skos:exactMatch	uniprot	Q8NER1	TRPV1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C495270	CTNNB1 protein, human	skos:exactMatch	uniprot	P35222	CTNNB1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C578038	MEF2B protein, human	skos:exactMatch	uniprot	Q02080	MEF2B	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C077171	HIVEP2 protein, human	skos:exactMatch	uniprot	P31629	HIVEP2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C414177	SLC7A2 protein, human	skos:exactMatch	uniprot	P52569	SLC7A2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C497937	STXBP1 protein, human	skos:exactMatch	uniprot	P61764	STXBP1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C494841	KCNMA1 protein, human	skos:exactMatch	uniprot	Q12791	KCNMA1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C108096	SDHC protein, human	skos:exactMatch	uniprot	Q99643	SDHC	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C511268	SDHA protein, human	skos:exactMatch	uniprot	P31040	SDHA	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C102467	SDF2 protein, human	skos:exactMatch	uniprot	Q99470	SDF2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C494881	DGAT1 protein, human	skos:exactMatch	uniprot	O75907	DGAT1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C580923	RASAL1 protein, human	skos:exactMatch	uniprot	O95294	RASAL1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C580922	SMC4 protein, human	skos:exactMatch	uniprot	Q9NTJ3	SMC4	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C500151	SYBU protein, human	skos:exactMatch	uniprot	Q9NX95	SYBU	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C456359	PSMG2 protein, human	skos:exactMatch	uniprot	Q969U7	PSMG2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C513866	CPEB3 protein, human	skos:exactMatch	uniprot	Q8NE35	CPEB3	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C489108	CRYBA1 protein, human	skos:exactMatch	uniprot	P05813	CRYBA1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C490613	ANK3 protein, human	skos:exactMatch	uniprot	Q12955	ANK3	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C491904	AP3D1 protein, human	skos:exactMatch	uniprot	O14617	AP3D1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C510070	AP3M2 protein, human	skos:exactMatch	uniprot	P53677	AP3M2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C497872	FOSL2 protein, human	skos:exactMatch	uniprot	P15408	FOSL2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C498630	PCLO protein, human	skos:exactMatch	uniprot	Q9Y6V0	PCLO	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C512817	CA11 protein, human	skos:exactMatch	uniprot	O75493	CA11	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C407644	IL1RAPL2 protein, human	skos:exactMatch	uniprot	Q9NP60	IL1RAPL2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C403492	FEM1B protein, human	skos:exactMatch	uniprot	Q9UK73	FEM1B	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C485764	OPRM1 protein, human	skos:exactMatch	uniprot	P35372	OPRM1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C109742	SLMAP protein, human	skos:exactMatch	uniprot	Q14BN4	SLMAP	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C402222	MTCH1 protein, human	skos:exactMatch	uniprot	Q9NZJ7	MTCH1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C488761	RAET1G protein, human	skos:exactMatch	uniprot	Q6H3X3	RAET1G	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C488760	RAET1E protein, human	skos:exactMatch	uniprot	Q8TD07	RAET1E	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C490522	RAE1 protein, human	skos:exactMatch	uniprot	P78406	RAE1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C419389	ASPH protein, human	skos:exactMatch	uniprot	Q12797	ASPH	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C508131	ING5 protein, human	skos:exactMatch	uniprot	Q8WYH8	ING5	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C504404	SPOCK2 protein, human	skos:exactMatch	uniprot	Q92563	SPOCK2	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C578040	MEF2C protein, human	skos:exactMatch	uniprot	Q06413	MEF2C	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C502025	MRPL37 protein, human	skos:exactMatch	uniprot	Q9BZE1	MRPL37	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C556354	AHSG protein, human	skos:exactMatch	uniprot	P02765	AHSG	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C519072	CHRNB1 protein, human	skos:exactMatch	uniprot	P11230	CHRNB1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C519156	MTIF3 protein, human	skos:exactMatch	uniprot	Q9H2K0	MTIF3	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C518505	ZBED1 protein, human	skos:exactMatch	uniprot	O96006	ZBED1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C578043	MEF2D protein, human	skos:exactMatch	uniprot	Q14814	MEF2D	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C463459	GPRASP1 protein, human	skos:exactMatch	uniprot	Q5JY77	GPRASP1	manually_reviewed	orcid:0000-0001-9439-5346
+mesh	C417919	GPRC5C protein, human	skos:exactMatch	uniprot	Q9NQ84	GPRC5C	manually_reviewed	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449619	Host translation inhibitor nsp1	skos:exactMatch	ncbiprotein	YP_009725297	leader protein	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449620	Non-structural protein 2	skos:exactMatch	ncbiprotein	YP_009725298	nsp2	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449621	Non-structural protein 3	skos:exactMatch	ncbiprotein	YP_009742610	nsp3	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449622	Non-structural protein 4	skos:exactMatch	ncbiprotein	YP_009742611	nsp4	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449623	3C-like proteinase	skos:exactMatch	ncbiprotein	YP_009742612	3C-like proteinase	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449624	Non-structural protein 6	skos:exactMatch	ncbiprotein	YP_009742613	nsp6	manual	orcid:0000-0001-9439-5346
+uniprot.chain	PRO_0000449624	Non-structural protein 6	skos:exactMatch	ncbiprotein	YP_009742614	nsp7	manual	orcid:0000-0001-9439-5346


### PR DESCRIPTION
This PR adds manually curated mappings for protein fragments derived from SARS-CoV-2 Replicase polyprotein 1a and Replicase polyprotein 1ab between `ncbiprotein` and `uniprot.chain`. It also adds some random other reviewed curations from automated mappings.