### PR TITLE
Add SSSOM Export

### DIFF
--- a/docs/_data/biomappings.sssom.tsv
+++ b/docs/_data/biomappings.sssom.tsv
@@ -1,2299 +1,2299 @@
-subject_id	predicate_id	object_id	subject_label	object_label	creator_id	license
-umls:C0001973	skos:narrower	mesh:D000435	Alcoholic Intoxication, Chronic	Alcoholic Intoxication	orcid:0000-0003-4423-4370	CC0
-umls:C0004352	skos:exactMatch	mesh:D001321	Autistic Disorder	Autistic Disorder	orcid:0000-0003-4423-4370	CC0
-umls:C0006118	skos:exactMatch	mesh:D001932	Brain Neoplasms	Brain Neoplasms	orcid:0000-0003-4423-4370	CC0
-umls:C0006142	skos:exactMatch	mesh:D001943	Malignant neoplasm of breast	Breast Neoplasms	orcid:0000-0003-4423-4370	CC0
-mesh:C108192	skos:exactMatch	chebi:CHEBI:101381	aloxistatin	aloxistatin	orcid:0000-0001-9439-5346	CC0
-pfam:PF01391	skos:exactMatch	mesh:D003094	Collagen	Collagen	orcid:0000-0001-9439-5346	CC0
-mesh:D002465	skos:exactMatch	go:GO:0048870	Cell Movement	cell motility	orcid:0000-0001-9439-5346	CC0
-mesh:D002914	skos:exactMatch	go:GO:0042627	Chylomicrons	chylomicron	orcid:0000-0001-9439-5346	CC0
-mesh:D012374	skos:exactMatch	go:GO:0120200	Rod Cell Outer Segment	rod photoreceptor outer segment	orcid:0000-0001-9439-5346	CC0
-mesh:D014158	skos:exactMatch	go:GO:0006351	Transcription, Genetic	transcription, DNA-templated	orcid:0000-0001-9439-5346	CC0
-mesh:D014176	skos:exactMatch	go:GO:0006412	Protein Biosynthesis	translation	orcid:0000-0001-9439-5346	CC0
-mesh:D018919	skos:exactMatch	go:GO:0001525	Neovascularization, Physiologic	angiogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D048708	skos:exactMatch	go:GO:0016049	Cell Growth Processes	cell growth	orcid:0000-0001-9439-5346	CC0
-mesh:D058750	skos:exactMatch	go:GO:0001837	Epithelial-Mesenchymal Transition	epithelial to mesenchymal transition	orcid:0000-0001-9439-5346	CC0
-mesh:D059767	skos:exactMatch	go:GO:0000725	Recombinational DNA Repair	recombinational repair	orcid:0000-0001-9439-5346	CC0
-mesh:D016195	skos:exactMatch	go:GO:0051319	G2 Phase	G2 phase	orcid:0000-0001-9439-5346	CC0
-mesh:C497399	skos:exactMatch	uniprot:Q15797	SMAD1 protein, human	SMAD1	orcid:0000-0001-9439-5346	CC0
-mesh:C497782	skos:exactMatch	uniprot:Q15796	SMAD2 protein, human	SMAD2	orcid:0000-0001-9439-5346	CC0
-mesh:C497790	skos:exactMatch	uniprot:P84022	SMAD3 protein, human	SMAD3	orcid:0000-0001-9439-5346	CC0
-mesh:C497796	skos:exactMatch	uniprot:Q13485	SMAD4 protein, human	SMAD4	orcid:0000-0001-9439-5346	CC0
-mesh:C497797	skos:exactMatch	uniprot:Q99717	SMAD5 protein, human	SMAD5	orcid:0000-0001-9439-5346	CC0
-mesh:C497802	skos:exactMatch	uniprot:O43541	SMAD6 protein, human	SMAD6	orcid:0000-0001-9439-5346	CC0
-mesh:C497806	skos:exactMatch	uniprot:O15105	SMAD7 protein, human	SMAD7	orcid:0000-0001-9439-5346	CC0
-mesh:D005759	skos:exactMatch	ncit:C34632	Gastroenteritis	Gastroenteritis	orcid:0000-0001-9439-5346	CC0
-mesh:D005762	skos:exactMatch	ncit:C16603	Gastroenterology	Gastroenterology	orcid:0000-0001-9439-5346	CC0
-mesh:D005756	skos:exactMatch	ncit:C26780	Gastritis	Gastritis	orcid:0000-0001-9439-5346	CC0
-mesh:D005755	skos:exactMatch	chebi:CHEBI:75436	Gastrins	gastrin	orcid:0000-0001-9439-5346	CC0
-mesh:D005753	skos:exactMatch	ncit:C32656	Gastric Mucosa	Gastric Mucosa	orcid:0000-0001-9439-5346	CC0
-mesh:D005746	skos:exactMatch	go:GO:0035483	Gastric Emptying	gastric emptying	orcid:0000-0001-9439-5346	CC0
-mesh:D005744	skos:exactMatch	ncit:C94192	Gastric Acid	Gastric Acid	orcid:0000-0001-9439-5346	CC0
-mesh:D005743	skos:exactMatch	ncit:C15236	Gastrectomy	Gastrectomy	orcid:0000-0001-9439-5346	CC0
-mesh:D005735	skos:exactMatch	ncit:C122627	Garbage	Trash	orcid:0000-0001-9439-5346	CC0
-mesh:D005729	skos:exactMatch	ncit:C3049	Ganglioneuroma	Ganglioneuroma	orcid:0000-0001-9439-5346	CC0
-mesh:D005728	skos:exactMatch	ncit:C12467	Ganglia, Sympathetic	Sympathetic Ganglion	orcid:0000-0001-9439-5346	CC0
-mesh:D005708	skos:exactMatch	ncit:C66798	Gallium	Gallium	orcid:0000-0001-9439-5346	CC0
-mesh:D005707	skos:exactMatch	ncit:C63648	Gallic Acid	Gallic Acid	orcid:0000-0001-9439-5346	CC0
-mesh:D005693	skos:exactMatch	ncit:C84723	Galactosemias	Galactosemia	orcid:0000-0001-9439-5346	CC0
-mesh:D005690	skos:exactMatch	chebi:CHEBI:28260	Galactose	galactose	orcid:0000-0001-9439-5346	CC0
-mesh:D005697	skos:exactMatch	chebi:CHEBI:24163	Galactosides	galactoside	orcid:0000-0001-9439-5346	CC0
-mesh:D005687	skos:exactMatch	ncit:C113343	Galactorrhea	Galactorrhea	orcid:0000-0001-9439-5346	CC0
-mesh:D005685	skos:exactMatch	chebi:CHEBI:37165	Galactans	galactan	orcid:0000-0001-9439-5346	CC0
-mesh:D005684	skos:exactMatch	ncit:C75445	Gait	Gait	orcid:0000-0001-9439-5346	CC0
-mesh:D005661	skos:exactMatch	chebi:CHEBI:131714	Furagin	furagin	orcid:0000-0001-9439-5346	CC0
-mesh:D005664	skos:exactMatch	chebi:CHEBI:5195	Furazolidone	furazolidone	orcid:0000-0001-9439-5346	CC0
-mesh:D005665	skos:exactMatch	chebi:CHEBI:47426	Furosemide	furosemide	orcid:0000-0001-9439-5346	CC0
-mesh:D005667	skos:exactMatch	ncit:C34629	Furunculosis	Furunculosis	orcid:0000-0001-9439-5346	CC0
-mesh:D005669	skos:exactMatch	chebi:CHEBI:5199	Fusaric Acid	Fusaric acid	orcid:0000-0001-9439-5346	CC0
-mesh:D005670	skos:exactMatch	ncit:C77185	Fusarium	Fusarium	orcid:0000-0001-9439-5346	CC0
-mesh:D005672	skos:exactMatch	ncit:C65793	Fusidic Acid	Fusidic Acid	orcid:0000-0001-9439-5346	CC0
-mesh:D005673	skos:exactMatch	ncit:C76323	Fusobacterium	Fusobacterium	orcid:0000-0001-9439-5346	CC0
-mesh:D005674	skos:exactMatch	ncit:C84722	Fusobacterium Infections	Fusobacterium Infection	orcid:0000-0001-9439-5346	CC0
-mesh:D005675	skos:exactMatch	ncit:C86401	Fusobacterium necrophorum	Fusobacterium necrophorum	orcid:0000-0001-9439-5346	CC0
-mesh:D005677	skos:exactMatch	chebi:CHEBI:61048	G(M1) Ganglioside	ganglioside GM1	orcid:0000-0001-9439-5346	CC0
-mesh:D005678	skos:exactMatch	ncit:C516	G(M2) Ganglioside	Ganglioside GM2	orcid:0000-0001-9439-5346	CC0
-mesh:D005681	skos:exactMatch	ncit:C16596	Gabon	Gabon	orcid:0000-0001-9439-5346	CC0
-mesh:D005683	skos:exactMatch	ncit:C34630	Gagging	Gagging	orcid:0000-0001-9439-5346	CC0
-mesh:D005639	skos:exactMatch	ncit:C61483	Frustration	Frustration	orcid:0000-0001-9439-5346	CC0
-mesh:D005638	skos:exactMatch	ncit:C71972	Fruit	Fruit	orcid:0000-0001-9439-5346	CC0
-mesh:D005640	skos:exactMatch	chebi:CHEBI:81569	Follicle Stimulating Hormone	Follicle stimulating hormone	orcid:0000-0001-9439-5346	CC0
-mesh:D005641	skos:exactMatch	chebi:CHEBI:32188	Tegafur	Tegafur	orcid:0000-0001-9439-5346	CC0
-mesh:D005627	skos:exactMatch	ncit:C34627	Frostbite	Frostbite	orcid:0000-0001-9439-5346	CC0
-mesh:D005630	skos:exactMatch	chebi:CHEBI:28796	Fructans	fructan	orcid:0000-0001-9439-5346	CC0
-mesh:D005625	skos:exactMatch	ncit:C23287	Frontal Lobe	Frontal Lobe	orcid:0000-0001-9439-5346	CC0
-mesh:D005624	skos:exactMatch	ncit:C32635	Frontal Bone	Frontal Bone	orcid:0000-0001-9439-5346	CC0
-mesh:D005622	skos:exactMatch	ncit:C14362	Friend murine leukemia virus	Friend Murine Leukemia Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D005621	skos:exactMatch	ncit:C84718	Friedreich Ataxia	Friedreich Ataxia	orcid:0000-0001-9439-5346	CC0
-mesh:D005620	skos:exactMatch	ncit:C2347	Freund's Adjuvant	Freund's Adjuvant	orcid:0000-0001-9439-5346	CC0
-mesh:D005616	skos:exactMatch	ncit:C16593	French Guiana	French Guiana	orcid:0000-0001-9439-5346	CC0
-mesh:D005609	skos:exactMatch	ncit:C512	Free Radicals	Free Radical	orcid:0000-0001-9439-5346	CC0
-mesh:D005602	skos:exactMatch	ncit:C16592	France	France	orcid:0000-0001-9439-5346	CC0
-mesh:D005615	skos:exactMatch	ncit:C48160	Freezing	Freezing	orcid:0000-0001-9439-5346	CC0
-mesh:D005634	skos:exactMatch	ncit:C129394	Fructose-Bisphosphate Aldolase	Fructose-Bisphosphate Aldolase	orcid:0000-0001-9439-5346	CC0
-mesh:D005642	skos:exactMatch	ncit:C84721	Fuchs' Endothelial Dystrophy	Fuchs Endothelial Dystrophy	orcid:0000-0001-9439-5346	CC0
-mesh:C095085	skos:exactMatch	uniprot:P32302	CXCR5 protein, human	CXCR5	orcid:0000-0001-9439-5346	CC0
-mesh:C497894	skos:exactMatch	uniprot:Q08722	CD47 protein, human	CD47	orcid:0000-0001-9439-5346	CC0
-mesh:C497139	skos:exactMatch	uniprot:Q16760	DGKD protein, human	DGKD	orcid:0000-0001-9439-5346	CC0
-mesh:C537126	skos:exactMatch	doid:DOID:0111438	Optic atrophy 5	optic atrophy 5	orcid:0000-0001-9439-5346	CC0
-mesh:C537127	skos:exactMatch	doid:DOID:0111435	Optic atrophy 6	optic atrophy 6	orcid:0000-0001-9439-5346	CC0
-mesh:C537117	skos:exactMatch	doid:DOID:0080549	LEOPARD syndrome, 2	LEOPARD syndrome 2	orcid:0000-0001-9439-5346	CC0
-mesh:C537115	skos:exactMatch	doid:DOID:0111507	Lenz Majewski hyperostotic dwarfism	Lenz-Majewski hyperostotic dwarfism	orcid:0000-0001-9439-5346	CC0
-mesh:C537098	skos:exactMatch	doid:DOID:0050690	Brachyolmia	brachyolmia	orcid:0000-0001-9439-5346	CC0
-mesh:C537162	skos:exactMatch	doid:DOID:6823	Pancreatoblastoma	pancreatoblastoma	orcid:0000-0001-9439-5346	CC0
-mesh:C537202	skos:exactMatch	doid:DOID:0050974	Spinocerebellar ataxia 25	spinocerebellar ataxia type 25	orcid:0000-0001-9439-5346	CC0
-mesh:C537203	skos:exactMatch	doid:DOID:0050975	Spinocerebellar ataxia 26	spinocerebellar ataxia type 26	orcid:0000-0001-9439-5346	CC0
-mesh:C537199	skos:exactMatch	doid:DOID:0050971	Spinocerebellar ataxia 20	spinocerebellar ataxia type 20	orcid:0000-0001-9439-5346	CC0
-mesh:C537262	skos:exactMatch	ncit:C95436	Hereditary pancreatitis	Hereditary Pancreatitis	orcid:0000-0001-9439-5346	CC0
-mesh:C000622468	skos:exactMatch	uniprot:Q6PI78	TMEM65 protein, human	TMEM65	orcid:0000-0001-9439-5346	CC0
-mesh:C000626007	skos:exactMatch	uniprot:O15481	MAGEB4 protein, human	MAGEB4	orcid:0000-0001-9439-5346	CC0
-mesh:C493803	skos:exactMatch	uniprot:Q8WVX9	FAR1 protein, human	FAR1	orcid:0000-0001-9439-5346	CC0
-mesh:C000626466	skos:exactMatch	uniprot:O94919	ENDOD1 protein, human	ENDOD1	orcid:0000-0001-9439-5346	CC0
-mesh:D016985	skos:exactMatch	ncit:C86784	Streptococcus bovis	Streptococcus bovis	orcid:0000-0001-9439-5346	CC0
-mesh:D016990	skos:exactMatch	ncit:C86833	Ureaplasma urealyticum	Ureaplasma urealyticum	orcid:0000-0001-9439-5346	CC0
-mesh:D016993	skos:exactMatch	ncit:C76272	Chlamydophila pneumoniae	Chlamydophila pneumoniae	orcid:0000-0001-9439-5346	CC0
-mesh:D016997	skos:exactMatch	ncit:C86328	Coxiella burnetii	Coxiella burnetii	orcid:0000-0001-9439-5346	CC0
-mesh:D016998	skos:exactMatch	ncit:C14296	Helicobacter	Helicobacter	orcid:0000-0001-9439-5346	CC0
-mesh:D017000	skos:exactMatch	ncit:C86230	Campylobacter coli	Campylobacter coli	orcid:0000-0001-9439-5346	CC0
-mesh:D017006	skos:exactMatch	ncit:C33497	Rotator Cuff	Rotator Cuff	orcid:0000-0001-9439-5346	CC0
-mesh:D017011	skos:exactMatch	ncit:C86807	Streptococcus suis	Streptococcus suis	orcid:0000-0001-9439-5346	CC0
-mesh:D017023	skos:exactMatch	ncit:C100085	Coronary Angiography	Coronary Angiography	orcid:0000-0001-9439-5346	CC0
-mesh:D017024	skos:exactMatch	ncit:C15360	Chemotherapy, Adjuvant	Adjuvant Chemotherapy	orcid:0000-0001-9439-5346	CC0
-mesh:D017041	skos:exactMatch	ncit:C142541	Ethics Committees	Ethics Committee	orcid:0000-0001-9439-5346	CC0
-mesh:D017043	skos:exactMatch	ncit:C26717	Chalazion	Chalazion	orcid:0000-0001-9439-5346	CC0
-mesh:D017045	skos:exactMatch	ncit:C86483	Lactococcus	Lactococcus	orcid:0000-0001-9439-5346	CC0
-mesh:D017051	skos:exactMatch	ncit:C15252	Hospice Care	Hospice Care	orcid:0000-0001-9439-5346	CC0
-mesh:D017058	skos:exactMatch	ncit:C67114	Mexican Americans	Mexican American	orcid:0000-0001-9439-5346	CC0
-mesh:D017072	skos:exactMatch	ncit:C111122	Neostriatum	Neostriatum	orcid:0000-0001-9439-5346	CC0
-mesh:D017073	skos:exactMatch	ncit:C157793	Atherectomy	Atherectomy	orcid:0000-0001-9439-5346	CC0
-mesh:D017074	skos:exactMatch	ncit:C26725	Common Variable Immunodeficiency	Common Variable Immunodeficiency	orcid:0000-0001-9439-5346	CC0
-mesh:D017081	skos:exactMatch	ncit:C51681	Cholecystectomy, Laparoscopic	Laparoscopic Cholecystectomy	orcid:0000-0001-9439-5346	CC0
-mesh:D017089	skos:exactMatch	ncit:C14100	Ankyrin Repeat	Ankyrin Repeat	orcid:0000-0001-9439-5346	CC0
-mesh:D017092	skos:exactMatch	ncit:C84697	Porphyria, Erythropoietic	Erythropoietic Porphyria	orcid:0000-0001-9439-5346	CC0
-mesh:D017101	skos:exactMatch	ncit:C14301	Bacteriophage P1	Bacteriophage P1	orcid:0000-0001-9439-5346	CC0
-mesh:D017114	skos:exactMatch	ncit:C84396	Liver Failure, Acute	Acute Liver Failure	orcid:0000-0001-9439-5346	CC0
-mesh:D017026	skos:exactMatch	chebi:CHEBI:9367	Swainsonine	swainsonine	orcid:0000-0001-9439-5346	CC0
-mesh:D016966	skos:exactMatch	ncit:C86657	Porphyromonas gingivalis	Porphyromonas gingivalis	orcid:0000-0001-9439-5346	CC0
-mesh:D016967	skos:exactMatch	ncit:C86404	Fusobacterium nucleatum	Fusobacterium nucleatum	orcid:0000-0001-9439-5346	CC0
-mesh:D016960	skos:exactMatch	ncit:C86138	Agrobacterium tumefaciens	Agrobacterium tumefaciens	orcid:0000-0001-9439-5346	CC0
-mesh:D016958	skos:exactMatch	ncit:C86705	Pseudomonas putida	Pseudomonas putida	orcid:0000-0001-9439-5346	CC0
-mesh:D016957	skos:exactMatch	ncit:C86227	Burkholderia pseudomallei	Burkholderia pseudomallei	orcid:0000-0001-9439-5346	CC0
-mesh:D016955	skos:exactMatch	ncit:C86524	Moraxella bovis	Moraxella bovis	orcid:0000-0001-9439-5346	CC0
-mesh:D016979	skos:exactMatch	ncit:C76373	Pasteurella multocida	Pasteurella multocida	orcid:0000-0001-9439-5346	CC0
-mesh:D016980	skos:exactMatch	ncit:C86125	Aeromonas hydrophila	Aeromonas hydrophila	orcid:0000-0001-9439-5346	CC0
-mesh:D016978	skos:exactMatch	ncit:C86508	Mannheimia haemolytica	Mannheimia haemolytica	orcid:0000-0001-9439-5346	CC0
-mesh:D016981	skos:exactMatch	ncit:C86651	Plesiomonas	Plesiomonas	orcid:0000-0001-9439-5346	CC0
-mesh:D016982	skos:exactMatch	ncit:C86513	Micrococcus luteus	Micrococcus luteus	orcid:0000-0001-9439-5346	CC0
-mesh:D016983	skos:exactMatch	ncit:C76311	Enterococcus	Enterococcus	orcid:0000-0001-9439-5346	CC0
-mesh:D016984	skos:exactMatch	ncit:C86369	Enterococcus faecium	Enterococcus faecium	orcid:0000-0001-9439-5346	CC0
-mesh:D017027	skos:exactMatch	ncit:C17444	Protein Tyrosine Phosphatases	Protein Tyrosine Phosphatase	orcid:0000-0001-9439-5346	CC0
-mesh:D017028	skos:exactMatch	ncit:C17445	Caregivers	Caregiver	orcid:0000-0001-9439-5346	CC0
-mesh:D017035	skos:exactMatch	ncit:C62070	Pravastatin	Pravastatin	orcid:0000-0001-9439-5346	CC0
-mesh:D016975	skos:exactMatch	ncit:C86409	Gardnerella	Gardnerella	orcid:0000-0001-9439-5346	CC0
-mesh:D016970	skos:exactMatch	ncit:C86350	Eikenella	Eikenella	orcid:0000-0001-9439-5346	CC0
-mesh:D016968	skos:exactMatch	ncit:C86850	Wolinella	Wolinella	orcid:0000-0001-9439-5346	CC0
-mesh:D016919	skos:exactMatch	hp:HP:0032160	Meningitis, Cryptococcal	Cryptococcal meningitis	orcid:0000-0001-9439-5346	CC0
-mesh:D016918	skos:exactMatch	ncit:C128332	Arthritis, Reactive	Reactive Arthritis	orcid:0000-0001-9439-5346	CC0
-mesh:D016920	skos:exactMatch	ncit:C118297	Meningitis, Bacterial	Bacterial Meningitis	orcid:0000-0001-9439-5346	CC0
-mesh:D016923	skos:exactMatch	go:GO:0008219	Cell Death	cell death	orcid:0000-0001-9439-5346	CC0
-mesh:D016924	skos:exactMatch	ncit:C86115	Actinomyces viscosus	Actinomyces viscosus	orcid:0000-0001-9439-5346	CC0
-mesh:D016912	skos:exactMatch	chebi:CHEBI:6443	Levonorgestrel	levonorgestrel	orcid:0000-0001-9439-5346	CC0
-mesh:D016909	skos:exactMatch	ncit:C12824	Tibial Arteries	Tibial Artery	orcid:0000-0001-9439-5346	CC0
-mesh:D016906	skos:exactMatch	hgnc:6029	Interleukin-9	IL9	orcid:0000-0001-9439-5346	CC0
-mesh:D016856	skos:exactMatch	ncit:C112397	Phlebovirus	Phlebovirus	orcid:0000-0001-9439-5346	CC0
-mesh:D016859	skos:exactMatch	chebi:CHEBI:35856	Lipoxygenase Inhibitors	lipoxygenase inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D016878	skos:exactMatch	ncit:C80303	POEMS Syndrome	POEMS Syndrome	orcid:0000-0001-9439-5346	CC0
-mesh:D016879	skos:exactMatch	ncit:C15359	Salvage Therapy	Salvage Therapy	orcid:0000-0001-9439-5346	CC0
-mesh:D016880	skos:exactMatch	ncit:C17442	Anisotropy	Anisotropy	orcid:0000-0001-9439-5346	CC0
-mesh:D016881	skos:exactMatch	ncit:C84891	Microsporidiosis	Microsporidiosis	orcid:0000-0001-9439-5346	CC0
-mesh:D016883	skos:exactMatch	ncit:C50530	Diabetic Ketoacidosis	Diabetic Ketoacidosis	orcid:0000-0001-9439-5346	CC0
-mesh:D016885	skos:exactMatch	ncit:C68708	United States Department of Agriculture	United States Department of Agriculture	orcid:0000-0001-9439-5346	CC0
-mesh:D017122	skos:exactMatch	ncit:C14302	Bacteriophage T4	Bacteriophage T4	orcid:0000-0001-9439-5346	CC0
-mesh:D017127	skos:exactMatch	ncit:C106312	Glycation End Products, Advanced	Advanced Glycation End Product	orcid:0000-0001-9439-5346	CC0
-mesh:D017128	skos:exactMatch	ncit:C52001	Embolectomy	Embolectomy	orcid:0000-0001-9439-5346	CC0
-mesh:D017129	skos:exactMatch	ncit:C128393	Anisakiasis	Anisakiasis	orcid:0000-0001-9439-5346	CC0
-mesh:D017131	skos:exactMatch	ncit:C52003	Thrombectomy	Thrombectomy	orcid:0000-0001-9439-5346	CC0
-mesh:D017130	skos:exactMatch	ncit:C51999	Angioplasty	Angioplasty	orcid:0000-0001-9439-5346	CC0
-mesh:D017135	skos:exactMatch	ncit:C47476	Desogestrel	Desogestrel	orcid:0000-0001-9439-5346	CC0
-mesh:D017136	skos:exactMatch	go:GO:0006811	Ion Transport	ion transport	orcid:0000-0001-9439-5346	CC0
-mesh:D017144	skos:exactMatch	ncit:C154589	Focus Groups	Focus Group	orcid:0000-0001-9439-5346	CC0
-mesh:D017245	skos:exactMatch	ncit:C71630	Foscarnet	Foscarnet	orcid:0000-0001-9439-5346	CC0
-mesh:D017242	skos:exactMatch	ncit:C97211	Complement Factor H	Complement Factor H	orcid:0000-0001-9439-5346	CC0
-mesh:D017252	skos:exactMatch	ncit:C38897	CD3 Complex	CD3 Complex	orcid:0000-0001-9439-5346	CC0
-mesh:D017255	skos:exactMatch	ncit:C985	Acitretin	Acitretin	orcid:0000-0001-9439-5346	CC0
-mesh:D017257	skos:exactMatch	chebi:CHEBI:8774	Ramipril	ramipril	orcid:0000-0001-9439-5346	CC0
-mesh:D017259	skos:exactMatch	chebi:CHEBI:81389	Dimaprit	Dimaprit	orcid:0000-0001-9439-5346	CC0
-mesh:D017241	skos:exactMatch	ncit:C84885	MELAS Syndrome	MELAS Syndrome	orcid:0000-0001-9439-5346	CC0
-mesh:D017239	skos:exactMatch	chebi:CHEBI:45863	Paclitaxel	paclitaxel	orcid:0000-0001-9439-5346	CC0
-mesh:D017229	skos:exactMatch	ncit:C128396	Enterobiasis	Enterobiasis	orcid:0000-0001-9439-5346	CC0
-mesh:D017228	skos:exactMatch	ncit:C20428	Hepatocyte Growth Factor	Hepatocyte Growth Factor	orcid:0000-0001-9439-5346	CC0
-mesh:D017240	skos:exactMatch	ncit:C101328	Mitochondrial Myopathies	Mitochondrial Myopathy	orcid:0000-0001-9439-5346	CC0
-mesh:D017270	skos:exactMatch	hgnc:6667	Lipoprotein(a)	LPA	orcid:0000-0001-9439-5346	CC0
-mesh:D017271	skos:exactMatch	ncit:C84654	Craniomandibular Disorders	Craniomandibular Disorder	orcid:0000-0001-9439-5346	CC0
-mesh:D017273	skos:exactMatch	chebi:CHEBI:5523	Goserelin	Goserelin	orcid:0000-0001-9439-5346	CC0
-mesh:D017274	skos:exactMatch	chebi:CHEBI:7445	Nafarelin	Nafarelin	orcid:0000-0001-9439-5346	CC0
-mesh:D017275	skos:exactMatch	chebi:CHEBI:6073	Isradipine	Isradipine	orcid:0000-0001-9439-5346	CC0
-mesh:D017279	skos:exactMatch	ncit:C1223	Selenocysteine	Selenocysteine	orcid:0000-0001-9439-5346	CC0
-mesh:D017280	skos:exactMatch	ncit:C28258	Condoms	Condom	orcid:0000-0001-9439-5346	CC0
-pr:PR:000037273	skos:exactMatch	uniprot.chain:PRO_0000013209	sonic hedgehog protein N-product	Sonic hedgehog protein N-product	orcid:0000-0001-9439-5346	CC0
-pr:PR:000025578	skos:exactMatch	uniprot.chain:PRO_0000000090	soluble APP-beta	Soluble APP-beta	orcid:0000-0001-9439-5346	CC0
-pr:PR:000025577	skos:exactMatch	uniprot.chain:PRO_0000000089	soluble APP-alpha	Soluble APP-alpha	orcid:0000-0001-9439-5346	CC0
-pr:PR:000035908	skos:exactMatch	uniprot.chain:PRO_0000413735	serine/threonine-protein kinase 4 37kDa subunit	Serine/threonine-protein kinase 4 37kDa subunit	orcid:0000-0001-9439-5346	CC0
-pr:PR:000035906	skos:exactMatch	uniprot.chain:PRO_0000413713	serine/threonine-protein kinase 3 36kDa subunit	Serine/threonine-protein kinase 3 36kDa subunit	orcid:0000-0001-9439-5346	CC0
-pr:PR:000025588	skos:exactMatch	uniprot.chain:PRO_0000000096	P3(40)	P3(40)	orcid:0000-0001-9439-5346	CC0
-pr:PR:000025587	skos:exactMatch	uniprot.chain:PRO_0000000095	P3(42)	P3(42)	orcid:0000-0001-9439-5346	CC0
-pr:PR:000001757	skos:exactMatch	uniprot.chain:PRO_0000030311	nuclear factor NF-kappa-B p50 subunit	Nuclear factor NF-kappa-B p50 subunit	orcid:0000-0001-9439-5346	CC0
-pr:PR:000025586	skos:exactMatch	uniprot.chain:PRO_0000000097	gamma-secretase C-terminal fragment 59	Gamma-secretase C-terminal fragment 59	orcid:0000-0003-4423-4370	CC0
-pr:PR:000025589	skos:exactMatch	uniprot.chain:PRO_0000000099	gamma-secretase C-terminal fragment 50	Gamma-secretase C-terminal fragment 50	orcid:0000-0003-4423-4370	CC0
-pr:PR:000025585	skos:exactMatch	uniprot.chain:PRO_0000000098	gamma-secretase C-terminal fragment 57	Gamma-secretase C-terminal fragment 57	orcid:0000-0003-4423-4370	CC0
-pr:PR:000050115	skos:exactMatch	uniprot.chain:PRO_0000042262	heparanase 50 kDa subunit	Heparanase 50 kDa subunit	orcid:0000-0003-4423-4370	CC0
-pr:PR:000025582	skos:exactMatch	uniprot.chain:PRO_0000384574	C80	C80	orcid:0000-0003-4423-4370	CC0
-pr:PR:000025581	skos:exactMatch	uniprot.chain:PRO_0000000094	C83	C83	orcid:0000-0003-4423-4370	CC0
-pr:PR:000025580	skos:exactMatch	uniprot.chain:PRO_0000000091	C99	C99	orcid:0000-0003-4423-4370	CC0
-mesh:C514899	skos:exactMatch	uniprot:P48147	PREP protein, human	PREP	orcid:0000-0003-4423-4370	CC0
-mesh:C077914	skos:exactMatch	uniprot:Q01954	BNC1 protein, human	BNC1	orcid:0000-0003-4423-4370	CC0
-mesh:C497562	skos:exactMatch	uniprot:P40938	RFC3 protein, human	RFC3	orcid:0000-0003-4423-4370	CC0
-mesh:C456923	skos:exactMatch	uniprot:Q8N0V4	LGI2 protein, human	LGI2	orcid:0000-0003-4423-4370	CC0
-mesh:C480021	skos:exactMatch	uniprot:P30838	ALDH3A1 protein, human	ALDH3A1	orcid:0000-0003-4423-4370	CC0
-mesh:C581575	skos:exactMatch	uniprot:Q9BT17	MTG1 protein, human	MTG1	orcid:0000-0003-4423-4370	CC0
-mesh:C079091	skos:exactMatch	uniprot:Q02410	APBA1 protein, human	APBA1	orcid:0000-0003-4423-4370	CC0
-mesh:C493728	skos:exactMatch	uniprot:Q01196	RUNX1 protein, human	RUNX1	orcid:0000-0003-4423-4370	CC0
-mesh:C488098	skos:exactMatch	uniprot:Q96CM4	NXNL1 protein, human	NXNL1	orcid:0000-0003-4423-4370	CC0
-mesh:C492913	skos:exactMatch	uniprot:P38398	BRCA1 protein, human	BRCA1	orcid:0000-0003-4423-4370	CC0
-mesh:C000621508	skos:exactMatch	uniprot:P55085	F2RL1 protein, human	F2RL1	orcid:0000-0003-4423-4370	CC0
-mesh:C490780	skos:exactMatch	uniprot:Q9UNN5	FAF1 protein, human	FAF1	orcid:0000-0003-4423-4370	CC0
-mesh:C497563	skos:exactMatch	uniprot:P35249	RFC4 protein, human	RFC4	orcid:0000-0003-4423-4370	CC0
-mesh:C496061	skos:exactMatch	uniprot:P49023	PXN protein, human	PXN	orcid:0000-0003-4423-4370	CC0
-mesh:C497651	skos:exactMatch	uniprot:Q00597	FANCC protein, human	FANCC	orcid:0000-0003-4423-4370	CC0
-mesh:C489785	skos:exactMatch	uniprot:Q9NR77	PXMP2 protein, human	PXMP2	orcid:0000-0003-4423-4370	CC0
-mesh:C489803	skos:exactMatch	uniprot:Q9NP90	RAB9B protein, human	RAB9B	orcid:0000-0003-4423-4370	CC0
-mesh:C497564	skos:exactMatch	uniprot:P40937	RFC5 protein, human	RFC5	orcid:0000-0003-4423-4370	CC0
-mesh:C512648	skos:exactMatch	uniprot:Q9Y266	NUDC protein, human	NUDC	orcid:0000-0003-4423-4370	CC0
-mesh:C431383	skos:exactMatch	uniprot:Q96JC9	EAF1 protein, human	EAF1	orcid:0000-0003-4423-4370	CC0
-mesh:C070699	skos:exactMatch	uniprot:Q14512	FGFBP1 protein, human	FGFBP1	orcid:0000-0003-4423-4370	CC0
-mesh:C000592900	skos:exactMatch	uniprot:Q86VR8	FJX1 protein, human	FJX1	orcid:0000-0003-4423-4370	CC0
-mesh:C098179	skos:exactMatch	uniprot:Q13045	FLII protein, human	FLII	orcid:0000-0003-4423-4370	CC0
-mesh:C530652	skos:exactMatch	uniprot:Q9UIV8	SERPINB13 protein, human	SERPINB13	orcid:0000-0003-4423-4370	CC0
-mesh:C492570	skos:exactMatch	uniprot:P22674	CCNO protein, human	CCNO	orcid:0000-0003-4423-4370	CC0
-mesh:C094154	skos:exactMatch	uniprot:P55082	MFAP3 protein, human	MFAP3	orcid:0000-0003-4423-4370	CC0
-mesh:C578035	skos:exactMatch	uniprot:Q02078	MEF2A protein, human	MEF2A	orcid:0000-0003-4423-4370	CC0
-mesh:C496469	skos:exactMatch	uniprot:Q5TCQ9	MAGI3 protein, human	MAGI3	orcid:0000-0003-4423-4370	CC0
-pr:PR:000035910	skos:exactMatch	uniprot.chain:PRO_0000002981	coagulation factor V light chain	Coagulation factor V light chain	orcid:0000-0003-4423-4370	CC0
-uniprot.chain:PRO_0000005909	speciesSpecific	pr:PR:000050120	Complement C3 alpha chain	complement C3 alpha chain	orcid:0000-0003-4423-4370	CC0
-pr:PR:000050114	skos:exactMatch	uniprot.chain:PRO_0000042260	heparanase 8 kDa subunit	Heparanase 8 kDa subunit	orcid:0000-0003-4423-4370	CC0
-pr:PR:000050188	skos:exactMatch	uniprot.chain:PRO_0000014901	polymeric immunoglobulin receptor secretory component	Secretory component	orcid:0000-0003-4423-4370	CC0
-mesh:C495815	skos:exactMatch	uniprot:Q9Y281	CFL2 protein, human	CFL2	orcid:0000-0003-4423-4370	CC0
-mesh:C497121	skos:exactMatch	uniprot:Q02447	SP3 protein, human	SP3	orcid:0000-0003-4423-4370	CC0
-mesh:C091671	skos:exactMatch	uniprot:P46094	XCR1 protein, human	XCR1	orcid:0000-0003-4423-4370	CC0
-mesh:C099100	skos:exactMatch	uniprot:Q9BRK5	SDF4 protein, human	SDF4	orcid:0000-0003-4423-4370	CC0
-mesh:C000631507	skos:exactMatch	uniprot:Q9H8S5	CNTD2 protein, human	CNTD2	orcid:0000-0003-4423-4370	CC0
-mesh:C497453	skos:exactMatch	uniprot:P41134	ID1 protein, human	ID1	orcid:0000-0003-4423-4370	CC0
-mesh:C497442	skos:exactMatch	uniprot:Q16665	HIF1A protein, human	HIF1A	orcid:0000-0003-4423-4370	CC0
-mesh:C115114	skos:exactMatch	uniprot:Q9H2X6	HIPK2 protein, human	HIPK2	orcid:0000-0003-4423-4370	CC0
-mesh:C109102	skos:exactMatch	uniprot:Q9H422	HIPK3 protein, human	HIPK3	orcid:0000-0003-4423-4370	CC0
-mesh:C526744	skos:exactMatch	uniprot:Q9NR71	ASAH2 protein, human	ASAH2	orcid:0000-0003-4423-4370	CC0
-mesh:C000656407	skos:exactMatch	uniprot:Q96H12	MSANTD3 protein, human	MSANTD3	orcid:0000-0003-4423-4370	CC0
-mesh:C000656449	skos:exactMatch	uniprot:Q9NRY5	FAM114A2 protein, human	FAM114A2	orcid:0000-0003-4423-4370	CC0
-mesh:C496590	skos:exactMatch	uniprot:P49406	MRPL19 protein, human	MRPL19	orcid:0000-0003-4423-4370	CC0
-mesh:C519405	skos:exactMatch	uniprot:Q9Y5T4	DNAJC15 protein, human	DNAJC15	orcid:0000-0003-4423-4370	CC0
-mesh:C486655	skos:exactMatch	uniprot:Q96LC9	BMF protein, human	BMF	orcid:0000-0003-4423-4370	CC0
-mesh:C439386	skos:exactMatch	uniprot:Q9BYW1	SLC2A11 protein, human	SLC2A11	orcid:0000-0003-4423-4370	CC0
-mesh:C103258	skos:exactMatch	uniprot:Q14566	MCM6 protein, human	MCM6	orcid:0000-0003-4423-4370	CC0
-mesh:C502654	skos:exactMatch	uniprot:Q8IXM3	MRPL41 protein, human	MRPL41	orcid:0000-0003-4423-4370	CC0
-mesh:C100930	skos:exactMatch	uniprot:Q13405	MRPL49 protein, human	MRPL49	orcid:0000-0003-4423-4370	CC0
-mesh:C089821	skos:exactMatch	uniprot:Q96HJ5	MS4A3 protein, human	MS4A3	orcid:0000-0003-4423-4370	CC0
-mesh:C424714	skos:exactMatch	uniprot:Q96JQ5	MS4A4A protein, human	MS4A4A	orcid:0000-0003-4423-4370	CC0
-pr:PR:000050122	skos:exactMatch	uniprot.chain:PRO_0000005910	C3 anaphylatoxin	C3a anaphylatoxin	orcid:0000-0003-4423-4370	CC0
-mesh:C054369	skos:exactMatch	uniprot:P10636	MAPT protein, human	MAPT	orcid:0000-0003-4423-4370	CC0
-mesh:D001064	skos:exactMatch	ncit:C35145	Appendicitis	Appendicitis	orcid:0000-0003-4423-4370	CC0
-mesh:D000072000	skos:exactMatch	ncit:C17678	NF-KappaB Inhibitor alpha	NF-Kappa-B Inhibitor Alpha	orcid:0000-0003-4423-4370	CC0
-mesh:D001062	skos:exactMatch	ncit:C51687	Appendectomy	Appendectomy	orcid:0000-0003-4423-4370	CC0
-mesh:D003785	skos:exactMatch	ncit:C63715	Dental Pulp Capping	Dental Pulp Capping	orcid:0000-0003-4423-4370	CC0
-mesh:D001065	skos:exactMatch	ncit:C12380	Appendix	Appendix	orcid:0000-0003-4423-4370	CC0
-mesh:D000075927	skos:exactMatch	ncit:C25772	KRIT1 Protein	Krev Interaction Trapped Protein 1	orcid:0000-0003-4423-4370	CC0
-mesh:C012566	skos:exactMatch	ncit:C2639	taurolidine	Taurolidine	orcid:0000-0003-4423-4370	CC0
-mesh:D013654	skos:exactMatch	chebi:CHEBI:15891	Taurine	taurine	orcid:0000-0003-4423-4370	CC0
-mesh:D013656	skos:exactMatch	chebi:CHEBI:28865	Taurocholic Acid	taurocholic acid	orcid:0000-0003-4423-4370	CC0
-mesh:D013657	skos:exactMatch	chebi:CHEBI:9410	Taurodeoxycholic Acid	taurodeoxycholic acid	orcid:0000-0003-4423-4370	CC0
-mesh:D013658	skos:exactMatch	chebi:CHEBI:36259	Taurolithocholic Acid	taurolithocholic acid	orcid:0000-0003-4423-4370	CC0
-pr:PR:000050069	skos:exactMatch	uniprot.chain:PRO_0000005002	voltage-dependent calcium channel subunit delta-1	Voltage-dependent calcium channel subunit delta-1	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050130	skos:exactMatch	uniprot.chain:PRO_0000005914	complement C3g fragment	Complement C3g fragment	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050127	skos:exactMatch	uniprot.chain:PRO_0000005913	complement C3dg fragment	Complement C3dg fragment	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050131	skos:exactMatch	uniprot.chain:PRO_0000005915	complement C3d fragment	Complement C3d fragment	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050119	skos:exactMatch	uniprot.chain:PRO_0000005908	complement C3 beta chain	Complement C3 beta chain	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050124	skos:exactMatch	uniprot.chain:PRO_0000005911	complement C3b alpha' chain	Complement C3b alpha' chain	orcid:0000-0001-9439-5346	CC0
-pr:PR:000035934	skos:exactMatch	uniprot.chain:PRO_0000027759	coagulation factor IXa heavy chain	Coagulation factor IXa heavy chain	orcid:0000-0001-9439-5346	CC0
-pr:PR:000003367	skos:exactMatch	uniprot.chain:PRO_0000005731	chondrocalcin	Chondrocalcin	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050089	skos:exactMatch	uniprot.chain:PRO_0000004641	caspase-9 subunit p35	Caspase-9 subunit p35	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050090	skos:exactMatch	uniprot.chain:PRO_0000004643	caspase-9 subunit p10	Caspase-9 subunit p10	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002459	skos:exactMatch	uniprot.chain:PRO_0000004617	caspase-7 subunit p20	Caspase-7 subunit p20	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002458	skos:exactMatch	uniprot.chain:PRO_0000004619	caspase-7 subunit p11	Caspase-7 subunit p11	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002457	skos:exactMatch	uniprot.chain:PRO_0000004609	caspase-6 subunit p18	Caspase-6 subunit p18	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002456	skos:exactMatch	uniprot.chain:PRO_0000004611	caspase-6 subunit p11	Caspase-6 subunit p11	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002451	skos:exactMatch	uniprot.chain:PRO_0000004542	caspase-2 subunit p18	Caspase-2 subunit p18	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002452	skos:exactMatch	uniprot.chain:PRO_0000004544	caspase-2 subunit p13	Caspase-2 subunit p13	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036012	skos:exactMatch	uniprot.chain:PRO_0000420659	angiotensin 1-9	Angiotensin 1-9	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036013	skos:exactMatch	uniprot.chain:PRO_0000420660	angiotensin 1-7	Angiotensin 1-7	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050121	skos:exactMatch	uniprot.chain:PRO_0000430430	C3-beta-c	C3-beta-c	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002453	skos:exactMatch	uniprot.chain:PRO_0000004545	caspase-2 subunit p12	Caspase-2 subunit p12	orcid:0000-0001-9439-5346	CC0
-pr:PR:000035724	skos:exactMatch	uniprot.chain:PRO_0000396434	60S ribosomal protein L40	60S ribosomal protein L40	orcid:0000-0001-9439-5346	CC0
-pr:PR:000035936	skos:exactMatch	uniprot.chain:PRO_0000027791	activated factor Xa heavy chain	Activated factor Xa heavy chain	orcid:0000-0001-9439-5346	CC0
-mesh:D066293	skos:exactMatch	ncit:C33463	Renshaw Cells	Renshaw Cell	orcid:0000-0001-9439-5346	CC0
-mesh:D066292	skos:exactMatch	go:GO:0005811	Lipid Droplets	lipid droplet	orcid:0000-0001-9439-5346	CC0
-mesh:D066271	skos:exactMatch	ncit:C32550	External Capsule	External Capsule	orcid:0000-0001-9439-5346	CC0
-mesh:D066270	skos:exactMatch	ncit:C93209	Social Capital	Social Capital	orcid:0000-0001-9439-5346	CC0
-mesh:D066261	skos:exactMatch	ncit:C105920	Epigen	Epigen	orcid:0000-0001-9439-5346	CC0
-mesh:D066259	skos:exactMatch	ncit:C20432	Betacellulin	Betacellulin	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036062	skos:exactMatch	uniprot.chain:PRO_0000004629	caspase-8 isoform 1 cleaved 1	Caspase-8 subunit p18	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036064	skos:exactMatch	uniprot.chain:PRO_0000004631	caspase-8 isoform 1 cleaved 2	Caspase-8 subunit p10	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002449	skos:exactMatch	uniprot.chain:PRO_0000004522	caspase-1 isoform 1 cleaved 1	Caspase-1 subunit p20	orcid:0000-0001-9439-5346	CC0
-mesh:D066248	skos:exactMatch	ncit:C87668	High Fructose Corn Syrup	High Fructose Corn Syrup	orcid:0000-0001-9439-5346	CC0
-mesh:D066247	skos:exactMatch	hgnc:3432	Receptor, ErbB-4	ERBB4	orcid:0000-0001-9439-5346	CC0
-mesh:D066126	skos:exactMatch	ncit:C27994	Cardiotoxicity	Cardiotoxicity	orcid:0000-0001-9439-5346	CC0
-mesh:D066127	skos:exactMatch	ncit:C33892	White Matter	White Matter	orcid:0000-0001-9439-5346	CC0
-mesh:D066128	skos:exactMatch	ncit:C32695	Gray Matter	Gray Matter	orcid:0000-0001-9439-5346	CC0
-mesh:D066166	skos:exactMatch	ncit:C168385	Pectus Carinatum	Pectus Carinatum	orcid:0000-0001-9439-5346	CC0
-mesh:D066186	skos:exactMatch	ncit:C32391	Costal Cartilage	Costal Cartilage	orcid:0000-0001-9439-5346	CC0
-mesh:D066191	skos:exactMatch	ncit:C154777	Sensorimotor Cortex	Sensorimotor Cortex	orcid:0000-0001-9439-5346	CC0
-mesh:D066233	skos:exactMatch	ncit:C18740	Psychology, Developmental	Developmental Psychology	orcid:0000-0001-9439-5346	CC0
-mesh:D066235	skos:exactMatch	ncit:C146991	Fluorine-19 Magnetic Resonance Imaging	Fluorine-19 Magnetic Resonance Imaging	orcid:0000-0001-9439-5346	CC0
-mesh:D066066	skos:exactMatch	ncit:C49164	Response Evaluation Criteria in Solid Tumors	Response Evaluation Criteria in Solid Tumors	orcid:0000-0001-9439-5346	CC0
-mesh:D066027	skos:exactMatch	ncit:C159659	Transplant Recipients	Transplant Recipient	orcid:0000-0001-9439-5346	CC0
-mesh:D066007	skos:exactMatch	ncit:C90478	Toxicokinetics	Toxicokinetics	orcid:0000-0001-9439-5346	CC0
-mesh:D065927	skos:exactMatch	efo:0005191	Waist-Height Ratio	waist height ratio	orcid:0000-0001-9439-5346	CC0
-mesh:D065886	skos:exactMatch	efo:0010642	Neurodevelopmental Disorders	Neurodevelopmental disorder	orcid:0000-0001-9439-5346	CC0
-mesh:D065866	skos:exactMatch	ncit:C33218	Optic Tract	Optic Tract	orcid:0000-0001-9439-5346	CC0
-mesh:D065850	skos:exactMatch	ncit:C32291	Cerebral Peduncle	Cerebral Peduncle	orcid:0000-0001-9439-5346	CC0
-mesh:D065843	skos:exactMatch	ncit:C32409	Cerebral Crus	Crus Cerebri	orcid:0000-0001-9439-5346	CC0
-mesh:D065819	skos:exactMatch	ncit:C1707	Voriconazole	Voriconazole	orcid:0000-0001-9439-5346	CC0
-mesh:D065842	skos:exactMatch	ncit:C97341	Pars Compacta	Pars Compacta	orcid:0000-0001-9439-5346	CC0
-mesh:D065631	skos:exactMatch	doid:DOID:4481	Rhinitis, Allergic	allergic rhinitis	orcid:0000-0001-9439-5346	CC0
-mesh:D065707	skos:exactMatch	ncit:C99056	Schizencephaly	Schizencephaly	orcid:0000-0001-9439-5346	CC0
-mesh:D065527	skos:exactMatch	ncit:C157799	Brachial Plexus Block	Brachial Plexus Block	orcid:0000-0001-9439-5346	CC0
-mesh:D065108	skos:exactMatch	ncit:C2088	Ornithine Decarboxylase Inhibitors	Ornithine Decarboxylase Inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D065168	skos:exactMatch	chebi:CHEBI:68557	Bradykinin Receptor Antagonists	bradykinin receptor antagonist	orcid:0000-0001-9439-5346	CC0
-mesh:D065170	skos:exactMatch	ncit:C92730	Pregnancy, Angular	Angular Pregnancy	orcid:0000-0001-9439-5346	CC0
-mesh:D065171	skos:exactMatch	chebi:CHEBI:50792	Estrogen Receptor Antagonists	estrogen receptor antagonist	orcid:0000-0001-9439-5346	CC0
-mesh:D065173	skos:exactMatch	ncit:C92761	Pregnancy, Cornual	Cornual Pregnancy	orcid:0000-0001-9439-5346	CC0
-mesh:D065207	skos:exactMatch	ncit:C171516	Middle East Respiratory Syndrome Coronavirus	Middle East Respiratory Syndrome Coronavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D065290	skos:exactMatch	efo:0007949	Acute-On-Chronic Liver Failure	acute-on-chronic liver failure	orcid:0000-0001-9439-5346	CC0
-mesh:D065306	skos:exactMatch	ncit:C35392	Corneal Injuries	Corneal Injury	orcid:0000-0001-9439-5346	CC0
-mesh:D065326	skos:exactMatch	ncit:C157359	Children's Health Insurance Program	Children's Health Insurance Program	orcid:0000-0001-9439-5346	CC0
-mesh:D065426	skos:exactMatch	ncit:C132068	Cytoreduction Surgical Procedures	Cytoreductive Surgery	orcid:0000-0001-9439-5346	CC0
-mesh:D065102	skos:exactMatch	ncit:C20822	Licensed Practical Nurses	Licensed Practical Nurse	orcid:0000-0001-9439-5346	CC0
-mesh:D064966	skos:exactMatch	ncit:C17653	British Virgin Islands	Virgin Islands, British	orcid:0000-0001-9439-5346	CC0
-mesh:D064888	skos:exactMatch	ncit:C16084	Observational Study	Observational Study	orcid:0000-0001-9439-5346	CC0
-mesh:D064886	skos:exactMatch	ncit:C47824	Dataset	Data Set	orcid:0000-0001-9439-5346	CC0
-mesh:D064878	skos:exactMatch	ncit:C142748	Web Browser	Web Browser	orcid:0000-0001-9439-5346	CC0
-mesh:D064847	skos:exactMatch	ncit:C19341	Multimodal Imaging	Multimodal Imaging	orcid:0000-0001-9439-5346	CC0
-mesh:D064890	skos:exactMatch	ncit:C171586	Social Determinants of Health	Social Determinants of Health	orcid:0000-0001-9439-5346	CC0
-mesh:D064794	skos:exactMatch	chebi:CHEBI:135646	Lorajmine	lorajmine	orcid:0000-0001-9439-5346	CC0
-mesh:D064750	skos:exactMatch	chebi:CHEBI:8768	Rabeprazole	rabeprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D064748	skos:exactMatch	ncit:C73192	Dexlansoprazole	Dexlansoprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D064747	skos:exactMatch	ncit:C29150	Lansoprazole	Lansoprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D064751	skos:exactMatch	chebi:CHEBI:35276	Ammonium Compounds	ammonium compound	orcid:0000-0001-9439-5346	CC0
-mesh:D064791	skos:exactMatch	ncit:C65369	Desoxycorticosterone Acetate	Desoxycorticosterone Acetate	orcid:0000-0001-9439-5346	CC0
-mesh:D065026	skos:exactMatch	ncit:C77962	Hope	Hope	orcid:0000-0001-9439-5346	CC0
-mesh:D064696	skos:exactMatch	ncit:C66870	Zuclomiphene	Zuclomiphene	orcid:0000-0001-9439-5346	CC0
-mesh:D064695	skos:exactMatch	ncit:C28211	Enclomiphene	Enclomiphene	orcid:0000-0001-9439-5346	CC0
-mesh:D064692	skos:exactMatch	ncit:C29104	Hyoscyamine	Hyoscyamine	orcid:0000-0001-9439-5346	CC0
-mesh:D064704	skos:exactMatch	ncit:C1586	Levofloxacin	Levofloxacin	orcid:0000-0001-9439-5346	CC0
-mesh:D064705	skos:exactMatch	ncit:C76546	Racepinephrine	Racepinephrine	orcid:0000-0001-9439-5346	CC0
-mesh:D064730	skos:exactMatch	ncit:C1333	Dexrazoxane	Dexrazoxane	orcid:0000-0001-9439-5346	CC0
-mesh:D064906	skos:exactMatch	ncit:C93098	Qigong	Qigong	orcid:0000-0001-9439-5346	CC0
-mesh:D064591	skos:exactMatch	ncit:C60701	Allografts	Allograft	orcid:0000-0001-9439-5346	CC0
-mesh:D064652	skos:exactMatch	ncit:C32183	Basal Bodies	Basal Body	orcid:0000-0001-9439-5346	CC0
-mesh:D064650	skos:exactMatch	ncit:C20883	Home Health Nursing	Home Health Nursing	orcid:0000-0001-9439-5346	CC0
-mesh:D064648	skos:exactMatch	ncit:C17602	Critical Care Nursing	Critical Care Nursing	orcid:0000-0001-9439-5346	CC0
-mesh:D064706	skos:exactMatch	hp:HP:0031801	Vocal Cord Dysfunction	Vocal cord dysfunction	orcid:0000-0001-9439-5346	CC0
-mesh:D064386	skos:exactMatch	efo:0009615	Ankle Fractures	ankle fracture	orcid:0000-0001-9439-5346	CC0
-mesh:D064346	skos:exactMatch	ncit:C87054	Sagittal Abdominal Diameter	Sagittal Abdominal Diameter	orcid:0000-0001-9439-5346	CC0
-mesh:D064232	skos:exactMatch	ncit:C121547	Visual Analog Scale	Visual Analog Scale	orcid:0000-0001-9439-5346	CC0
-mesh:D064209	skos:exactMatch	ncit:C28269	Phytochemicals	Phytochemical	orcid:0000-0001-9439-5346	CC0
-mesh:D064208	skos:exactMatch	ncit:C86135	Aggregatibacter segnis	Aggregatibacter segnis	orcid:0000-0001-9439-5346	CC0
-mesh:D064206	skos:exactMatch	ncit:C86132	Aggregatibacter	Aggregatibacter	orcid:0000-0001-9439-5346	CC0
-mesh:D064207	skos:exactMatch	ncit:C86134	Aggregatibacter aphrophilus	Aggregatibacter aphrophilus	orcid:0000-0001-9439-5346	CC0
-mesh:D064166	skos:exactMatch	ncit:C69183	Vaccine Potency	Vaccine Potency	orcid:0000-0001-9439-5346	CC0
-mesh:D064048	skos:exactMatch	ncit:C13365	Spindle Pole Bodies	Spindle Pole Body	orcid:0000-0001-9439-5346	CC0
-mesh:D064047	skos:exactMatch	go:GO:0000922	Spindle Poles	spindle pole	orcid:0000-0001-9439-5346	CC0
-mesh:D064068	skos:exactMatch	ncit:C45426	Collagenous Sprue	Collagenous Sprue	orcid:0000-0001-9439-5346	CC0
-mesh:D064090	skos:exactMatch	ncit:C9184	Intraocular Lymphoma	Intraocular Lymphoma	orcid:0000-0001-9439-5346	CC0
-mesh:D064096	skos:exactMatch	ncit:C30006	Aurora Kinase A	Aurora Kinase A	orcid:0000-0001-9439-5346	CC0
-mesh:D064098	skos:exactMatch	ncit:C65538	Esomeprazole	Esomeprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D064107	skos:exactMatch	ncit:C68596	Aurora Kinase B	Aurora Kinase B	orcid:0000-0001-9439-5346	CC0
-mesh:D064108	skos:exactMatch	ncit:C95267	Aurora Kinase C	Aurora Kinase C	orcid:0000-0001-9439-5346	CC0
-mesh:D063990	skos:exactMatch	ncit:C43520	Gene Ontology	Gene Ontology	orcid:0000-0001-9439-5346	CC0
-mesh:D063826	skos:exactMatch	ncit:C123740	Kosovo	Kosovo	orcid:0000-0001-9439-5346	CC0
-mesh:D063806	skos:exactMatch	ncit:C27009	Myalgia	Myalgia	orcid:0000-0001-9439-5346	CC0
-mesh:D063766	skos:exactMatch	ncit:C84449	Pediatric Obesity	Childhood Obesity	orcid:0000-0001-9439-5346	CC0
-mesh:D063646	skos:exactMatch	ncit:C18078	Carcinogenesis	Carcinogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D063325	skos:exactMatch	chebi:CHEBI:32220	Tiapride Hydrochloride	Tiapride hydrochloride	orcid:0000-0001-9439-5346	CC0
-mesh:D063386	skos:exactMatch	chebi:CHEBI:67072	Cannabinoid Receptor Agonists	cannabinoid receptor agonist	orcid:0000-0001-9439-5346	CC0
-mesh:D063426	skos:exactMatch	ncit:C15422	Human Migration	Human Migration	orcid:0000-0001-9439-5346	CC0
-mesh:D063546	skos:exactMatch	go:GO:0020011	Apicoplasts	apicoplast	orcid:0000-0001-9439-5346	CC0
-mesh:D063388	skos:exactMatch	chebi:CHEBI:67197	Endocannabinoids	endocannabinoid	orcid:0000-0001-9439-5346	CC0
-mesh:D063088	skos:exactMatch	chebi:CHEBI:17102	Phosphoramides	phosphoramide	orcid:0000-0001-9439-5346	CC0
-mesh:D063005	skos:exactMatch	ncit:C18229	Health Information Systems	Health Information System	orcid:0000-0001-9439-5346	CC0
-mesh:D063126	skos:exactMatch	ncit:C157795	Balloon Valvuloplasty	Balloon Valvuloplasty	orcid:0000-0001-9439-5346	CC0
-mesh:D062907	skos:exactMatch	chebi:CHEBI:30744	Oxaloacetic Acid	oxaloacetic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D062745	skos:exactMatch	ncit:C118593	Junctional Adhesion Molecule A	Junctional Adhesion Molecule A	orcid:0000-0001-9439-5346	CC0
-mesh:D062689	skos:exactMatch	ncit:C27483	Lipoblastoma	Lipoblastoma	orcid:0000-0001-9439-5346	CC0
-mesh:D062559	skos:exactMatch	hgnc:10582	NAV1.8 Voltage-Gated Sodium Channel	SCN10A	orcid:0000-0001-9439-5346	CC0
-mesh:D062408	skos:exactMatch	ncit:C80249	Breakfast	Breakfast	orcid:0000-0001-9439-5346	CC0
-mesh:D062409	skos:exactMatch	ncit:C80250	Lunch	Lunch	orcid:0000-0001-9439-5346	CC0
-mesh:D062485	skos:exactMatch	ncit:C121558	Breath Holding	Breath Holding	orcid:0000-0001-9439-5346	CC0
-mesh:D062445	skos:exactMatch	hgnc:2032	Claudin-1	CLDN1	orcid:0000-0001-9439-5346	CC0
-mesh:D062446	skos:exactMatch	hgnc:2041	Claudin-2	CLDN2	orcid:0000-0001-9439-5346	CC0
-mesh:D062465	skos:exactMatch	hgnc:2045	Claudin-3	CLDN3	orcid:0000-0001-9439-5346	CC0
-mesh:D062506	skos:exactMatch	hgnc:2046	Claudin-4	CLDN4	orcid:0000-0001-9439-5346	CC0
-mesh:D062507	skos:exactMatch	hgnc:2047	Claudin-5	CLDN5	orcid:0000-0001-9439-5346	CC0
-mesh:D066249	skos:exactMatch	ncit:C41365	Craving	Craving	orcid:0000-0001-9439-5346	CC0
-mesh:D064703	skos:exactMatch	ncit:C71290	Family Nurse Practitioners	Family Nurse Practitioner	orcid:0000-0001-9439-5346	CC0
-mesh:D064690	skos:exactMatch	chebi:CHEBI:77567	Wakefulness-Promoting Agents	eugeroic	orcid:0000-0001-9439-5346	CC0
-mesh:D020169	skos:exactMatch	ncit:C18153	Caspases	Caspase	orcid:0000-0001-9439-5346	CC0
-mesh:D020170	skos:exactMatch	hgnc:1499	Caspase 1	CASP1	orcid:0000-0001-9439-5346	CC0
-mesh:D053148	skos:exactMatch	hgnc:1504	Caspase 3	CASP3	orcid:0000-0001-9439-5346	CC0
-mesh:D053178	skos:exactMatch	hgnc:1507	Caspase 6	CASP6	orcid:0000-0001-9439-5346	CC0
-mesh:D053455	skos:exactMatch	hgnc:1500	Caspase 10	CASP10	orcid:0000-0001-9439-5346	CC0
-mesh:D053456	skos:exactMatch	hgnc:1502	Caspase 14	CASP14	orcid:0000-0001-9439-5346	CC0
-mesh:C033246	skos:exactMatch	ncit:C121971	prostaglandin E3	Prostaglandin E3	orcid:0000-0001-9439-5346	CC0
-mesh:D011448	skos:exactMatch	chebi:CHEBI:49023	Prostaglandin Antagonists	prostaglandin antagonist	orcid:0000-0001-9439-5346	CC0
-mesh:D011453	skos:exactMatch	ncit:C782	Prostaglandins	Prostaglandin	orcid:0000-0001-9439-5346	CC0
-mesh:D011454	skos:exactMatch	chebi:CHEBI:26334	Prostaglandins A	prostaglandins A	orcid:0000-0001-9439-5346	CC0
-mesh:D011456	skos:exactMatch	chebi:CHEBI:26335	Prostaglandins B	prostaglandins B	orcid:0000-0001-9439-5346	CC0
-mesh:D011457	skos:exactMatch	chebi:CHEBI:26337	Prostaglandins D	prostaglandins D	orcid:0000-0001-9439-5346	CC0
-mesh:D011458	skos:exactMatch	chebi:CHEBI:26338	Prostaglandins E	prostaglandins E	orcid:0000-0001-9439-5346	CC0
-mesh:D011460	skos:exactMatch	chebi:CHEBI:26340	Prostaglandins F	prostaglandins F	orcid:0000-0001-9439-5346	CC0
-mesh:D011462	skos:exactMatch	chebi:CHEBI:26343	Prostaglandins G	prostaglandins G	orcid:0000-0001-9439-5346	CC0
-mesh:D011463	skos:exactMatch	chebi:CHEBI:26344	Prostaglandins H	prostaglandins H	orcid:0000-0001-9439-5346	CC0
-mesh:D015230	skos:exactMatch	chebi:CHEBI:15555	Prostaglandin D2	prostaglandin D2	orcid:0000-0001-9439-5346	CC0
-mesh:D044062	skos:exactMatch	chebi:CHEBI:26345	Prostaglandins I	prostaglandins I	orcid:0000-0001-9439-5346	CC0
-mesh:D044262	skos:exactMatch	chebi:CHEBI:15554	Prostaglandin H2	prostaglandin H2	orcid:0000-0001-9439-5346	CC0
-mesh:C000606551	skos:exactMatch	ncit:C152185	remdesivir	Remdesivir	orcid:0000-0001-9439-5346	CC0
-mesh:C000623728	skos:exactMatch	ncit:C112409	Rhinovirus C	Rhinovirus C	orcid:0000-0001-9439-5346	CC0
-mesh:C000623735	skos:exactMatch	ncit:C112408	Rhinovirus B	Rhinovirus B	orcid:0000-0001-9439-5346	CC0
-mesh:C000623787	skos:exactMatch	ncit:C112407	Rhinovirus A	Rhinovirus A	orcid:0000-0001-9439-5346	CC0
-mesh:C000592662	skos:exactMatch	ncit:C171848	DORAVIRINE	Doravirine	orcid:0000-0001-9439-5346	CC0
-mesh:C063638	skos:exactMatch	ncit:C82253	lobucavir	Lobucavir	orcid:0000-0001-9439-5346	CC0
-mesh:C066100	skos:exactMatch	ncit:C118556	poliovirus receptor	Poliovirus Receptor	orcid:0000-0001-9439-5346	CC0
-mesh:C053001	skos:exactMatch	ncit:C61526	adefovir	Adefovir	orcid:0000-0001-9439-5346	CC0
-mesh:C083858	skos:exactMatch	ncit:C73147	emivirine	Emivirine	orcid:0000-0001-9439-5346	CC0
-mesh:C087098	skos:exactMatch	ncit:C26677	virulizin	Virulizin	orcid:0000-0001-9439-5346	CC0
-mesh:C098320	skos:exactMatch	ncit:C29027	efavirenz	Efavirenz	orcid:0000-0001-9439-5346	CC0
-mesh:C107733	skos:exactMatch	ncit:C1786	cyanovirin N	Cyanovirin-N	orcid:0000-0001-9439-5346	CC0
-mesh:C414210	skos:exactMatch	ncit:C81611	peramivir	Peramivir	orcid:0000-0001-9439-5346	CC0
-mesh:C400401	skos:exactMatch	ncit:C82254	maribavir	Maribavir	orcid:0000-0001-9439-5346	CC0
-mesh:C118874	skos:exactMatch	ncit:C82255	rupintrivir	Rupintrivir	orcid:0000-0001-9439-5346	CC0
-mesh:C453221	skos:exactMatch	ncit:C136516	pritelivir	Pritelivir	orcid:0000-0001-9439-5346	CC0
-mesh:C462182	skos:exactMatch	ncit:C81605	favipiravir	Favipiravir	orcid:0000-0001-9439-5346	CC0
-mesh:C481671	skos:exactMatch	ncit:C73205	Dapivirine	Dapivirine	orcid:0000-0001-9439-5346	CC0
-mesh:C497721	skos:exactMatch	ncit:C66453	pradefovir	Pradefovir	orcid:0000-0001-9439-5346	CC0
-mesh:C505045	skos:exactMatch	ncit:C81606	Tecovirimat	Tecovirimat	orcid:0000-0001-9439-5346	CC0
-mesh:C549273	skos:exactMatch	ncit:C114981	daclatasvir	Daclatasvir	orcid:0000-0001-9439-5346	CC0
-mesh:C525733	skos:exactMatch	ncit:C90587	brincidofovir	Brincidofovir	orcid:0000-0001-9439-5346	CC0
-mesh:D000068696	skos:exactMatch	ncit:C76929	Rilpivirine	Rilpivirine	orcid:0000-0001-9439-5346	CC0
-mesh:D000068698	skos:exactMatch	ncit:C29490	Tenofovir	Tenofovir	orcid:0000-0001-9439-5346	CC0
-mesh:D000068898	skos:exactMatch	ncit:C73823	Raltegravir Potassium	Raltegravir Potassium	orcid:0000-0001-9439-5346	CC0
-mesh:D000069446	skos:exactMatch	ncit:C28835	Atazanavir Sulfate	Atazanavir Sulfate	orcid:0000-0001-9439-5346	CC0
-mesh:D000069454	skos:exactMatch	chebi:CHEBI:367163	Darunavir	darunavir	orcid:0000-0001-9439-5346	CC0
-mesh:D000069474	skos:exactMatch	ncit:C101263	Sofosbuvir	Sofosbuvir	orcid:0000-0001-9439-5346	CC0
-mesh:D000069616	skos:exactMatch	ncit:C129015	Simeprevir	Simeprevir	orcid:0000-0001-9439-5346	CC0
-mesh:D000071243	skos:exactMatch	ncit:C128423	Zika Virus Infection	Zika Virus Infection	orcid:0000-0001-9439-5346	CC0
-mesh:D000071244	skos:exactMatch	ncit:C128553	Zika Virus	Zika Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D000072230	skos:exactMatch	ncit:C120598	Sustained Virologic Response	Sustained Virologic Response	orcid:0000-0001-9439-5346	CC0
-mesh:D000072596	skos:exactMatch	ncit:C116608	Hepatitis A Virus Cellular Receptor 1	Hepatitis A Virus Cellular Receptor 1	orcid:0000-0001-9439-5346	CC0
-mesh:D000072597	skos:exactMatch	ncit:C104278	Hepatitis A Virus Cellular Receptor 2	Hepatitis A Virus Cellular Receptor 2	orcid:0000-0001-9439-5346	CC0
-mesh:D000073638	skos:exactMatch	ncit:C119319	Alphacoronavirus	Alphacoronavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D000073640	skos:exactMatch	ncit:C113207	Betacoronavirus	Betacoronavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D000073642	skos:exactMatch	ncit:C122313	Gammacoronavirus	Gammacoronavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D000077483	skos:exactMatch	ncit:C28235	Valacyclovir	Valacyclovir	orcid:0000-0001-9439-5346	CC0
-mesh:D000077560	skos:exactMatch	ncit:C2105	Enfuvirtide	Enfuvirtide	orcid:0000-0001-9439-5346	CC0
-mesh:D000077562	skos:exactMatch	ncit:C2629	Valganciclovir	Valganciclovir	orcid:0000-0001-9439-5346	CC0
-mesh:D000077592	skos:exactMatch	ncit:C73144	Maraviroc	Maraviroc	orcid:0000-0001-9439-5346	CC0
-mesh:D000077595	skos:exactMatch	ncit:C29044	Famciclovir	Famciclovir	orcid:0000-0001-9439-5346	CC0
-mesh:D000080309	skos:exactMatch	ncit:C169106	Environmental DNA	Environmental DNA	orcid:0000-0001-9439-5346	CC0
-mesh:D000077404	skos:exactMatch	ncit:C1600	Cidofovir	Cidofovir	orcid:0000-0001-9439-5346	CC0
-mesh:D000076142	skos:exactMatch	ncit:C18468	Virtual Reality	Virtual Reality	orcid:0000-0001-9439-5346	CC0
-mesh:D000212	skos:exactMatch	ncit:C205	Acyclovir	Acyclovir	orcid:0000-0001-9439-5346	CC0
-mesh:D000257	skos:exactMatch	ncit:C115149	Adenoviridae Infections	Adenovirus Infection	orcid:0000-0001-9439-5346	CC0
-mesh:D000524	skos:exactMatch	ncit:C112030	Alphavirus	Alphavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D000998	skos:exactMatch	ncit:C281	Antiviral Agents	Antiviral Agent	orcid:0000-0001-9439-5346	CC0
-mesh:D001103	skos:exactMatch	ncit:C112230	Arboviruses	Arbovirus	orcid:0000-0001-9439-5346	CC0
-mesh:D001739	skos:exactMatch	ncit:C89820	BK Virus	BK Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D001355	skos:exactMatch	ncit:C14186	Alpharetrovirus	Alpharetrovirus	orcid:0000-0001-9439-5346	CC0
-mesh:D002043	skos:exactMatch	ncit:C112028	Bunyaviridae	Bunyaviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D002139	skos:exactMatch	ncit:C14304	Caliciviridae	Caliciviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D003236	skos:exactMatch	ncit:C34509	Conjunctivitis, Viral	Viral Conjunctivitis	orcid:0000-0001-9439-5346	CC0
-mesh:D003716	skos:exactMatch	ncit:C112036	Dengue Virus	Dengue Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D004263	skos:exactMatch	ncit:C14199	DNA Tumor Viruses	DNA Tumor Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D004267	skos:exactMatch	ncit:C14200	DNA Viruses	DNA Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D004777	skos:exactMatch	ncit:C16551	Environment	Environment	orcid:0000-0001-9439-5346	CC0
-mesh:D004781	skos:exactMatch	ncit:C16552	Environmental Exposure	Environmental Exposure	orcid:0000-0001-9439-5346	CC0
-mesh:D004860	skos:exactMatch	ncit:C14205	Infectious Anemia Virus, Equine	Equine Infectious Anemia Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D005416	skos:exactMatch	ncit:C14208	Flavivirus	Flavivirus	orcid:0000-0001-9439-5346	CC0
-mesh:D019213	skos:exactMatch	ncit:C14326	Rubulavirus	Rubulavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D012229	skos:exactMatch	ncit:C77200	Rhinovirus	Rhinovirus	orcid:0000-0001-9439-5346	CC0
-mesh:D012209	skos:exactMatch	ncit:C112027	Rhabdoviridae	Rhabdoviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D012254	skos:exactMatch	ncit:C807	Ribavirin	Ribavirin	orcid:0000-0001-9439-5346	CC0
-mesh:D012328	skos:exactMatch	ncit:C14269	RNA Viruses	RNA Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D012412	skos:exactMatch	ncit:C77198	Rubella virus	Rubella Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D012901	skos:exactMatch	ncit:C96527	Variola virus	Variola Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D013155	skos:exactMatch	ncit:C14276	Spleen Focus-Forming Viruses	Spleen Focus-Forming Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D014035	skos:exactMatch	ncit:C77197	Togaviridae	Togaviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D012190	skos:exactMatch	ncit:C14268	Retroviridae	Retroviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D012087	skos:exactMatch	ncit:C112026	Reoviridae	Reoviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D011212	skos:exactMatch	ncit:C14261	Poxviridae	Poxvirus	orcid:0000-0001-9439-5346	CC0
-mesh:D011120	skos:exactMatch	ncit:C14260	Polyomavirus	Polyomavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D010942	skos:exactMatch	ncit:C14257	Plant Viruses	Plant Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D009975	skos:exactMatch	ncit:C53453	Orthomyxoviridae	Orthomyxoviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D010252	skos:exactMatch	ncit:C14255	Paramyxoviridae	Paramyxoviridae	orcid:0000-0001-9439-5346	CC0
-mesh:D010285	skos:exactMatch	ncit:C112401	Pseudocowpox Virus	Pseudocowpox Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D010849	skos:exactMatch	ncit:C14256	Picornaviridae	Picornavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D011054	skos:exactMatch	ncit:C91715	Poliovirus Vaccine, Inactivated	Inactivated Poliovirus Vaccine	orcid:0000-0001-9439-5346	CC0
-mesh:D014036	skos:exactMatch	ncit:C85192	Togaviridae Infections	Togaviridae Infection	orcid:0000-0001-9439-5346	CC0
-mesh:D014484	skos:exactMatch	ncit:C17236	United States Environmental Protection Agency	Environmental Protection Agency	orcid:0000-0001-9439-5346	CC0
-mesh:D045403	skos:exactMatch	ncit:C112290	Henipavirus	Henipavirus	orcid:0000-0001-9439-5346	CC0
-mesh:D029322	skos:exactMatch	ncit:C112362	Norovirus	Norovirus	orcid:0000-0001-9439-5346	CC0
-mesh:D014772	skos:exactMatch	ncit:C95945	Viroids	Viroid	orcid:0000-0001-9439-5346	CC0
-mesh:D014773	skos:exactMatch	ncit:C17256	Virology	Virology	orcid:0000-0001-9439-5346	CC0
-mesh:D014774	skos:exactMatch	ncit:C28198	Virulence	Virulence	orcid:0000-0001-9439-5346	CC0
-mesh:D014780	skos:exactMatch	ncit:C14283	Viruses	Virus	orcid:0000-0001-9439-5346	CC0
-mesh:D014903	skos:exactMatch	ncit:C43473	West Virginia	West Virginia	orcid:0000-0001-9439-5346	CC0
-mesh:D014768	skos:exactMatch	ncit:C43472	Virginia	Virginia	orcid:0000-0001-9439-5346	CC0
-mesh:D014767	skos:exactMatch	ncit:C17255	United States Virgin Islands	Virgin Islands, U.S.	orcid:0000-0001-9439-5346	CC0
-mesh:D015774	skos:exactMatch	chebi:CHEBI:465284	Ganciclovir	ganciclovir	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050268	skos:exactMatch	uniprot.chain:PRO_0000449648	spike protein S2 (SARS-CoV-2)	Spike protein S2	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050267	skos:exactMatch	uniprot.chain:PRO_0000449647	spike protein S1 (SARS-CoV-2)	Spike protein S1	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050278	skos:exactMatch	uniprot.chain:PRO_0000449627	non-structural protein 9 (SARS-CoV-2)	Non-structural protein 9	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050277	skos:exactMatch	uniprot.chain:PRO_0000449626	non-structural protein 8 (SARS-CoV-2)	Non-structural protein 8	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050276	skos:exactMatch	uniprot.chain:PRO_0000449625	non-structural protein 7 (SARS-CoV-2)	Non-structural protein 7	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050275	skos:exactMatch	uniprot.chain:PRO_0000449624	non-structural protein 6 (SARS-CoV-2)	Non-structural protein 6	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050273	skos:exactMatch	uniprot.chain:PRO_0000449622	non-structural protein 4 (SARS-CoV-2)	Non-structural protein 4	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050272	skos:exactMatch	uniprot.chain:PRO_0000449621	non-structural protein 3 (SARS-CoV-2)	Non-structural protein 3	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050271	skos:exactMatch	uniprot.chain:PRO_0000449620	non-structural protein 2 (SARS-CoV-2)	Non-structural protein 2	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050280	skos:exactMatch	uniprot.chain:PRO_0000449645	non-structural protein 11 (SARS-CoV-2)	Non-structural protein 11	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050279	skos:exactMatch	uniprot.chain:PRO_0000449628	non-structural protein 10 (SARS-CoV-2)	Non-structural protein 10	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050270	skos:exactMatch	uniprot.chain:PRO_0000449619	host translation inhibitor nsp1 (SARS-CoV-2)	Host translation inhibitor nsp1	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050285	skos:exactMatch	uniprot.chain:PRO_0000449630	helicase (SARS-CoV-2)	Helicase	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050274	skos:exactMatch	uniprot.chain:PRO_0000449623	3C-like proteinase (SARS-CoV-2)	3C-like proteinase	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050288	skos:exactMatch	uniprot.chain:PRO_0000449633	2'-O-methyltransferase (SARS-CoV-2)	2'-O-methyltransferase	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036008	skos:exactMatch	uniprot.chain:PRO_0000032457	angiotensin I	Angiotensin-1	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036009	skos:exactMatch	uniprot.chain:PRO_0000032458	angiotensin II	Angiotensin-2	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036010	skos:exactMatch	uniprot.chain:PRO_0000032459	angiotensin III	Angiotensin-3	orcid:0000-0001-9439-5346	CC0
-pr:PR:000036011	skos:exactMatch	uniprot.chain:PRO_0000420663	angiotensin IV	Angiotensin-4	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050135	skos:exactMatch	uniprot.chain:PRO_0000005909	complement C3 alpha chain (human)	Complement C3 alpha chain	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002450	skos:exactMatch	uniprot.chain:PRO_0000004524	caspase-1 isoform 1 cleaved 2	Caspase-1 subunit p10	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002454	skos:exactMatch	uniprot.chain:PRO_0000004572	caspase-3 isoform 1 cleaved 1	Caspase-3 subunit p12	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002455	skos:exactMatch	uniprot.chain:PRO_0000004571	caspase-3 isoform 1 cleaved 2	Caspase-3 subunit p17	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050084	skos:exactMatch	uniprot.chain:PRO_0000367048	155 kDa platelet multimerin (human)	155 kDa platelet multimerin	orcid:0000-0001-9439-5346	CC0
-pr:PR:000035718	skos:exactMatch	uniprot.chain:PRO_0000396478	40S ribosomal protein S27a	40S ribosomal protein S27a	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050083	skos:exactMatch	uniprot.chain:PRO_0000367047	platelet glycoprotein Ia* (human)	Platelet glycoprotein Ia*	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050284	skos:exactMatch	uniprot.chain:PRO_0000449629	RNA-directed RNA polymerase (SARS-CoV-2)	RNA-directed RNA polymerase	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002439	skos:exactMatch	uniprot.chain:PRO_0000223233	BH3-interacting domain death agonist isoform 1 cleaved 1	BH3-interacting domain death agonist p15	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002440	skos:exactMatch	uniprot.chain:PRO_0000223232	BH3-interacting domain death agonist isoform 1 cleaved 2	BH3-interacting domain death agonist p13	orcid:0000-0001-9439-5346	CC0
-pr:PR:000002441	skos:exactMatch	uniprot.chain:PRO_0000223231	BH3-interacting domain death agonist isoform 1 cleaved 3	BH3-interacting domain death agonist p11	orcid:0000-0001-9439-5346	CC0
-mesh:D066258	skos:exactMatch	hgnc:651	Amphiregulin	AREG	orcid:0000-0001-9439-5346	CC0
-mesh:D066260	skos:exactMatch	hgnc:3443	Epiregulin	EREG	orcid:0000-0001-9439-5346	CC0
-mesh:D066257	skos:exactMatch	hgnc:3059	Heparin-binding EGF-like Growth Factor	HBEGF	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050287	skos:exactMatch	uniprot.chain:PRO_0000449632	uridylate-specific endoribonuclease (SARS-CoV-2)	Uridylate-specific endoribonuclease	orcid:0000-0001-9439-5346	CC0
-mesh:D045473	skos:exactMatch	ncit:C112432	SARS Virus	SARS Coronavirus	orcid:0000-0001-9439-5346	CC0
-mesh:C000656484	skos:exactMatch	ncit:C169076	severe acute respiratory syndrome coronavirus 2	SARS Coronavirus 2	orcid:0000-0001-9439-5346	CC0
-mesh:C000657245	skos:exactMatch	doid:DOID:0080600	COVID-19	COVID-19	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050269	skos:exactMatch	uniprot.chain:PRO_0000449649	spike protein S2' (SARS-CoV-2)	Spike protein S2'	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050266	skos:exactMatch	uniprot.chain:PRO_0000449646	spike glycoprotein, signal peptide removed form (SARS-CoV-2)	Spike glycoprotein	orcid:0000-0001-9439-5346	CC0
-pr:PR:000050265	skos:exactMatch	uniprot.chain:PRO_0000449654	ORF7a protein, signal peptide removed form (SARS-CoV-2)	ORF7a protein	orcid:0000-0001-9439-5346	CC0
-mesh:D065098	skos:exactMatch	chebi:CHEBI:48406	Catechol O-Methyltransferase Inhibitors	EC 2.1.1.6 (catechol O-methyltransferase) inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D065093	skos:exactMatch	chebi:CHEBI:35625	beta-Lactamase Inhibitors	EC 3.5.2.6 (beta-lactamase) inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D064801	skos:exactMatch	chebi:CHEBI:50469	Phospholipase A2 Inhibitors	EC 3.1.1.4 (phospholipase A2) inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D064546	skos:exactMatch	hgnc:9395	Protein Kinase C beta	PRKCB	orcid:0000-0001-9439-5346	CC0
-mesh:D064424	skos:exactMatch	ncit:C18059	Tobacco Use	Tobacco Use	orcid:0000-0001-9439-5346	CC0
-mesh:D063926	skos:exactMatch	ncit:C112208	Drug Hypersensitivity Syndrome	Drug Hypersensitivity Syndrome	orcid:0000-0001-9439-5346	CC0
-mesh:D062385	skos:exactMatch	chebi:CHEBI:24675	Hydroxybenzoates	hydroxybenzoate	orcid:0000-0001-9439-5346	CC0
-mesh:D062405	skos:exactMatch	ncit:C157765	Motivational Interviewing	Motivational Interviewing	orcid:0000-0001-9439-5346	CC0
-mesh:D062407	skos:exactMatch	ncit:C80248	Meals	Meal	orcid:0000-0001-9439-5346	CC0
-mesh:D062625	skos:exactMatch	ncit:C8985	Cystadenofibroma	Cystadenofibroma	orcid:0000-0001-9439-5346	CC0
-mesh:D062645	skos:exactMatch	ncit:C99521	Percutaneous Coronary Intervention	Percutaneous Coronary Intervention	orcid:0000-0001-9439-5346	CC0
-mesh:D062685	skos:exactMatch	doid:DOID:0111556	Steatocystoma Multiplex	steatocystoma multiplex	orcid:0000-0001-9439-5346	CC0
-mesh:D062765	skos:exactMatch	hgnc:14686	Junctional Adhesion Molecule B	JAM2	orcid:0000-0001-9439-5346	CC0
-mesh:D062786	skos:exactMatch	hgnc:15532	Junctional Adhesion Molecule C	JAM3	orcid:0000-0001-9439-5346	CC0
-mesh:D061988	skos:exactMatch	ncit:C2160	Proteasome Inhibitors	Proteasome Inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D061986	skos:exactMatch	ncit:C18096	MCF-7 Cells	MCF7	orcid:0000-0001-9439-5346	CC0
-mesh:D061965	skos:exactMatch	chebi:CHEBI:50664	Matrix Metalloproteinase Inhibitors	matrix metalloproteinase inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D062245	skos:exactMatch	ncit:C127112	RxNorm	RxNorm	orcid:0000-0001-9439-5346	CC0
-mesh:D062187	skos:exactMatch	ncit:C21023	Spinal Cord Stimulation	Spinal Cord Stimulation	orcid:0000-0001-9439-5346	CC0
-mesh:D062085	skos:exactMatch	ncit:C88924	RNA, Long Noncoding	LincRNA	orcid:0000-0001-9439-5346	CC0
-mesh:D062071	skos:exactMatch	ncit:C114939	Infant, Extremely Premature	Extremely Preterm Infant	orcid:0000-0001-9439-5346	CC0
-mesh:D062048	skos:exactMatch	ncit:C116496	Narrow Band Imaging	Narrow Band Imaging	orcid:0000-0001-9439-5346	CC0
-mesh:D062365	skos:exactMatch	chebi:CHEBI:22494	Aminobenzoates	aminobenzoate	orcid:0000-0001-9439-5346	CC0
-mesh:D062346	skos:exactMatch	ncit:C18885	Molecular Medicine	Molecular Medicine	orcid:0000-0001-9439-5346	CC0
-mesh:D061466	skos:exactMatch	chebi:CHEBI:31781	Lopinavir	lopinavir	orcid:0000-0001-9439-5346	CC0
-mesh:D000001	skos:exactMatch	chebi:CHEBI:3305	Calcimycin	Calcimycin	orcid:0000-0001-9439-5346	CC0
-mesh:D000019	skos:exactMatch	chebi:CHEBI:50691	Abortifacient Agents	abortifacient	orcid:0000-0001-9439-5346	CC0
-mesh:D000068180	skos:exactMatch	chebi:CHEBI:31236	Aripiprazole	aripiprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D000068338	skos:exactMatch	chebi:CHEBI:68478	Everolimus	everolimus	orcid:0000-0001-9439-5346	CC0
-mesh:D000068576	skos:exactMatch	chebi:CHEBI:5938	Interferon beta-1b	Interferon beta-1b	orcid:0000-0001-9439-5346	CC0
-mesh:D000068679	skos:exactMatch	chebi:CHEBI:31536	Emtricitabine	emtricitabine	orcid:0000-0001-9439-5346	CC0
-mesh:D000068796	skos:exactMatch	chebi:CHEBI:83296	Orexin Receptor Antagonists	orexin receptor antagonist	orcid:0000-0001-9439-5346	CC0
-mesh:D000069059	skos:exactMatch	chebi:CHEBI:39548	Atorvastatin	atorvastatin	orcid:0000-0001-9439-5346	CC0
-mesh:D000069349	skos:exactMatch	chebi:CHEBI:63607	Linezolid	linezolid	orcid:0000-0001-9439-5346	CC0
-mesh:D000069557	skos:exactMatch	chebi:CHEBI:746859	Travoprost	travoprost	orcid:0000-0001-9439-5346	CC0
-mesh:D000070	skos:exactMatch	chebi:CHEBI:2379	Acebutolol	acebutolol	orcid:0000-0001-9439-5346	CC0
-mesh:D000072318	skos:exactMatch	chebi:CHEBI:38922	Dibenzofurans	dibenzofurans	orcid:0000-0001-9439-5346	CC0
-mesh:D000072376	skos:exactMatch	chebi:CHEBI:53030	Oxysterols	oxysterol	orcid:0000-0001-9439-5346	CC0
-mesh:D000072664	skos:exactMatch	chebi:CHEBI:50188	Provitamins	provitamin	orcid:0000-0001-9439-5346	CC0
-mesh:D000073	skos:exactMatch	chebi:CHEBI:22156	Acenaphthenes	acenaphthenes	orcid:0000-0001-9439-5346	CC0
-mesh:D000074382	skos:exactMatch	chebi:CHEBI:76413	Greenhouse Gases	greenhouse gas	orcid:0000-0001-9439-5346	CC0
-mesh:D000075163	skos:exactMatch	chebi:CHEBI:33963	Metallocenes	metallocene	orcid:0000-0001-9439-5346	CC0
-mesh:D000077145	skos:exactMatch	chebi:CHEBI:45373	Sulfanilamide	sulfanilamide	orcid:0000-0001-9439-5346	CC0
-mesh:D000077149	skos:exactMatch	chebi:CHEBI:9130	Sevoflurane	sevoflurane	orcid:0000-0001-9439-5346	CC0
-mesh:D000077150	skos:exactMatch	chebi:CHEBI:31941	Oxaliplatin	oxaliplatin	orcid:0000-0001-9439-5346	CC0
-mesh:D000077157	skos:exactMatch	chebi:CHEBI:50924	Sorafenib	sorafenib	orcid:0000-0001-9439-5346	CC0
-mesh:D000077205	skos:exactMatch	chebi:CHEBI:8228	Pioglitazone	pioglitazone	orcid:0000-0001-9439-5346	CC0
-mesh:D000077208	skos:exactMatch	chebi:CHEBI:8802	Remifentanil	remifentanil	orcid:0000-0001-9439-5346	CC0
-mesh:D000077210	skos:exactMatch	chebi:CHEBI:38940	Sunitinib	sunitinib	orcid:0000-0001-9439-5346	CC0
-mesh:D000077222	skos:exactMatch	chebi:CHEBI:15384	Limonene	limonene	orcid:0000-0001-9439-5346	CC0
-mesh:D000077236	skos:exactMatch	chebi:CHEBI:63631	Topiramate	topiramate	orcid:0000-0001-9439-5346	CC0
-mesh:D000077261	skos:exactMatch	chebi:CHEBI:3441	Carvedilol	carvedilol	orcid:0000-0001-9439-5346	CC0
-mesh:D000077266	skos:exactMatch	chebi:CHEBI:63611	Moxifloxacin	moxifloxacin	orcid:0000-0001-9439-5346	CC0
-mesh:D000077271	skos:exactMatch	chebi:CHEBI:36704	Imiquimod	imiquimod	orcid:0000-0001-9439-5346	CC0
-mesh:D000077276	skos:exactMatch	chebi:CHEBI:15948	Lycopene	lycopene	orcid:0000-0001-9439-5346	CC0
-mesh:D000077287	skos:exactMatch	chebi:CHEBI:6437	Levetiracetam	levetiracetam	orcid:0000-0001-9439-5346	CC0
-mesh:D000072338	skos:exactMatch	chebi:CHEBI:134046	Dibenzofurans, Polychlorinated	polychlorinated dibenzofuran	orcid:0000-0001-9439-5346	CC0
-mesh:D000072317	skos:exactMatch	chebi:CHEBI:36682	Polychlorinated Dibenzodioxins	polychlorinated dibenzodioxine	orcid:0000-0001-9439-5346	CC0
-mesh:D000077290	skos:exactMatch	chebi:CHEBI:61379	Harmala Alkaloids	harmala alkaloid	orcid:0000-0001-9439-5346	CC0
-mesh:D000077289	skos:exactMatch	chebi:CHEBI:6413	Letrozole	letrozole	orcid:0000-0001-9439-5346	CC0
-mesh:D000077288	skos:exactMatch	chebi:CHEBI:9753	Troglitazone	troglitazone	orcid:0000-0001-9439-5346	CC0
-mesh:D000077335	skos:exactMatch	chebi:CHEBI:4445	Desflurane	desflurane	orcid:0000-0001-9439-5346	CC0
-mesh:D000077336	skos:exactMatch	chebi:CHEBI:474180	Caspofungin	caspofungin	orcid:0000-0001-9439-5346	CC0
-mesh:D000077339	skos:exactMatch	chebi:CHEBI:6402	Leflunomide	leflunomide	orcid:0000-0001-9439-5346	CC0
-mesh:D000077405	skos:exactMatch	chebi:CHEBI:5959	Irbesartan	irbesartan	orcid:0000-0001-9439-5346	CC0
-mesh:D000077409	skos:exactMatch	chebi:CHEBI:9398	Tamsulosin	tamsulosin	orcid:0000-0001-9439-5346	CC0
-mesh:D000077333	skos:exactMatch	chebi:CHEBI:9434	Telmisartan	telmisartan	orcid:0000-0001-9439-5346	CC0
-mesh:D000077422	skos:exactMatch	chebi:CHEBI:35720	Enrofloxacin	enrofloxacin	orcid:0000-0001-9439-5346	CC0
-mesh:D000077465	skos:exactMatch	chebi:CHEBI:3286	Cabergoline	cabergoline	orcid:0000-0001-9439-5346	CC0
-mesh:D000077466	skos:exactMatch	chebi:CHEBI:9605	Tirofiban	tirofiban	orcid:0000-0001-9439-5346	CC0
-mesh:D000077484	skos:exactMatch	chebi:CHEBI:63637	Vemurafenib	vemurafenib	orcid:0000-0001-9439-5346	CC0
-mesh:D000077545	skos:exactMatch	chebi:CHEBI:31547	Eplerenone	eplerenone	orcid:0000-0001-9439-5346	CC0
-mesh:D000077553	skos:exactMatch	chebi:CHEBI:31530	Edaravone	edaravone	orcid:0000-0001-9439-5346	CC0
-mesh:D000077554	skos:exactMatch	chebi:CHEBI:6149	Levobupivacaine	levobupivacaine	orcid:0000-0001-9439-5346	CC0
-mesh:D000077583	skos:exactMatch	chebi:CHEBI:8713	Quinapril	quinapril	orcid:0000-0001-9439-5346	CC0
-mesh:D000077590	skos:exactMatch	chebi:CHEBI:6958	Mivacurium	Mivacurium	orcid:0000-0001-9439-5346	CC0
-mesh:D000077609	skos:exactMatch	chebi:CHEBI:90748	O-(Chloroacetylcarbamoyl)fumagillol	O-(chloroacetylcarbamoyl)fumagillol	orcid:0000-0001-9439-5346	CC0
-mesh:D000077613	skos:exactMatch	chebi:CHEBI:6339	Etoricoxib	etoricoxib	orcid:0000-0001-9439-5346	CC0
-mesh:D000077723	skos:exactMatch	chebi:CHEBI:478164	Cefepime	cefepime	orcid:0000-0001-9439-5346	CC0
-mesh:D000077731	skos:exactMatch	chebi:CHEBI:43968	Meropenem	meropenem	orcid:0000-0001-9439-5346	CC0
-mesh:D000078183	skos:exactMatch	chebi:CHEBI:38459	Oxindoles	oxindoles	orcid:0000-0001-9439-5346	CC0
-mesh:D000078102	skos:exactMatch	chebi:CHEBI:156095	Lumefantrine	lumefantrine	orcid:0000-0001-9439-5346	CC0
-mesh:D000077922	skos:exactMatch	chebi:CHEBI:39185	Thiamethoxam	thiamethoxam	orcid:0000-0001-9439-5346	CC0
-mesh:D000077771	skos:exactMatch	chebi:CHEBI:6817	Methantheline	Methantheline	orcid:0000-0001-9439-5346	CC0
-mesh:D000077770	skos:exactMatch	chebi:CHEBI:135948	Amifampridine	amifampridine	orcid:0000-0001-9439-5346	CC0
-mesh:D000077769	skos:exactMatch	chebi:CHEBI:8862	Rilmenidine	Rilmenidine	orcid:0000-0001-9439-5346	CC0
-mesh:D000078223	skos:exactMatch	chebi:CHEBI:18293	5-Methoxypsoralen	5-methoxypsoralen	orcid:0000-0001-9439-5346	CC0
-mesh:D000078328	skos:exactMatch	chebi:CHEBI:4995	Felbamate	felbamate	orcid:0000-0001-9439-5346	CC0
-mesh:D000078330	skos:exactMatch	chebi:CHEBI:7824	Oxcarbazepine	oxcarbazepine	orcid:0000-0001-9439-5346	CC0
-mesh:D000078604	skos:exactMatch	chebi:CHEBI:90414	Secretagogues	secretagogue	orcid:0000-0001-9439-5346	CC0
-mesh:D000078785	skos:exactMatch	chebi:CHEBI:6950	Mirtazapine	mirtazapine	orcid:0000-0001-9439-5346	CC0
-mesh:D000078789	skos:exactMatch	chebi:CHEBI:60552	Polyacetylene Polymer	polyacetylene polymer	orcid:0000-0001-9439-5346	CC0
-mesh:D000079	skos:exactMatch	chebi:CHEBI:15343	Acetaldehyde	acetaldehyde	orcid:0000-0001-9439-5346	CC0
-mesh:D000080	skos:exactMatch	chebi:CHEBI:59769	Acetals	acetal	orcid:0000-0001-9439-5346	CC0
-mesh:D000080084	skos:exactMatch	chebi:CHEBI:64068	Calicheamicins	calicheamicin	orcid:0000-0001-9439-5346	CC0
-mesh:D000081	skos:exactMatch	chebi:CHEBI:22160	Acetamides	acetamides	orcid:0000-0001-9439-5346	CC0
-mesh:D000081026	skos:exactMatch	chebi:CHEBI:26199	Polyprenols	polyprenol	orcid:0000-0001-9439-5346	CC0
-mesh:D000081503	skos:exactMatch	chebi:CHEBI:51185	Organoiron Compounds	organoiron compound	orcid:0000-0001-9439-5346	CC0
-mesh:D000086	skos:exactMatch	chebi:CHEBI:27690	Acetazolamide	acetazolamide	orcid:0000-0001-9439-5346	CC0
-mesh:D000093	skos:exactMatch	chebi:CHEBI:15688	Acetoin	acetoin	orcid:0000-0001-9439-5346	CC0
-mesh:D000096	skos:exactMatch	chebi:CHEBI:15347	Acetone	acetone	orcid:0000-0001-9439-5346	CC0
-mesh:D000098	skos:exactMatch	chebi:CHEBI:22187	Acetophenones	acetophenones	orcid:0000-0001-9439-5346	CC0
-mesh:D000109	skos:exactMatch	chebi:CHEBI:15355	Acetylcholine	acetylcholine	orcid:0000-0001-9439-5346	CC0
-mesh:D000114	skos:exactMatch	chebi:CHEBI:27518	Acetylene	acetylene	orcid:0000-0001-9439-5346	CC0
-mesh:D000156	skos:exactMatch	chebi:CHEBI:22211	Aconitic Acid	aconitic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D000157	skos:exactMatch	chebi:CHEBI:2430	Aconitine	aconitine	orcid:0000-0001-9439-5346	CC0
-mesh:D000165	skos:exactMatch	chebi:CHEBI:51739	Acridine Orange	acridine orange	orcid:0000-0001-9439-5346	CC0
-mesh:D000166	skos:exactMatch	chebi:CHEBI:22213	Acridines	acridines	orcid:0000-0001-9439-5346	CC0
-mesh:D000171	skos:exactMatch	chebi:CHEBI:15368	Acrolein	acrolein	orcid:0000-0001-9439-5346	CC0
-mesh:D000145	skos:exactMatch	chebi:CHEBI:26643	Acids, Aldehydic	aldehydic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D000178	skos:exactMatch	chebi:CHEBI:22216	Acrylamides	acrylamides	orcid:0000-0001-9439-5346	CC0
-mesh:D000181	skos:exactMatch	chebi:CHEBI:28217	Acrylonitrile	acrylonitrile	orcid:0000-0001-9439-5346	CC0
-mesh:D000186	skos:exactMatch	chebi:CHEBI:33337	Actinium	actinium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D000225	skos:exactMatch	chebi:CHEBI:16708	Adenine	adenine	orcid:0000-0001-9439-5346	CC0
-mesh:D000241	skos:exactMatch	chebi:CHEBI:16335	Adenosine	adenosine	orcid:0000-0001-9439-5346	CC0
-mesh:D000255	skos:exactMatch	chebi:CHEBI:15422	Adenosine Triphosphate	ATP	orcid:0000-0001-9439-5346	CC0
-mesh:D000325	skos:exactMatch	chebi:CHEBI:48962	Adrenodoxin	adrenodoxin	orcid:0000-0001-9439-5346	CC0
-mesh:D000345	skos:exactMatch	chebi:CHEBI:60788	Affinity Labels	affinity label	orcid:0000-0001-9439-5346	CC0
-mesh:D000376	skos:exactMatch	chebi:CHEBI:17431	Agmatine	agmatine	orcid:0000-0001-9439-5346	CC0
-mesh:D000404	skos:exactMatch	chebi:CHEBI:28462	Ajmaline	ajmaline	orcid:0000-0001-9439-5346	CC0
-mesh:D000409	skos:exactMatch	chebi:CHEBI:16449	Alanine	alanine	orcid:0000-0001-9439-5346	CC0
-mesh:D000420	skos:exactMatch	chebi:CHEBI:2549	Albuterol	albuterol	orcid:0000-0001-9439-5346	CC0
-mesh:D000431	skos:exactMatch	chebi:CHEBI:16236	Ethanol	ethanol	orcid:0000-0001-9439-5346	CC0
-mesh:D000432	skos:exactMatch	chebi:CHEBI:17790	Methanol	methanol	orcid:0000-0001-9439-5346	CC0
-mesh:D000443	skos:exactMatch	chebi:CHEBI:55313	Alcuronium	alcuronium	orcid:0000-0001-9439-5346	CC0
-mesh:D000447	skos:exactMatch	chebi:CHEBI:17478	Aldehydes	aldehyde	orcid:0000-0001-9439-5346	CC0
-mesh:D000448	skos:exactMatch	chebi:CHEBI:2555	Aldicarb	aldicarb	orcid:0000-0001-9439-5346	CC0
-mesh:D000450	skos:exactMatch	chebi:CHEBI:27584	Aldosterone	aldosterone	orcid:0000-0001-9439-5346	CC0
-mesh:D000466	skos:exactMatch	chebi:CHEBI:33646	Alkadienes	alkadiene	orcid:0000-0001-9439-5346	CC0
-mesh:D000473	skos:exactMatch	chebi:CHEBI:18310	Alkanes	alkane	orcid:0000-0001-9439-5346	CC0
-mesh:D000479	skos:exactMatch	chebi:CHEBI:33255	Alkylmercury Compounds	alkylmercury compound	orcid:0000-0001-9439-5346	CC0
-mesh:D000481	skos:exactMatch	chebi:CHEBI:15676	Allantoin	allantoin	orcid:0000-0001-9439-5346	CC0
-mesh:D000485	skos:exactMatch	chebi:CHEBI:50904	Allergens	allergen	orcid:0000-0001-9439-5346	CC0
-mesh:D000493	skos:exactMatch	chebi:CHEBI:40279	Allopurinol	allopurinol	orcid:0000-0001-9439-5346	CC0
-mesh:D000500	skos:exactMatch	chebi:CHEBI:31189	Allylestrenol	Allylestrenol	orcid:0000-0001-9439-5346	CC0
-mesh:D000523	skos:exactMatch	chebi:CHEBI:763	Algestone	algestone	orcid:0000-0001-9439-5346	CC0
-mesh:D000525	skos:exactMatch	chebi:CHEBI:2611	Alprazolam	alprazolam	orcid:0000-0001-9439-5346	CC0
-mesh:D000547	skos:exactMatch	chebi:CHEBI:2618	Amantadine	amantadine	orcid:0000-0001-9439-5346	CC0
-mesh:D000576	skos:exactMatch	chebi:CHEBI:33389	Americium	americium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D000583	skos:exactMatch	chebi:CHEBI:2637	Amikacin	amikacin	orcid:0000-0001-9439-5346	CC0
-mesh:D000584	skos:exactMatch	chebi:CHEBI:2639	Amiloride	amiloride	orcid:0000-0001-9439-5346	CC0
-mesh:D000605	skos:exactMatch	chebi:CHEBI:22478	Amino Alcohols	amino alcohol	orcid:0000-0001-9439-5346	CC0
-mesh:D000606	skos:exactMatch	chebi:CHEBI:28963	Amino Sugars	amino sugar	orcid:0000-0001-9439-5346	CC0
-mesh:D000609	skos:exactMatch	chebi:CHEBI:51803	Aminoacridines	aminoacridines	orcid:0000-0001-9439-5346	CC0
-mesh:D000625	skos:exactMatch	chebi:CHEBI:40823	Aminooxyacetic Acid	aminooxyacetic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D000628	skos:exactMatch	chebi:CHEBI:2659	Aminophylline	aminophylline	orcid:0000-0001-9439-5346	CC0
-mesh:D000631	skos:exactMatch	chebi:CHEBI:38207	Aminopyridines	aminopyridine	orcid:0000-0001-9439-5346	CC0
-mesh:D000634	skos:exactMatch	chebi:CHEBI:36709	Aminoquinolines	aminoquinoline	orcid:0000-0001-9439-5346	CC0
-mesh:D000639	skos:exactMatch	chebi:CHEBI:2666	Amitriptyline	amitriptyline	orcid:0000-0001-9439-5346	CC0
-mesh:D000640	skos:exactMatch	chebi:CHEBI:40036	Amitrole	amitrole	orcid:0000-0001-9439-5346	CC0
-mesh:D000641	skos:exactMatch	chebi:CHEBI:16134	Ammonia	ammonia	orcid:0000-0001-9439-5346	CC0
-mesh:D000644	skos:exactMatch	chebi:CHEBI:35273	Quaternary Ammonium Compounds	quaternary ammonium salt	orcid:0000-0001-9439-5346	CC0
-mesh:D000655	skos:exactMatch	chebi:CHEBI:2674	Amodiaquine	amodiaquine	orcid:0000-0001-9439-5346	CC0
-mesh:D000658	skos:exactMatch	chebi:CHEBI:2676	Amoxicillin	amoxicillin	orcid:0000-0001-9439-5346	CC0
-mesh:D000661	skos:exactMatch	chebi:CHEBI:2679	Amphetamine	amphetamine	orcid:0000-0001-9439-5346	CC0
-mesh:D000662	skos:exactMatch	chebi:CHEBI:35338	Amphetamines	amphetamines	orcid:0000-0001-9439-5346	CC0
-mesh:D000667	skos:exactMatch	chebi:CHEBI:28971	Ampicillin	ampicillin	orcid:0000-0001-9439-5346	CC0
-mesh:D000654	skos:exactMatch	chebi:CHEBI:2673	Amobarbital	amobarbital	orcid:0000-0001-9439-5346	CC0
-mesh:D000638	skos:exactMatch	chebi:CHEBI:2663	Amiodarone	amiodarone	orcid:0000-0001-9439-5346	CC0
-mesh:D000701	skos:exactMatch	chebi:CHEBI:35482	Analgesics, Opioid	opioid analgesic	orcid:0000-0001-9439-5346	CC0
-mesh:D000968	skos:exactMatch	chebi:CHEBI:2762	Antimycin A	antimycin A	orcid:0000-0001-9439-5346	CC0
-mesh:D000931	skos:exactMatch	chebi:CHEBI:50247	Antidotes	antidote	orcid:0000-0001-9439-5346	CC0
-mesh:D000983	skos:exactMatch	chebi:CHEBI:31225	Antipyrine	antipyrine	orcid:0000-0001-9439-5346	CC0
-mesh:D000982	skos:exactMatch	chebi:CHEBI:59683	Antipruritics	antipruritic drug	orcid:0000-0001-9439-5346	CC0
-mesh:D000981	skos:exactMatch	chebi:CHEBI:35820	Antiprotozoal Agents	antiprotozoal drug	orcid:0000-0001-9439-5346	CC0
-mesh:D000980	skos:exactMatch	chebi:CHEBI:35684	Antiplatyhelmintic Agents	antiplatyhelmintic drug	orcid:0000-0001-9439-5346	CC0
-mesh:D000935	skos:exactMatch	chebi:CHEBI:35718	Antifungal Agents	antifungal agent	orcid:0000-0001-9439-5346	CC0
-mesh:D000934	skos:exactMatch	chebi:CHEBI:77973	Antifoaming Agents	antifoaming agent	orcid:0000-0001-9439-5346	CC0
-mesh:D000933	skos:exactMatch	chebi:CHEBI:48675	Antifibrinolytic Agents	antifibrinolytic drug	orcid:0000-0001-9439-5346	CC0
-mesh:D000924	skos:exactMatch	chebi:CHEBI:35821	Anticholesteremic Agents	anticholesteremic drug	orcid:0000-0001-9439-5346	CC0
-mesh:D000897	skos:exactMatch	chebi:CHEBI:49201	Anti-Ulcer Agents	anti-ulcer drug	orcid:0000-0001-9439-5346	CC0
-mesh:D001074	skos:exactMatch	chebi:CHEBI:34938	Propoxur	propoxur	orcid:0000-0001-9439-5346	CC0
-mesh:D001059	skos:exactMatch	chebi:CHEBI:13850	Apoproteins	apoprotein	orcid:0000-0001-9439-5346	CC0
-mesh:D001052	skos:exactMatch	chebi:CHEBI:2784	Apoferritins	Apoferritin	orcid:0000-0001-9439-5346	CC0
-mesh:D000995	skos:exactMatch	chebi:CHEBI:33231	Antitubercular Agents	antitubercular agent	orcid:0000-0001-9439-5346	CC0
-mesh:D001120	skos:exactMatch	chebi:CHEBI:29016	Arginine	arginine	orcid:0000-0001-9439-5346	CC0
-mesh:D001147	skos:exactMatch	chebi:CHEBI:49477	Arsanilic Acid	arsanilic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D001151	skos:exactMatch	chebi:CHEBI:27563	Arsenic	arsenic atom	orcid:0000-0001-9439-5346	CC0
-mesh:D001153	skos:exactMatch	chebi:CHEBI:9016	Arsphenamine	arsphenamine	orcid:0000-0001-9439-5346	CC0
-mesh:D001252	skos:exactMatch	chebi:CHEBI:74783	Astringents	astringent	orcid:0000-0001-9439-5346	CC0
-mesh:D001278	skos:exactMatch	chebi:CHEBI:2913	Atractyloside	Atractyloside	orcid:0000-0001-9439-5346	CC0
-mesh:D001279	skos:exactMatch	chebi:CHEBI:2914	Atracurium	atracurium	orcid:0000-0001-9439-5346	CC0
-mesh:D001280	skos:exactMatch	chebi:CHEBI:15930	Atrazine	atrazine	orcid:0000-0001-9439-5346	CC0
-mesh:D001285	skos:exactMatch	chebi:CHEBI:16684	Atropine	atropine	orcid:0000-0001-9439-5346	CC0
-mesh:D001430	skos:exactMatch	chebi:CHEBI:48081	Bacteriocins	bacteriocin	orcid:0000-0001-9439-5346	CC0
-mesh:D001429	skos:exactMatch	chebi:CHEBI:38201	Bacteriochlorophylls	bacteriochlorophyll	orcid:0000-0001-9439-5346	CC0
-mesh:D001414	skos:exactMatch	chebi:CHEBI:28669	Bacitracin	bacitracin	orcid:0000-0001-9439-5346	CC0
-mesh:D001391	skos:exactMatch	chebi:CHEBI:37533	Azo Compounds	azo compound	orcid:0000-0001-9439-5346	CC0
-mesh:D001384	skos:exactMatch	chebi:CHEBI:38777	Azetidines	azetidines	orcid:0000-0001-9439-5346	CC0
-mesh:D001565	skos:exactMatch	chebi:CHEBI:22718	Benzoates	benzoates	orcid:0000-0001-9439-5346	CC0
-mesh:D001566	skos:exactMatch	chebi:CHEBI:116735	Benzocaine	benzocaine	orcid:0000-0001-9439-5346	CC0
-mesh:D001554	skos:exactMatch	chebi:CHEBI:16716	Benzene	benzene	orcid:0000-0001-9439-5346	CC0
-mesh:D001556	skos:exactMatch	chebi:CHEBI:24536	Hexachlorocyclohexane	hexachlorocyclohexane	orcid:0000-0001-9439-5346	CC0
-mesh:D001573	skos:exactMatch	chebi:CHEBI:17682	Benzoin	benzoin	orcid:0000-0001-9439-5346	CC0
-mesh:D001577	skos:exactMatch	chebi:CHEBI:22726	Benzophenones	benzophenones	orcid:0000-0001-9439-5346	CC0
-mesh:D001583	skos:exactMatch	chebi:CHEBI:46700	Benzoxazoles	benzoxazole	orcid:0000-0001-9439-5346	CC0
-mesh:D001589	skos:exactMatch	chebi:CHEBI:3044	Benzphetamine	benzphetamine	orcid:0000-0001-9439-5346	CC0
-mesh:D001572	skos:exactMatch	chebi:CHEBI:35259	Benzofurans	benzofurans	orcid:0000-0001-9439-5346	CC0
-mesh:D065808	skos:exactMatch	go:GO:0060134	Prepulse Inhibition	prepulse inhibition	orcid:0000-0001-9439-5346	CC0
-mesh:D065819	skos:exactMatch	chebi:CHEBI:10023	Voriconazole	voriconazole	orcid:0000-0001-9439-5346	CC0
-mesh:D065766	skos:exactMatch	doid:DOID:0080301	Atypical Hemolytic Uremic Syndrome	atypical hemolytic-uremic syndrome	orcid:0000-0001-9439-5346	CC0
-mesh:D064704	skos:exactMatch	chebi:CHEBI:63598	Levofloxacin	levofloxacin	orcid:0000-0001-9439-5346	CC0
-mesh:D064747	skos:exactMatch	chebi:CHEBI:6375	Lansoprazole	lansoprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D064748	skos:exactMatch	chebi:CHEBI:135931	Dexlansoprazole	dexlansoprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D064107	skos:exactMatch	hgnc:11390	Aurora Kinase B	AURKB	orcid:0000-0001-9439-5346	CC0
-mesh:D064098	skos:exactMatch	chebi:CHEBI:50275	Esomeprazole	esomeprazole	orcid:0000-0001-9439-5346	CC0
-mesh:D064096	skos:exactMatch	hgnc:11393	Aurora Kinase A	AURKA	orcid:0000-0001-9439-5346	CC0
-mesh:D064048	skos:exactMatch	go:GO:0005816	Spindle Pole Bodies	spindle pole body	orcid:0000-0001-9439-5346	CC0
-mesh:D061346	skos:exactMatch	efo:0009111	Laser Capture Microdissection	laser capture microdissection	orcid:0000-0001-9439-5346	CC0
-mesh:D061988	skos:exactMatch	chebi:CHEBI:52726	Proteasome Inhibitors	proteasome inhibitor	orcid:0000-0001-9439-5346	CC0
-mesh:D062556	skos:exactMatch	hgnc:10597	NAV1.7 Voltage-Gated Sodium Channel	SCN9A	orcid:0000-0001-9439-5346	CC0
-mesh:D059748	skos:exactMatch	go:GO:0006508	Proteolysis	proteolysis	orcid:0000-0001-9439-5346	CC0
-mesh:D059765	skos:exactMatch	go:GO:0035825	Homologous Recombination	homologous recombination	orcid:0000-0001-9439-5346	CC0
-mesh:D059370	skos:exactMatch	go:GO:0034337	RNA Folding	RNA folding	orcid:0000-0001-9439-5346	CC0
-mesh:D059246	skos:exactMatch	efo:0009840	Tachypnea	tachypnea	orcid:0000-0001-9439-5346	CC0
-mesh:D059390	skos:exactMatch	hp:HP:0032149	Breakthrough Pain	Breakthrough pain	orcid:0000-0001-9439-5346	CC0
-mesh:D059630	skos:exactMatch	efo:0000586	Mesenchymal Stem Cells	mesenchymal stem cell	orcid:0000-0001-9439-5346	CC0
-mesh:D058924	skos:exactMatch	chebi:CHEBI:37942	Thienopyridines	thienopyridine	orcid:0000-0001-9439-5346	CC0
-mesh:D056892	skos:exactMatch	go:GO:0016592	Mediator Complex	mediator complex	orcid:0000-0001-9439-5346	CC0
-mesh:D056850	skos:exactMatch	hgnc:1779	Cyclin-Dependent Kinase 8	CDK8	orcid:0000-0001-9439-5346	CC0
-mesh:D056743	skos:exactMatch	hgnc:1585	Cyclin D3	CCND3	orcid:0000-0001-9439-5346	CC0
-mesh:D056744	skos:exactMatch	hgnc:1579	Cyclin B1	CCNB1	orcid:0000-0001-9439-5346	CC0
-mesh:D056748	skos:exactMatch	hgnc:1594	Cyclin H	CCNH	orcid:0000-0001-9439-5346	CC0
-mesh:D056750	skos:exactMatch	hgnc:1577	Cyclin A1	CCNA1	orcid:0000-0001-9439-5346	CC0
-mesh:D056751	skos:exactMatch	hgnc:1578	Cyclin A2	CCNA2	orcid:0000-0001-9439-5346	CC0
-mesh:D056765	skos:exactMatch	hgnc:1580	Cyclin B2	CCNB2	orcid:0000-0001-9439-5346	CC0
-mesh:D056807	skos:exactMatch	hp:HP:0025630	Argininosuccinic Aciduria	Argininosuccinic aciduria	orcid:0000-0001-9439-5346	CC0
-mesh:D056833	skos:exactMatch	hp:HP:0025567	Central Serous Chorioretinopathy	Central serous chorioretinopathy	orcid:0000-0001-9439-5346	CC0
-mesh:D056849	skos:exactMatch	hgnc:1772	Cyclin-Dependent Kinase 3	CDK3	orcid:0000-0001-9439-5346	CC0
-mesh:D055531	skos:exactMatch	go:GO:0097504	Gemini of Coiled Bodies	Gemini of coiled bodies	orcid:0000-0001-9439-5346	CC0
-mesh:D055495	skos:exactMatch	go:GO:0022008	Neurogenesis	neurogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D055623	skos:exactMatch	hp:HP:0025127	Keratosis, Actinic	Actinic keratosis	orcid:0000-0001-9439-5346	CC0
-mesh:D055417	skos:exactMatch	hgnc:1072	Bone Morphogenetic Protein 5	BMP5	orcid:0000-0001-9439-5346	CC0
-mesh:D055418	skos:exactMatch	hgnc:1073	Bone Morphogenetic Protein 6	BMP6	orcid:0000-0001-9439-5346	CC0
-mesh:D055419	skos:exactMatch	hgnc:1074	Bone Morphogenetic Protein 7	BMP7	orcid:0000-0001-9439-5346	CC0
-mesh:D055427	skos:exactMatch	hgnc:4217	Growth Differentiation Factor 2	GDF2	orcid:0000-0001-9439-5346	CC0
-mesh:D055428	skos:exactMatch	hgnc:4220	Growth Differentiation Factor 5	GDF5	orcid:0000-0001-9439-5346	CC0
-mesh:D055429	skos:exactMatch	hgnc:4224	Growth Differentiation Factor 9	GDF9	orcid:0000-0001-9439-5346	CC0
-mesh:D055423	skos:exactMatch	efo:0009371	Diet, Ketogenic	ketogenic diet	orcid:0000-0001-9439-5346	CC0
-mesh:D055430	skos:exactMatch	hgnc:1068	Bone Morphogenetic Protein 15	BMP15	orcid:0000-0001-9439-5346	CC0
-mesh:D055436	skos:exactMatch	hgnc:30142	Growth Differentiation Factor 15	GDF15	orcid:0000-0001-9439-5346	CC0
-mesh:D055451	skos:exactMatch	hgnc:4218	Growth Differentiation Factor 3	GDF3	orcid:0000-0001-9439-5346	CC0
-mesh:D055415	skos:exactMatch	hgnc:1071	Bone Morphogenetic Protein 4	BMP4	orcid:0000-0001-9439-5346	CC0
-mesh:D055398	skos:exactMatch	hgnc:1070	Bone Morphogenetic Protein 3	BMP3	orcid:0000-0001-9439-5346	CC0
-mesh:D055413	skos:exactMatch	hgnc:4215	Growth Differentiation Factor 10	GDF10	orcid:0000-0001-9439-5346	CC0
-mesh:D054876	skos:exactMatch	go:GO:0097354	Prenylation	prenylation	orcid:0000-0001-9439-5346	CC0
-mesh:D054816	skos:exactMatch	chebi:CHEBI:51174	Levopropoxyphene	levopropoxyphene	orcid:0000-0001-9439-5346	CC0
-mesh:D055257	skos:exactMatch	hgnc:7516	Mucin-5B	MUC5B	orcid:0000-0001-9439-5346	CC0
-mesh:D055262	skos:exactMatch	hgnc:7512	Mucin-2	MUC2	orcid:0000-0001-9439-5346	CC0
-mesh:D055272	skos:exactMatch	hgnc:7517	Mucin-6	MUC6	orcid:0000-0001-9439-5346	CC0
-mesh:D054638	skos:exactMatch	hgnc:3064	Dual Specificity Phosphatase 1	DUSP1	orcid:0000-0001-9439-5346	CC0
-mesh:D054640	skos:exactMatch	hgnc:3069	Dual Specificity Phosphatase 3	DUSP3	orcid:0000-0001-9439-5346	CC0
-mesh:D054642	skos:exactMatch	hgnc:3072	Dual Specificity Phosphatase 6	DUSP6	orcid:0000-0001-9439-5346	CC0
-mesh:D054414	skos:exactMatch	hgnc:10615	Chemokine CCL17	CCL17	orcid:0000-0001-9439-5346	CC0
-mesh:D054415	skos:exactMatch	hgnc:10617	Chemokine CCL19	CCL19	orcid:0000-0001-9439-5346	CC0
-mesh:D054418	skos:exactMatch	hgnc:10619	Chemokine CCL20	CCL20	orcid:0000-0001-9439-5346	CC0
-mesh:D054422	skos:exactMatch	hgnc:10621	Chemokine CCL22	CCL22	orcid:0000-0001-9439-5346	CC0
-mesh:D054423	skos:exactMatch	hgnc:10623	Chemokine CCL24	CCL24	orcid:0000-0001-9439-5346	CC0
-mesh:D054425	skos:exactMatch	hgnc:10626	Chemokine CCL27	CCL27	orcid:0000-0001-9439-5346	CC0
-mesh:D054426	skos:exactMatch	hgnc:4603	Chemokine CXCL2	CXCL2	orcid:0000-0001-9439-5346	CC0
-mesh:D054427	skos:exactMatch	hgnc:10643	Chemokine CXCL6	CXCL6	orcid:0000-0001-9439-5346	CC0
-mesh:D054447	skos:exactMatch	hgnc:4474	Receptors, CCR10	CCR10	orcid:0000-0001-9439-5346	CC0
-mesh:D054377	skos:exactMatch	hgnc:10672	Chemokine CXCL12	CXCL12	orcid:0000-0001-9439-5346	CC0
-mesh:D054380	skos:exactMatch	hgnc:1060	Receptors, CXCR5	CXCR5	orcid:0000-0001-9439-5346	CC0
-mesh:D054390	skos:exactMatch	hgnc:1603	Receptors, CCR2	CCR2	orcid:0000-0001-9439-5346	CC0
-mesh:D054397	skos:exactMatch	hgnc:1604	Receptors, CCR3	CCR3	orcid:0000-0001-9439-5346	CC0
-mesh:D054405	skos:exactMatch	hgnc:10627	Chemokine CCL3	CCL3	orcid:0000-0001-9439-5346	CC0
-mesh:D054410	skos:exactMatch	hgnc:10634	Chemokine CCL7	CCL7	orcid:0000-0001-9439-5346	CC0
-mesh:D054412	skos:exactMatch	hgnc:10635	Chemokine CCL8	CCL8	orcid:0000-0001-9439-5346	CC0
-mesh:D054341	skos:exactMatch	hgnc:6338	Receptors, KIR3DL1	KIR3DL1	orcid:0000-0001-9439-5346	CC0
-mesh:D054342	skos:exactMatch	hgnc:6329	Receptors, KIR2DL1	KIR2DL1	orcid:0000-0001-9439-5346	CC0
-mesh:D054343	skos:exactMatch	hgnc:6330	Receptors, KIR2DL2	KIR2DL2	orcid:0000-0001-9439-5346	CC0
-mesh:D054344	skos:exactMatch	hgnc:6331	Receptors, KIR2DL3	KIR2DL3	orcid:0000-0001-9439-5346	CC0
-mesh:D054347	skos:exactMatch	hgnc:6339	Receptors, KIR3DL2	KIR3DL2	orcid:0000-0001-9439-5346	CC0
-mesh:D054360	skos:exactMatch	hgnc:4602	Chemokine CXCL1	CXCL1	orcid:0000-0001-9439-5346	CC0
-mesh:D053781	skos:exactMatch	hgnc:11768	Transforming Growth Factor beta2	TGFB2	orcid:0000-0001-9439-5346	CC0
-mesh:D053782	skos:exactMatch	hgnc:11769	Transforming Growth Factor beta3	TGFB3	orcid:0000-0001-9439-5346	CC0
-mesh:D054079	skos:exactMatch	efo:0006888	Vascular Malformations	vascular malformation	orcid:0000-0001-9439-5346	CC0
-mesh:D053613	skos:exactMatch	hgnc:6190	Janus Kinase 1	JAK1	orcid:0000-0001-9439-5346	CC0
-mesh:D053614	skos:exactMatch	hgnc:6192	Janus Kinase 2	JAK2	orcid:0000-0001-9439-5346	CC0
-mesh:D053616	skos:exactMatch	hgnc:6193	Janus Kinase 3	JAK3	orcid:0000-0001-9439-5346	CC0
-mesh:D053626	skos:exactMatch	chebi:CHEBI:575568	Atovaquone	atovaquone	orcid:0000-0001-9439-5346	CC0
-mesh:D053634	skos:exactMatch	hgnc:12440	TYK2 Kinase	TYK2	orcid:0000-0001-9439-5346	CC0
-mesh:D053533	skos:exactMatch	hgnc:6446	Keratin-8	KRT8	orcid:0000-0001-9439-5346	CC0
-mesh:D053535	skos:exactMatch	hgnc:6415	Keratin-13	KRT13	orcid:0000-0001-9439-5346	CC0
-mesh:D053537	skos:exactMatch	hgnc:6427	Keratin-17	KRT17	orcid:0000-0001-9439-5346	CC0
-mesh:D053538	skos:exactMatch	hgnc:6430	Keratin-18	KRT18	orcid:0000-0001-9439-5346	CC0
-mesh:D053539	skos:exactMatch	hgnc:6436	Keratin-19	KRT19	orcid:0000-0001-9439-5346	CC0
-mesh:D053179	skos:exactMatch	hgnc:1508	Caspase 7	CASP7	orcid:0000-0001-9439-5346	CC0
-mesh:D053181	skos:exactMatch	hgnc:1509	Caspase 8	CASP8	orcid:0000-0001-9439-5346	CC0
-mesh:D051526	skos:exactMatch	hgnc:3666	Fibroblast Growth Factor 10	FGF10	orcid:0000-0001-9439-5346	CC0
-mesh:D051538	skos:exactMatch	hgnc:11621	Hepatocyte Nuclear Factor 1-alpha	HNF1A	orcid:0000-0001-9439-5346	CC0
-mesh:D051539	skos:exactMatch	hgnc:11630	Hepatocyte Nuclear Factor 1-beta	HNF1B	orcid:0000-0001-9439-5346	CC0
-mesh:D051357	skos:exactMatch	hgnc:1771	Cyclin-Dependent Kinase 2	CDK2	orcid:0000-0001-9439-5346	CC0
-mesh:D051358	skos:exactMatch	hgnc:1773	Cyclin-Dependent Kinase 4	CDK4	orcid:0000-0001-9439-5346	CC0
-mesh:D051360	skos:exactMatch	hgnc:1774	Cyclin-Dependent Kinase 5	CDK5	orcid:0000-0001-9439-5346	CC0
-mesh:D051361	skos:exactMatch	hgnc:1777	Cyclin-Dependent Kinase 6	CDK6	orcid:0000-0001-9439-5346	CC0
-mesh:D051383	skos:exactMatch	hgnc:4564	GRB10 Adaptor Protein	GRB10	orcid:0000-0001-9439-5346	CC0
-mesh:D051523	skos:exactMatch	hgnc:3685	Fibroblast Growth Factor 7	FGF7	orcid:0000-0001-9439-5346	CC0
-mesh:D051524	skos:exactMatch	hgnc:3686	Fibroblast Growth Factor 8	FGF8	orcid:0000-0001-9439-5346	CC0
-mesh:C486356	skos:exactMatch	uniprot:P61328	FGF12 protein, human	FGF12	orcid:0000-0001-9439-5346	CC0
-mesh:C484724	skos:exactMatch	uniprot:O60258	FGF17 protein, human	FGF17	orcid:0000-0001-9439-5346	CC0
-mesh:C117476	skos:exactMatch	uniprot:O95750	FGF19 protein, human	FGF19	orcid:0000-0001-9439-5346	CC0
-mesh:C496444	skos:exactMatch	uniprot:P11487	FGF3 protein, human	FGF3	orcid:0000-0001-9439-5346	CC0
-mesh:C512705	skos:exactMatch	uniprot:O43320	FGF16 protein, human	FGF16	orcid:0000-0001-9439-5346	CC0
-mesh:C496445	skos:exactMatch	uniprot:P08620	FGF4 protein, human	FGF4	orcid:0000-0001-9439-5346	CC0
-mesh:C417531	skos:exactMatch	uniprot:Q8N441	FGFRL1 protein, human	FGFRL1	orcid:0000-0001-9439-5346	CC0
-mesh:C416003	skos:exactMatch	uniprot:Q9NP95	FGF20 protein, human	FGF20	orcid:0000-0001-9439-5346	CC0
-mesh:C496463	skos:exactMatch	uniprot:O15520	FGF10 protein, human	FGF10	orcid:0000-0001-9439-5346	CC0
-mesh:C496449	skos:exactMatch	uniprot:P12034	FGF5 protein, human	FGF5	orcid:0000-0001-9439-5346	CC0
-mesh:C496452	skos:exactMatch	uniprot:P10767	FGF6 protein, human	FGF6	orcid:0000-0001-9439-5346	CC0
-mesh:C496456	skos:exactMatch	uniprot:P55075	FGF8 protein, human	FGF8	orcid:0000-0001-9439-5346	CC0
-mesh:C496459	skos:exactMatch	uniprot:P31371	FGF9 protein, human	FGF9	orcid:0000-0001-9439-5346	CC0
-mesh:C496453	skos:exactMatch	uniprot:P21781	FGF7 protein, human	FGF7	orcid:0000-0001-9439-5346	CC0
-mesh:C496353	skos:exactMatch	uniprot:P21802	FGFR2 protein, human	FGFR2	orcid:0000-0001-9439-5346	CC0
-mesh:C496365	skos:exactMatch	uniprot:P22607	FGFR3 protein, human	FGFR3	orcid:0000-0001-9439-5346	CC0
-mesh:C496371	skos:exactMatch	uniprot:P22455	FGFR4 protein, human	FGFR4	orcid:0000-0001-9439-5346	CC0
-mesh:C496348	skos:exactMatch	uniprot:P11362	FGFR1 protein, human	FGFR1	orcid:0000-0001-9439-5346	CC0
-mesh:C000627735	skos:exactMatch	uniprot:Q9HCT0	FGF22 protein, human	FGF22	orcid:0000-0001-9439-5346	CC0
-mesh:C000706947	skos:exactMatch	uniprot:Q9NSA1	FGF21 protein, human	FGF21	orcid:0000-0001-9439-5346	CC0
-mesh:D016222	skos:exactMatch	hgnc:3676	Fibroblast Growth Factor 2	FGF2	orcid:0000-0001-9439-5346	CC0
-mesh:D016220	skos:exactMatch	hgnc:3665	Fibroblast Growth Factor 1	FGF1	orcid:0000-0001-9439-5346	CC0
-mesh:D042863	skos:exactMatch	hgnc:1780	Cyclin-Dependent Kinase 9	CDK9	orcid:0000-0001-9439-5346	CC0
-mesh:C000598645	skos:exactMatch	doid:DOID:0080091	Spheroid body myopathy	spheroid body myopathy	orcid:0000-0003-4423-4370	CC0
-mesh:C000596385	skos:exactMatch	doid:DOID:0111404	Jalili syndrome	Jalili syndrome	orcid:0000-0003-4423-4370	CC0
-mesh:C000626124	skos:exactMatch	doid:DOID:0060728	NGLY1 deficiency	NGLY1-deficiency	orcid:0000-0003-4423-4370	CC0
-mesh:C000656784	skos:exactMatch	doid:DOID:0050072	adiaspiromycosis	adiaspiromycosis	orcid:0000-0003-4423-4370	CC0
-mesh:C000656825	skos:exactMatch	doid:DOID:0050096	tinea barbae	tinea barbae	orcid:0000-0003-4423-4370	CC0
-mesh:C000656904	skos:exactMatch	doid:DOID:8912	tinea nigra	tinea nigra	orcid:0000-0003-4423-4370	CC0
-mesh:C535334	skos:exactMatch	doid:DOID:0050600	ABCD syndrome	ABCD syndrome	orcid:0000-0003-4423-4370	CC0
-mesh:C535358	skos:exactMatch	doid:DOID:980	Choroidal sclerosis	choroidal sclerosis	orcid:0000-0003-4423-4370	CC0
-mesh:C535388	skos:exactMatch	doid:DOID:0050647	Arts syndrome	Arts syndrome	orcid:0000-0003-4423-4370	CC0
-mesh:C535330	skos:exactMatch	doid:DOID:6691	Aagenaes syndrome	Aagenaes syndrome	orcid:0000-0003-4423-4370	CC0
-mesh:C535328	skos:exactMatch	doid:DOID:0060177	Homocarnosinosis	homocarnosinosis	orcid:0000-0003-4423-4370	CC0
-mesh:C535416	skos:exactMatch	doid:DOID:0110158	Charcot-Marie-Tooth disease, Type 2I	Charcot-Marie-Tooth disease type 2I	orcid:0000-0003-4423-4370	CC0
-mesh:C535420	skos:exactMatch	doid:DOID:0110191	Charcot-Marie-Tooth disease, Type 4B1	Charcot-Marie-Tooth disease type 4B1	orcid:0000-0003-4423-4370	CC0
-mesh:C535421	skos:exactMatch	doid:DOID:0110190	Charcot-Marie-Tooth disease, Type 4B2	Charcot-Marie-Tooth disease type 4B2	orcid:0000-0003-4423-4370	CC0
-mesh:C535436	skos:exactMatch	doid:DOID:0050663	Bethlem myopathy	Bethlem myopathy	orcid:0000-0003-4423-4370	CC0
-mesh:C535440	skos:exactMatch	doid:DOID:0050664	Bietti Crystalline Dystrophy	Bietti crystalline corneoretinal dystrophy	orcid:0000-0003-4423-4370	CC0
-mesh:C535549	skos:exactMatch	doid:DOID:3927	Pelvic lipomatosis	pelvic lipomatosis	orcid:0000-0003-4423-4370	CC0
-mesh:D066146	skos:exactMatch	go:GO:0044297	Cell Body	cell body	orcid:0000-0001-9439-5346	CC0
-mesh:C019919	skos:exactMatch	go:GO:1990143	CoA-synthesizing protein complex	CoA-synthesizing protein complex	orcid:0000-0001-9439-5346	CC0
-mesh:C035492	skos:exactMatch	go:GO:0031838	haptoglobin-hemoglobin complex	haptoglobin-hemoglobin complex	orcid:0000-0001-9439-5346	CC0
-mesh:C033727	skos:exactMatch	go:GO:0045283	fumarate reductase complex	fumarate reductase complex	orcid:0000-0001-9439-5346	CC0
-mesh:D000071218	skos:exactMatch	go:GO:0007624	Ultradian Rhythm	ultradian rhythm	orcid:0000-0001-9439-5346	CC0
-mesh:D000071437	skos:exactMatch	go:GO:0007411	Axon Guidance	axon guidance	orcid:0000-0001-9439-5346	CC0
-mesh:D000071444	skos:exactMatch	go:GO:0042331	Phototaxis	phototaxis	orcid:0000-0001-9439-5346	CC0
-mesh:D000071448	skos:exactMatch	go:GO:0007413	Axon Fasciculation	axonal fasciculation	orcid:0000-0001-9439-5346	CC0
-mesh:D000072159	skos:exactMatch	go:GO:0005869	Dynactin Complex	dynactin complex	orcid:0000-0001-9439-5346	CC0
-mesh:D000072777	skos:exactMatch	go:GO:0032537	Host-Seeking Behavior	host-seeking behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D000073398	skos:exactMatch	go:GO:0070988	Demethylation	demethylation	orcid:0000-0001-9439-5346	CC0
-mesh:D000073399	skos:exactMatch	go:GO:0080111	DNA Demethylation	DNA demethylation	orcid:0000-0001-9439-5346	CC0
-mesh:D000079403	skos:exactMatch	go:GO:0097707	Ferroptosis	ferroptosis	orcid:0000-0001-9439-5346	CC0
-mesh:D000078790	skos:exactMatch	go:GO:0030073	Insulin Secretion	insulin secretion	orcid:0000-0001-9439-5346	CC0
-mesh:D000077320	skos:exactMatch	go:GO:0110148	Biomineralization	biomineralization	orcid:0000-0001-9439-5346	CC0
-mesh:D000205	skos:exactMatch	go:GO:0042641	Actomyosin	actomyosin	orcid:0000-0001-9439-5346	CC0
-mesh:D000200	skos:exactMatch	go:GO:0001508	Action Potentials	action potential	orcid:0000-0001-9439-5346	CC0
-mesh:D000566	skos:exactMatch	go:GO:0097186	Amelogenesis	amelogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D000077743	skos:exactMatch	chebi:CHEBI:23847	Diterpene Alkaloids	diterpene alkaloid	orcid:0000-0001-9439-5346	CC0
-mesh:D000738	skos:exactMatch	chebi:CHEBI:16032	Androsterone	androsterone	orcid:0000-0001-9439-5346	CC0
-mesh:D000688	skos:exactMatch	chebi:CHEBI:28102	Amylose	amylose	orcid:0000-0001-9439-5346	CC0
-mesh:D000687	skos:exactMatch	chebi:CHEBI:28057	Amylopectin	amylopectin	orcid:0000-0001-9439-5346	CC0
-mesh:D000080549	skos:exactMatch	go:GO:0048102	Autophagic Cell Death	autophagic cell death	orcid:0000-0001-9439-5346	CC0
-mesh:D000940	skos:exactMatch	go:GO:0020033	Antigenic Variation	antigenic variation	orcid:0000-0001-9439-5346	CC0
-mesh:D001370	skos:exactMatch	go:GO:0098930	Axonal Transport	axonal transport	orcid:0000-0001-9439-5346	CC0
-mesh:D001777	skos:exactMatch	go:GO:0007596	Blood Coagulation	blood coagulation	orcid:0000-0001-9439-5346	CC0
-mesh:D002448	skos:exactMatch	go:GO:0007155	Cell Adhesion	cell adhesion	orcid:0000-0001-9439-5346	CC0
-mesh:D002449	skos:exactMatch	go:GO:0098743	Cell Aggregation	cell aggregation	orcid:0000-0001-9439-5346	CC0
-mesh:D002450	skos:exactMatch	go:GO:0007154	Cell Communication	cell communication	orcid:0000-0001-9439-5346	CC0
-mesh:D002453	skos:exactMatch	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0001-9439-5346	CC0
-mesh:D002455	skos:exactMatch	go:GO:0051301	Cell Division	cell division	orcid:0000-0001-9439-5346	CC0
-mesh:D002473	skos:exactMatch	go:GO:0005618	Cell Wall	cell wall	orcid:0000-0001-9439-5346	CC0
-mesh:D002634	skos:exactMatch	go:GO:0030595	Chemotaxis, Leukocyte	leukocyte chemotaxis	orcid:0000-0001-9439-5346	CC0
-mesh:D002837	skos:exactMatch	go:GO:0042583	Chromaffin Granules	chromaffin granule	orcid:0000-0001-9439-5346	CC0
-mesh:D003216	skos:exactMatch	go:GO:0035106	Conditioning, Operant	operant conditioning	orcid:0000-0001-9439-5346	CC0
-mesh:D003260	skos:exactMatch	go:GO:0060242	Contact Inhibition	contact inhibition	orcid:0000-0001-9439-5346	CC0
-mesh:D003307	skos:exactMatch	go:GO:0007620	Copulation	copulation	orcid:0000-0001-9439-5346	CC0
-mesh:D003341	skos:exactMatch	go:GO:0001554	Luteolysis	luteolysis	orcid:0000-0001-9439-5346	CC0
-mesh:D003595	skos:exactMatch	go:GO:0099636	Cytoplasmic Streaming	cytoplasmic streaming	orcid:0000-0001-9439-5346	CC0
-mesh:D003623	skos:exactMatch	go:GO:1990603	Dark Adaptation	dark adaptation	orcid:0000-0001-9439-5346	CC0
-mesh:D003810	skos:exactMatch	go:GO:0097187	Dentinogenesis	dentinogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D004031	skos:exactMatch	go:GO:0060207	Diestrus	diestrus	orcid:0000-0001-9439-5346	CC0
-mesh:D004063	skos:exactMatch	go:GO:0007586	Digestion	digestion	orcid:0000-0001-9439-5346	CC0
-mesh:D004327	skos:exactMatch	go:GO:0042756	Drinking Behavior	drinking behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D004455	skos:exactMatch	go:GO:0050959	Echolocation	echolocation	orcid:0000-0001-9439-5346	CC0
-mesh:D004705	skos:exactMatch	go:GO:0006897	Endocytosis	endocytosis	orcid:0000-0001-9439-5346	CC0
-mesh:D004903	skos:exactMatch	go:GO:0034117	Erythrocyte Aggregation	erythrocyte aggregation	orcid:0000-0001-9439-5346	CC0
-mesh:D004956	skos:exactMatch	go:GO:0042751	Estivation	estivation	orcid:0000-0001-9439-5346	CC0
-mesh:D005247	skos:exactMatch	go:GO:0007631	Feeding Behavior	feeding behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D005342	skos:exactMatch	go:GO:0042730	Fibrinolysis	fibrinolysis	orcid:0000-0001-9439-5346	CC0
-mesh:D005427	skos:exactMatch	go:GO:0000128	Flocculation	flocculation	orcid:0000-0001-9439-5346	CC0
-mesh:D005785	skos:exactMatch	go:GO:0035822	Gene Conversion	gene conversion	orcid:0000-0001-9439-5346	CC0
-mesh:D005786	skos:exactMatch	go:GO:0010468	Gene Expression Regulation	regulation of gene expression	orcid:0000-0001-9439-5346	CC0
-mesh:D005790	skos:exactMatch	go:GO:0051866	General Adaptation Syndrome	general adaptation syndrome	orcid:0000-0001-9439-5346	CC0
-mesh:D006031	skos:exactMatch	go:GO:0070085	Glycosylation	glycosylation	orcid:0000-0001-9439-5346	CC0
-mesh:D006605	skos:exactMatch	go:GO:0042750	Hibernation	hibernation	orcid:0000-0001-9439-5346	CC0
-mesh:D007314	skos:exactMatch	go:GO:0007320	Insemination	insemination	orcid:0000-0001-9439-5346	CC0
-mesh:D007408	skos:exactMatch	go:GO:0050892	Intestinal Absorption	intestinal absorption	orcid:0000-0001-9439-5346	CC0
-mesh:D007698	skos:exactMatch	go:GO:0042465	Kinesis	kinesis	orcid:0000-0001-9439-5346	CC0
-mesh:D007774	skos:exactMatch	go:GO:0007595	Lactation	lactation	orcid:0000-0001-9439-5346	CC0
-mesh:D008115	skos:exactMatch	go:GO:0097421	Liver Regeneration	liver regeneration	orcid:0000-0001-9439-5346	CC0
-mesh:D008247	skos:exactMatch	go:GO:0005764	Lysosomes	lysosome	orcid:0000-0001-9439-5346	CC0
-mesh:D008262	skos:exactMatch	go:GO:0042116	Macrophage Activation	macrophage activation	orcid:0000-0001-9439-5346	CC0
-mesh:D008425	skos:exactMatch	go:GO:0042711	Maternal Behavior	maternal behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D008561	skos:exactMatch	go:GO:0061025	Membrane Fusion	membrane fusion	orcid:0000-0001-9439-5346	CC0
-mesh:D008566	skos:exactMatch	go:GO:0016020	Membranes	membrane	orcid:0000-0001-9439-5346	CC0
-mesh:D008686	skos:exactMatch	go:GO:0060210	Metestrus	metestrus	orcid:0000-0001-9439-5346	CC0
-mesh:D008745	skos:exactMatch	go:GO:0032259	Methylation	methylation	orcid:0000-0001-9439-5346	CC0
-mesh:D009043	skos:exactMatch	go:GO:0003774	Motor Activity	motor activity	orcid:0000-0001-9439-5346	CC0
-mesh:D009079	skos:exactMatch	go:GO:0120197	Mucociliary Clearance	mucociliary clearance	orcid:0000-0001-9439-5346	CC0
-mesh:D009210	skos:exactMatch	go:GO:0030016	Myofibrils	myofibril	orcid:0000-0001-9439-5346	CC0
-mesh:D009469	skos:exactMatch	go:GO:0031594	Neuromuscular Junction	neuromuscular junction	orcid:0000-0001-9439-5346	CC0
-mesh:D009586	skos:exactMatch	go:GO:0009399	Nitrogen Fixation	nitrogen fixation	orcid:0000-0001-9439-5346	CC0
-mesh:D009697	skos:exactMatch	go:GO:0005731	Nucleolus Organizer Region	nucleolus organizer region	orcid:0000-0001-9439-5346	CC0
-mesh:D010058	skos:exactMatch	go:GO:0018991	Oviposition	oviposition	orcid:0000-0001-9439-5346	CC0
-mesh:D010064	skos:exactMatch	go:GO:0007566	Embryo Implantation	embryo implantation	orcid:0000-0001-9439-5346	CC0
-mesh:D010332	skos:exactMatch	go:GO:0042712	Paternal Behavior	paternal behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D010410	skos:exactMatch	go:GO:0043084	Penile Erection	penile erection	orcid:0000-0001-9439-5346	CC0
-mesh:D010452	skos:exactMatch	go:GO:0043043	Peptide Biosynthesis	peptide biosynthetic process	orcid:0000-0001-9439-5346	CC0
-mesh:D010873	skos:exactMatch	go:GO:0006907	Pinocytosis	pinocytosis	orcid:0000-0001-9439-5346	CC0
-mesh:D010974	skos:exactMatch	go:GO:0070527	Platelet Aggregation	platelet aggregation	orcid:0000-0001-9439-5346	CC0
-mesh:D010766	skos:exactMatch	go:GO:0016310	Phosphorylation	phosphorylation	orcid:0000-0001-9439-5346	CC0
-mesh:D011359	skos:exactMatch	go:GO:0060208	Proestrus	proestrus	orcid:0000-0001-9439-5346	CC0
-mesh:D011434	skos:exactMatch	go:GO:0019230	Proprioception	proprioception	orcid:0000-0001-9439-5346	CC0
-mesh:D011485	skos:exactMatch	go:GO:0005515	Protein Binding	protein binding	orcid:0000-0001-9439-5346	CC0
-mesh:D011489	skos:exactMatch	go:GO:0030164	Protein Denaturation	protein denaturation	orcid:0000-0001-9439-5346	CC0
-mesh:D011554	skos:exactMatch	go:GO:0031143	Pseudopodia	pseudopodium	orcid:0000-0001-9439-5346	CC0
-mesh:D012270	skos:exactMatch	go:GO:0005840	Ribosomes	ribosome	orcid:0000-0001-9439-5346	CC0
-mesh:D012472	skos:exactMatch	go:GO:0046541	Salivation	saliva secretion	orcid:0000-0001-9439-5346	CC0
-mesh:D012728	skos:exactMatch	go:GO:0001739	Sex Chromatin	sex chromatin	orcid:0000-0001-9439-5346	CC0
-mesh:D012733	skos:exactMatch	go:GO:0007548	Sex Differentiation	sex differentiation	orcid:0000-0001-9439-5346	CC0
-mesh:D012919	skos:exactMatch	go:GO:0035176	Social Behavior	social behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D013049	skos:exactMatch	go:GO:0008091	Spectrin	spectrin	orcid:0000-0001-9439-5346	CC0
-mesh:D013075	skos:exactMatch	go:GO:0048240	Sperm Capacitation	sperm capacitation	orcid:0000-0001-9439-5346	CC0
-mesh:D013077	skos:exactMatch	go:GO:0061827	Sperm Head	sperm head	orcid:0000-0001-9439-5346	CC0
-mesh:D013394	skos:exactMatch	go:GO:0070014	Sucrase-Isomaltase Complex	sucrase-isomaltase complex	orcid:0000-0001-9439-5346	CC0
-mesh:D013559	skos:exactMatch	go:GO:0044403	Symbiosis	symbiotic process	orcid:0000-0001-9439-5346	CC0
-mesh:D013570	skos:exactMatch	go:GO:0097060	Synaptic Membranes	synaptic membrane	orcid:0000-0001-9439-5346	CC0
-mesh:D013572	skos:exactMatch	go:GO:0008021	Synaptic Vesicles	synaptic vesicle	orcid:0000-0001-9439-5346	CC0
-mesh:D013573	skos:exactMatch	go:GO:0000795	Synaptonemal Complex	synaptonemal complex	orcid:0000-0001-9439-5346	CC0
-mesh:D014661	skos:exactMatch	go:GO:0042310	Vasoconstriction	vasoconstriction	orcid:0000-0001-9439-5346	CC0
-mesh:D014818	skos:exactMatch	go:GO:0007296	Vitellogenesis	vitellogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D016631	skos:exactMatch	go:GO:0097413	Lewy Bodies	Lewy body	orcid:0000-0001-9439-5346	CC0
-mesh:D016874	skos:exactMatch	go:GO:0097418	Neurofibrillary Tangles	neurofibrillary tangle	orcid:0000-0001-9439-5346	CC0
-mesh:D017368	skos:exactMatch	go:GO:0018342	Protein Prenylation	protein prenylation	orcid:0000-0001-9439-5346	CC0
-mesh:D015870	skos:exactMatch	go:GO:0010467	Gene Expression	gene expression	orcid:0000-0001-9439-5346	CC0
-mesh:D018087	skos:exactMatch	go:GO:0009536	Plastids	plastid	orcid:0000-0001-9439-5346	CC0
-mesh:D018271	skos:exactMatch	go:GO:0048500	Signal Recognition Particle	signal recognition particle	orcid:0000-0001-9439-5346	CC0
-mesh:D018386	skos:exactMatch	go:GO:0000776	Kinetochores	kinetochore	orcid:0000-0001-9439-5346	CC0
-mesh:D018522	skos:exactMatch	go:GO:0009630	Gravitropism	gravitropism	orcid:0000-0001-9439-5346	CC0
-mesh:D018523	skos:exactMatch	go:GO:0009606	Tropism	tropism	orcid:0000-0001-9439-5346	CC0
-mesh:D018524	skos:exactMatch	go:GO:0009638	Phototropism	phototropism	orcid:0000-0001-9439-5346	CC0
-mesh:D019175	skos:exactMatch	go:GO:0006306	DNA Methylation	DNA methylation	orcid:0000-0001-9439-5346	CC0
-mesh:D019599	skos:exactMatch	go:GO:0097457	Mossy Fibers, Hippocampal	hippocampal mossy fiber	orcid:0000-0001-9439-5346	CC0
-mesh:D019706	skos:exactMatch	go:GO:0060079	Excitatory Postsynaptic Potentials	excitatory postsynaptic potential	orcid:0000-0001-9439-5346	CC0
-mesh:D019898	skos:exactMatch	go:GO:0035425	Autocrine Communication	autocrine signaling	orcid:0000-0001-9439-5346	CC0
-mesh:D019899	skos:exactMatch	go:GO:0038001	Paracrine Communication	paracrine signaling	orcid:0000-0001-9439-5346	CC0
-mesh:D020101	skos:exactMatch	go:GO:0007340	Acrosome Reaction	acrosome reaction	orcid:0000-0001-9439-5346	CC0
-mesh:D020439	skos:exactMatch	go:GO:0030426	Growth Cones	growth cone	orcid:0000-0001-9439-5346	CC0
-mesh:D020460	skos:exactMatch	go:GO:0042470	Melanosomes	melanosome	orcid:0000-0001-9439-5346	CC0
-mesh:D020524	skos:exactMatch	go:GO:0009579	Thylakoids	thylakoid	orcid:0000-0001-9439-5346	CC0
-mesh:D020675	skos:exactMatch	go:GO:0005777	Peroxisomes	peroxisome	orcid:0000-0001-9439-5346	CC0
-mesh:D020676	skos:exactMatch	go:GO:0009514	Glyoxysomes	glyoxysome	orcid:0000-0001-9439-5346	CC0
-mesh:D020868	skos:exactMatch	go:GO:0016458	Gene Silencing	gene silencing	orcid:0000-0001-9439-5346	CC0
-mesh:D021381	skos:exactMatch	go:GO:0015031	Protein Transport	protein transport	orcid:0000-0001-9439-5346	CC0
-mesh:D021601	skos:exactMatch	go:GO:0005802	trans-Golgi Network	trans-Golgi network	orcid:0000-0001-9439-5346	CC0
-mesh:D022162	skos:exactMatch	go:GO:0031410	Cytoplasmic Vesicles	cytoplasmic vesicle	orcid:0000-0001-9439-5346	CC0
-mesh:D022163	skos:exactMatch	go:GO:0030136	Clathrin-Coated Vesicles	clathrin-coated vesicle	orcid:0000-0001-9439-5346	CC0
-mesh:D022502	skos:exactMatch	go:GO:0001725	Stress Fibers	stress fiber	orcid:0000-0001-9439-5346	CC0
-mesh:D030762	skos:exactMatch	go:GO:0044849	Estrous Cycle	estrous cycle	orcid:0000-0001-9439-5346	CC0
-mesh:D026721	skos:exactMatch	go:GO:0031123	RNA 3' End Processing	RNA 3'-end processing	orcid:0000-0001-9439-5346	CC0
-mesh:D031425	skos:exactMatch	go:GO:0009506	Plasmodesmata	plasmodesma	orcid:0000-0001-9439-5346	CC0
-mesh:D032961	skos:exactMatch	go:GO:0097225	Sperm Midpiece	sperm midpiece	orcid:0000-0001-9439-5346	CC0
-mesh:D034461	skos:exactMatch	go:GO:0001553	Luteinization	luteinization	orcid:0000-0001-9439-5346	CC0
-mesh:D036881	skos:exactMatch	go:GO:0060292	Long-Term Synaptic Depression	long-term synaptic depression	orcid:0000-0001-9439-5346	CC0
-mesh:D042003	skos:exactMatch	go:GO:0006323	DNA Packaging	DNA packaging	orcid:0000-0001-9439-5346	CC0
-mesh:D021962	skos:exactMatch	go:GO:0098857	Membrane Microdomains	membrane microdomain	orcid:0000-0001-9439-5346	CC0
-mesh:D043762	skos:exactMatch	go:GO:0019098	Reproductive Behavior	reproductive behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D044603	skos:exactMatch	go:GO:0043263	Cellulosomes	cellulosome	orcid:0000-0001-9439-5346	CC0
-mesh:D045524	skos:exactMatch	go:GO:0030089	Phycobilisomes	phycobilisome	orcid:0000-0001-9439-5346	CC0
-mesh:D046148	skos:exactMatch	go:GO:0007535	Donor Selection	donor selection	orcid:0000-0001-9439-5346	CC0
-mesh:D048648	skos:exactMatch	go:GO:0031039	Macronucleus	macronucleus	orcid:0000-0001-9439-5346	CC0
-mesh:D049229	skos:exactMatch	go:GO:0043197	Dendritic Spines	dendritic spine	orcid:0000-0001-9439-5346	CC0
-mesh:D049469	skos:exactMatch	go:GO:0007128	Meiotic Prophase I	meiotic prophase I	orcid:0000-0001-9439-5346	CC0
-mesh:D046249	skos:exactMatch	go:GO:0043039	Transfer RNA Aminoacylation	tRNA aminoacylation	orcid:0000-0001-9439-5346	CC0
-mesh:D050356	skos:exactMatch	go:GO:0006629	Lipid Metabolism	lipid metabolic process	orcid:0000-0001-9439-5346	CC0
-mesh:D053478	skos:exactMatch	go:GO:0043293	Apoptosomes	apoptosome	orcid:0000-0001-9439-5346	CC0
-mesh:D054262	skos:exactMatch	go:GO:0007369	Gastrulation	gastrulation	orcid:0000-0001-9439-5346	CC0
-mesh:D054337	skos:exactMatch	go:GO:0043697	Cell Dedifferentiation	cell dedifferentiation	orcid:0000-0001-9439-5346	CC0
-mesh:D054468	skos:exactMatch	go:GO:0005930	Axoneme	axoneme	orcid:0000-0001-9439-5346	CC0
-mesh:D054657	skos:exactMatch	go:GO:0044391	Ribosome Subunits	ribosomal subunit	orcid:0000-0001-9439-5346	CC0
-mesh:D054658	skos:exactMatch	go:GO:0015934	Ribosome Subunits, Large	large ribosomal subunit	orcid:0000-0001-9439-5346	CC0
-mesh:D054679	skos:exactMatch	go:GO:0015935	Ribosome Subunits, Small	small ribosomal subunit	orcid:0000-0001-9439-5346	CC0
-mesh:D054817	skos:exactMatch	go:GO:0009856	Pollination	pollination	orcid:0000-0001-9439-5346	CC0
-mesh:D054974	skos:exactMatch	go:GO:0043034	Costameres	costamere	orcid:0000-0001-9439-5346	CC0
-mesh:D054992	skos:exactMatch	go:GO:0001772	Immunological Synapses	immunological synapse	orcid:0000-0001-9439-5346	CC0
-mesh:D057897	skos:exactMatch	go:GO:0060013	Reflex, Righting	righting reflex	orcid:0000-0001-9439-5346	CC0
-mesh:D057900	skos:exactMatch	go:GO:0045056	Transcytosis	transcytosis	orcid:0000-0001-9439-5346	CC0
-mesh:D057907	skos:exactMatch	go:GO:0014069	Post-Synaptic Density	postsynaptic density	orcid:0000-0001-9439-5346	CC0
-mesh:D058767	skos:exactMatch	go:GO:0043335	Protein Unfolding	protein unfolding	orcid:0000-0001-9439-5346	CC0
-mesh:D058849	skos:exactMatch	go:GO:0042026	Protein Refolding	protein refolding	orcid:0000-0001-9439-5346	CC0
-mesh:D058894	skos:exactMatch	go:GO:0042151	Nematocyst	nematocyst	orcid:0000-0001-9439-5346	CC0
-mesh:D059007	skos:exactMatch	go:GO:0005700	Polytene Chromosomes	polytene chromosome	orcid:0000-0001-9439-5346	CC0
-mesh:D060049	skos:exactMatch	go:GO:0008356	Asymmetric Cell Division	asymmetric cell division	orcid:0000-0001-9439-5346	CC0
-mesh:D060449	skos:exactMatch	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0001-9439-5346	CC0
-mesh:D065608	skos:exactMatch	go:GO:0070293	Renal Reabsorption	renal absorption	orcid:0000-0001-9439-5346	CC0
-mesh:D000067128	skos:exactMatch	go:GO:1903561	Extracellular Vesicles	extracellular vesicle	orcid:0000-0001-9439-5346	CC0
-mesh:D000069292	skos:exactMatch	go:GO:0070269	Pyroptosis	pyroptosis	orcid:0000-0001-9439-5346	CC0
-mesh:D000071182	skos:exactMatch	go:GO:0005776	Autophagosomes	autophagosome	orcid:0000-0001-9439-5346	CC0
-mesh:D000705	skos:exactMatch	go:GO:0051322	Anaphase	anaphase	orcid:0000-0001-9439-5346	CC0
-mesh:D001329	skos:exactMatch	go:GO:0001896	Autolysis	autolysis	orcid:0000-0001-9439-5346	CC0
-mesh:D001343	skos:exactMatch	go:GO:0006914	Autophagy	autophagy	orcid:0000-0001-9439-5346	CC0
-mesh:D001485	skos:exactMatch	go:GO:0005604	Basement Membrane	basement membrane	orcid:0000-0001-9439-5346	CC0
-mesh:D001519	skos:exactMatch	go:GO:0007610	Behavior	behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D001775	skos:exactMatch	go:GO:0008015	Blood Circulation	blood circulation	orcid:0000-0001-9439-5346	CC0
-mesh:D002454	skos:exactMatch	go:GO:0030154	Cell Differentiation	cell differentiation	orcid:0000-0001-9439-5346	CC0
-mesh:D002462	skos:exactMatch	go:GO:0005886	Cell Membrane	plasma membrane	orcid:0000-0001-9439-5346	CC0
-mesh:D002479	skos:exactMatch	go:GO:0016234	Inclusion Bodies	inclusion body	orcid:0000-0001-9439-5346	CC0
-mesh:D002502	skos:exactMatch	go:GO:0005814	Centrioles	centriole	orcid:0000-0001-9439-5346	CC0
-mesh:D002633	skos:exactMatch	go:GO:0006935	Chemotaxis	chemotaxis	orcid:0000-0001-9439-5346	CC0
-mesh:D002736	skos:exactMatch	go:GO:0009507	Chloroplasts	chloroplast	orcid:0000-0001-9439-5346	CC0
-mesh:D002823	skos:exactMatch	go:GO:0042600	Chorion	chorion	orcid:0000-0001-9439-5346	CC0
-mesh:D002843	skos:exactMatch	go:GO:0000785	Chromatin	chromatin	orcid:0000-0001-9439-5346	CC0
-mesh:D002875	skos:exactMatch	go:GO:0005694	Chromosomes	chromosome	orcid:0000-0001-9439-5346	CC0
-mesh:D002940	skos:exactMatch	go:GO:0007623	Circadian Rhythm	circadian rhythm	orcid:0000-0001-9439-5346	CC0
-mesh:D003071	skos:exactMatch	go:GO:0050890	Cognition	cognition	orcid:0000-0001-9439-5346	CC0
-mesh:D003167	skos:exactMatch	go:GO:0006956	Complement Activation	complement activation	orcid:0000-0001-9439-5346	CC0
-mesh:D003593	skos:exactMatch	go:GO:0005737	Cytoplasm	cytoplasm	orcid:0000-0001-9439-5346	CC0
-mesh:D003599	skos:exactMatch	go:GO:0005856	Cytoskeleton	cytoskeleton	orcid:0000-0001-9439-5346	CC0
-mesh:D003600	skos:exactMatch	go:GO:0005829	Cytosol	cytosol	orcid:0000-0001-9439-5346	CC0
-mesh:D003672	skos:exactMatch	go:GO:0030421	Defecation	defecation	orcid:0000-0001-9439-5346	CC0
-mesh:D003712	skos:exactMatch	go:GO:0030425	Dendrites	dendrite	orcid:0000-0001-9439-5346	CC0
-mesh:D003896	skos:exactMatch	go:GO:0030057	Desmosomes	desmosome	orcid:0000-0001-9439-5346	CC0
-mesh:D004260	skos:exactMatch	go:GO:0006281	DNA Repair	DNA repair	orcid:0000-0001-9439-5346	CC0
-mesh:D004261	skos:exactMatch	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0001-9439-5346	CC0
-mesh:D004721	skos:exactMatch	go:GO:0005783	Endoplasmic Reticulum	endoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
-mesh:D005089	skos:exactMatch	go:GO:0006887	Exocytosis	exocytosis	orcid:0000-0001-9439-5346	CC0
-mesh:D005109	skos:exactMatch	go:GO:0031012	Extracellular Matrix	extracellular matrix	orcid:0000-0001-9439-5346	CC0
-mesh:D005110	skos:exactMatch	go:GO:0005615	Extracellular Space	extracellular space	orcid:0000-0001-9439-5346	CC0
-mesh:D005285	skos:exactMatch	go:GO:0006113	Fermentation	fermentation	orcid:0000-0001-9439-5346	CC0
-mesh:D005306	skos:exactMatch	go:GO:0009566	Fertilization	fertilization	orcid:0000-0001-9439-5346	CC0
-mesh:D005943	skos:exactMatch	go:GO:0006094	Gluconeogenesis	gluconeogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D006019	skos:exactMatch	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0001-9439-5346	CC0
-mesh:D006056	skos:exactMatch	go:GO:0005794	Golgi Apparatus	Golgi apparatus	orcid:0000-0001-9439-5346	CC0
-mesh:D006487	skos:exactMatch	go:GO:0007599	Hemostasis	hemostasis	orcid:0000-0001-9439-5346	CC0
-mesh:D006570	skos:exactMatch	go:GO:0000792	Heterochromatin	heterochromatin	orcid:0000-0001-9439-5346	CC0
-mesh:D006967	skos:exactMatch	go:GO:0002524	Hypersensitivity	hypersensitivity	orcid:0000-0001-9439-5346	CC0
-mesh:D007249	skos:exactMatch	go:GO:0006954	Inflammation	inflammatory response	orcid:0000-0001-9439-5346	CC0
-mesh:D007399	skos:exactMatch	go:GO:0051325	Interphase	interphase	orcid:0000-0001-9439-5346	CC0
-mesh:D007858	skos:exactMatch	go:GO:0007612	Learning	learning	orcid:0000-0001-9439-5346	CC0
-mesh:D008213	skos:exactMatch	go:GO:0046649	Lymphocyte Activation	lymphocyte activation	orcid:0000-0001-9439-5346	CC0
-mesh:D008409	skos:exactMatch	go:GO:0071626	Mastication	mastication	orcid:0000-0001-9439-5346	CC0
-mesh:D008572	skos:exactMatch	go:GO:0042696	Menarche	menarche	orcid:0000-0001-9439-5346	CC0
-mesh:D008593	skos:exactMatch	go:GO:0042697	Menopause	menopause	orcid:0000-0001-9439-5346	CC0
-mesh:D008597	skos:exactMatch	go:GO:0044850	Menstrual Cycle	menstrual cycle	orcid:0000-0001-9439-5346	CC0
-mesh:D008598	skos:exactMatch	go:GO:0042703	Menstruation	menstruation	orcid:0000-0001-9439-5346	CC0
-mesh:D008660	skos:exactMatch	go:GO:0008152	Metabolism	metabolic process	orcid:0000-0001-9439-5346	CC0
-mesh:D008677	skos:exactMatch	go:GO:0051323	Metaphase	metaphase	orcid:0000-0001-9439-5346	CC0
-mesh:D008830	skos:exactMatch	go:GO:0042579	Microbodies	microbody	orcid:0000-0001-9439-5346	CC0
-mesh:D008841	skos:exactMatch	go:GO:0015629	Actin Cytoskeleton	actin cytoskeleton	orcid:0000-0001-9439-5346	CC0
-mesh:D008870	skos:exactMatch	go:GO:0005874	Microtubules	microtubule	orcid:0000-0001-9439-5346	CC0
-mesh:D008928	skos:exactMatch	go:GO:0005739	Mitochondria	mitochondrion	orcid:0000-0001-9439-5346	CC0
-mesh:D009119	skos:exactMatch	go:GO:0006936	Muscle Contraction	muscle contraction	orcid:0000-0001-9439-5346	CC0
-mesh:D009186	skos:exactMatch	go:GO:0043209	Myelin Sheath	myelin sheath	orcid:0000-0001-9439-5346	CC0
-mesh:D009336	skos:exactMatch	go:GO:0070265	Necrosis	necrotic cell death	orcid:0000-0001-9439-5346	CC0
-mesh:D009685	skos:exactMatch	go:GO:0005635	Nuclear Envelope	nuclear envelope	orcid:0000-0001-9439-5346	CC0
-mesh:D009707	skos:exactMatch	go:GO:0000786	Nucleosomes	nucleosome	orcid:0000-0001-9439-5346	CC0
-mesh:D009805	skos:exactMatch	go:GO:0042476	Odontogenesis	odontogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D009866	skos:exactMatch	go:GO:0048477	Oogenesis	oogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D010060	skos:exactMatch	go:GO:0030728	Ovulation	ovulation	orcid:0000-0001-9439-5346	CC0
-mesh:D010085	skos:exactMatch	go:GO:0006119	Oxidative Phosphorylation	oxidative phosphorylation	orcid:0000-0001-9439-5346	CC0
-mesh:D010528	skos:exactMatch	go:GO:0030432	Peristalsis	peristalsis	orcid:0000-0001-9439-5346	CC0
-mesh:D010587	skos:exactMatch	go:GO:0006909	Phagocytosis	phagocytosis	orcid:0000-0001-9439-5346	CC0
-mesh:D010788	skos:exactMatch	go:GO:0015979	Photosynthesis	photosynthesis	orcid:0000-0001-9439-5346	CC0
-mesh:D010858	skos:exactMatch	go:GO:0043473	Pigmentation	pigmentation	orcid:0000-0001-9439-5346	CC0
-mesh:D011235	skos:exactMatch	go:GO:0002120	Predatory Behavior	predatory behavior	orcid:0000-0001-9439-5346	CC0
-mesh:D011418	skos:exactMatch	go:GO:0051324	Prophase	prophase	orcid:0000-0001-9439-5346	CC0
-mesh:D011992	skos:exactMatch	go:GO:0005768	Endosomes	endosome	orcid:0000-0001-9439-5346	CC0
-mesh:D012038	skos:exactMatch	go:GO:0031099	Regeneration	regeneration	orcid:0000-0001-9439-5346	CC0
-mesh:D012098	skos:exactMatch	go:GO:0000003	Reproduction	reproduction	orcid:0000-0001-9439-5346	CC0
-mesh:D012100	skos:exactMatch	go:GO:0019954	Reproduction, Asexual	asexual reproduction	orcid:0000-0001-9439-5346	CC0
-mesh:D012326	skos:exactMatch	go:GO:0008380	RNA Splicing	RNA splicing	orcid:0000-0001-9439-5346	CC0
-mesh:D012508	skos:exactMatch	go:GO:0042383	Sarcolemma	sarcolemma	orcid:0000-0001-9439-5346	CC0
-mesh:D012518	skos:exactMatch	go:GO:0030017	Sarcomeres	sarcomere	orcid:0000-0001-9439-5346	CC0
-mesh:D012519	skos:exactMatch	go:GO:0016529	Sarcoplasmic Reticulum	sarcoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
-mesh:D012730	skos:exactMatch	go:GO:0000803	Sex Chromosomes	sex chromosome	orcid:0000-0001-9439-5346	CC0
-mesh:D013081	skos:exactMatch	go:GO:0097722	Sperm Motility	sperm motility	orcid:0000-0001-9439-5346	CC0
-mesh:D013091	skos:exactMatch	go:GO:0007283	Spermatogenesis	spermatogenesis	orcid:0000-0001-9439-5346	CC0
-mesh:D013550	skos:exactMatch	go:GO:0036268	Swimming	swimming	orcid:0000-0001-9439-5346	CC0
-mesh:D013569	skos:exactMatch	go:GO:0045202	Synapses	synapse	orcid:0000-0001-9439-5346	CC0
-mesh:D013692	skos:exactMatch	go:GO:0051326	Telophase	telophase	orcid:0000-0001-9439-5346	CC0
-mesh:D014078	skos:exactMatch	go:GO:0044691	Tooth Eruption	tooth eruption	orcid:0000-0001-9439-5346	CC0
-mesh:D014617	skos:exactMatch	go:GO:0005773	Vacuoles	vacuole	orcid:0000-0001-9439-5346	CC0
-mesh:D014664	skos:exactMatch	go:GO:0042311	Vasodilation	vasodilation	orcid:0000-0001-9439-5346	CC0
-mesh:D014796	skos:exactMatch	go:GO:0007601	Visual Perception	visual perception	orcid:0000-0001-9439-5346	CC0
-mesh:D014945	skos:exactMatch	go:GO:0042060	Wound Healing	wound healing	orcid:0000-0001-9439-5346	CC0
-mesh:D014960	skos:exactMatch	go:GO:0000805	X Chromosome	X chromosome	orcid:0000-0001-9439-5346	CC0
-mesh:D014998	skos:exactMatch	go:GO:0000806	Y Chromosome	Y chromosome	orcid:0000-0001-9439-5346	CC0
-mesh:D015388	skos:exactMatch	go:GO:0043226	Organelles	organelle	orcid:0000-0001-9439-5346	CC0
-mesh:D015398	skos:exactMatch	go:GO:0007165	Signal Transduction	signal transduction	orcid:0000-0001-9439-5346	CC0
-mesh:D015530	skos:exactMatch	go:GO:0016363	Nuclear Matrix	nuclear matrix	orcid:0000-0001-9439-5346	CC0
-mesh:D015539	skos:exactMatch	go:GO:0030168	Platelet Activation	platelet activation	orcid:0000-0001-9439-5346	CC0
-mesh:D016193	skos:exactMatch	go:GO:0051318	G1 Phase	G1 phase	orcid:0000-0001-9439-5346	CC0
-mesh:D016196	skos:exactMatch	go:GO:0051320	S Phase	S phase	orcid:0000-0001-9439-5346	CC0
-mesh:D016723	skos:exactMatch	go:GO:0046849	Bone Remodeling	bone remodeling	orcid:0000-0001-9439-5346	CC0
-mesh:D016897	skos:exactMatch	go:GO:0045730	Respiratory Burst	respiratory burst	orcid:0000-0001-9439-5346	CC0
-mesh:D016922	skos:exactMatch	go:GO:0090398	Cellular Senescence	cellular senescence	orcid:0000-0001-9439-5346	CC0
-mesh:D017209	skos:exactMatch	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0001-9439-5346	CC0
-mesh:D017510	skos:exactMatch	go:GO:0006457	Protein Folding	protein folding	orcid:0000-0001-9439-5346	CC0
-mesh:D017629	skos:exactMatch	go:GO:0005921	Gap Junctions	gap junction	orcid:0000-0001-9439-5346	CC0
-mesh:D018375	skos:exactMatch	go:GO:0042119	Neutrophil Activation	neutrophil activation	orcid:0000-0001-9439-5346	CC0
-mesh:D018385	skos:exactMatch	go:GO:0005813	Centrosome	centrosome	orcid:0000-0001-9439-5346	CC0
-mesh:D018392	skos:exactMatch	go:GO:0071514	Genomic Imprinting	genetic imprinting	orcid:0000-0001-9439-5346	CC0
-mesh:D018699	skos:exactMatch	go:GO:0030135	Coated Vesicles	coated vesicle	orcid:0000-0001-9439-5346	CC0
-mesh:D018870	skos:exactMatch	go:GO:0005791	Endoplasmic Reticulum, Rough	rough endoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
-mesh:D018871	skos:exactMatch	go:GO:0005790	Endoplasmic Reticulum, Smooth	smooth endoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
-mesh:D019069	skos:exactMatch	go:GO:0045333	Cell Respiration	cellular respiration	orcid:0000-0001-9439-5346	CC0
-mesh:D019108	skos:exactMatch	go:GO:0070160	Tight Junctions	tight junction	orcid:0000-0001-9439-5346	CC0
-mesh:D019154	skos:exactMatch	go:GO:0030908	Protein Splicing	protein splicing	orcid:0000-0001-9439-5346	CC0
-mesh:D019276	skos:exactMatch	go:GO:0030112	Glycocalyx	glycocalyx	orcid:0000-0001-9439-5346	CC0
-mesh:D019457	skos:exactMatch	go:GO:0031052	Chromosome Breakage	chromosome breakage	orcid:0000-0001-9439-5346	CC0
-mesh:D020090	skos:exactMatch	go:GO:0007059	Chromosome Segregation	chromosome segregation	orcid:0000-0001-9439-5346	CC0
-mesh:D020894	skos:exactMatch	go:GO:0001527	Microfibrils	microfibril	orcid:0000-0001-9439-5346	CC0
-mesh:D021941	skos:exactMatch	go:GO:0005901	Caveolae	caveola	orcid:0000-0001-9439-5346	CC0
-mesh:D022002	skos:exactMatch	go:GO:0030056	Hemidesmosomes	hemidesmosome	orcid:0000-0001-9439-5346	CC0
-mesh:D022005	skos:exactMatch	go:GO:0005912	Adherens Junctions	adherens junction	orcid:0000-0001-9439-5346	CC0
-mesh:D022022	skos:exactMatch	go:GO:0005643	Nuclear Pore	nuclear pore	orcid:0000-0001-9439-5346	CC0
-mesh:D022041	skos:exactMatch	go:GO:0000791	Euchromatin	euchromatin	orcid:0000-0001-9439-5346	CC0
-mesh:D022161	skos:exactMatch	go:GO:0030133	Transport Vesicles	transport vesicle	orcid:0000-0001-9439-5346	CC0
-mesh:D023102	skos:exactMatch	go:GO:0043276	Anoikis	anoikis	orcid:0000-0001-9439-5346	CC0
-mesh:D034443	skos:exactMatch	go:GO:0050658	RNA Transport	RNA transport	orcid:0000-0001-9439-5346	CC0
-mesh:D034622	skos:exactMatch	go:GO:0016246	RNA Interference	RNA interference	orcid:0000-0001-9439-5346	CC0
-mesh:D034881	skos:exactMatch	go:GO:0005652	Nuclear Lamina	nuclear lamina	orcid:0000-0001-9439-5346	CC0
-mesh:D036801	skos:exactMatch	go:GO:0007567	Parturition	parturition	orcid:0000-0001-9439-5346	CC0
-mesh:D048348	skos:exactMatch	go:GO:0001171	Reverse Transcription	reverse transcription	orcid:0000-0001-9439-5346	CC0
-mesh:D048749	skos:exactMatch	go:GO:0000910	Cytokinesis	cytokinesis	orcid:0000-0001-9439-5346	CC0
-mesh:D049109	skos:exactMatch	go:GO:0008283	Cell Proliferation	cell population proliferation	orcid:0000-0001-9439-5346	CC0
-mesh:D051336	skos:exactMatch	go:GO:0031966	Mitochondrial Membranes	mitochondrial membrane	orcid:0000-0001-9439-5346	CC0
-mesh:D059447	skos:exactMatch	go:GO:0000075	Cell Cycle Checkpoints	cell cycle checkpoint	orcid:0000-0001-9439-5346	CC0
-mesh:D059547	skos:exactMatch	go:GO:0032420	Stereocilia	stereocilium	orcid:0000-0001-9439-5346	CC0
-mesh:D060152	skos:exactMatch	go:GO:0033151	V(D)J Recombination	V(D)J recombination	orcid:0000-0001-9439-5346	CC0
-mesh:D007382	skos:exactMatch	go:GO:0005882	Intermediate Filaments	intermediate filament	orcid:0000-0001-9439-5346	CC0
-mesh:D008871	skos:exactMatch	go:GO:0005902	Microvilli	microvillus	orcid:0000-0001-9439-5346	CC0
-mesh:D055944	skos:exactMatch	go:GO:0110143	Magnetosomes	magnetosome	orcid:0000-0001-9439-5346	CC0
-mesh:D057646	skos:exactMatch	go:GO:0019061	Virus Uncoating	uncoating of virus	orcid:0000-0001-9439-5346	CC0
-mesh:D057465	skos:exactMatch	go:GO:0061984	Catabolite Repression	catabolite repression	orcid:0000-0001-9439-5346	CC0
-mesh:D055212	skos:exactMatch	go:GO:0032391	Photoreceptor Connecting Cilium	photoreceptor connecting cilium	orcid:0000-0001-9439-5346	CC0
-mesh:D000069396	skos:exactMatch	go:GO:0005761	Mitochondrial Ribosomes	mitochondrial ribosome	orcid:0000-0001-9439-5346	CC0
-mesh:D000071040	skos:exactMatch	go:GO:0043194	Axon Initial Segment	axon initial segment	orcid:0000-0001-9439-5346	CC0
-mesh:D000080642	skos:exactMatch	go:GO:0061684	Chaperone-Mediated Autophagy	chaperone-mediated autophagy	orcid:0000-0001-9439-5346	CC0
-mesh:D000081363	skos:exactMatch	go:GO:0039679	Occlusion Bodies, Viral	viral occlusion body	orcid:0000-0001-9439-5346	CC0
-mesh:D001846	skos:exactMatch	go:GO:0060348	Bone Development	bone development	orcid:0000-0001-9439-5346	CC0
-mesh:D001861	skos:exactMatch	go:GO:1990523	Bone Regeneration	bone regeneration	orcid:0000-0001-9439-5346	CC0
-mesh:D001862	skos:exactMatch	go:GO:0045453	Bone Resorption	bone resorption	orcid:0000-0001-9439-5346	CC0
-mesh:D000873	skos:exactMatch	chebi:CHEBI:46955	Anthracenes	anthracenes	orcid:0000-0001-9439-5346	CC0
-mesh:D001381	skos:exactMatch	chebi:CHEBI:48105	Azepines	azepine	orcid:0000-0001-9439-5346	CC0
-mesh:D001218	skos:exactMatch	chebi:CHEBI:2877	Aspartame	aspartame	orcid:0000-0001-9439-5346	CC0
-mesh:D001507	skos:exactMatch	chebi:CHEBI:3001	Beclomethasone	beclomethasone	orcid:0000-0001-9439-5346	CC0
-mesh:D001539	skos:exactMatch	chebi:CHEBI:3013	Bendroflumethiazide	bendroflumethiazide	orcid:0000-0001-9439-5346	CC0
-mesh:D001542	skos:exactMatch	chebi:CHEBI:3015	Benomyl	benomyl	orcid:0000-0001-9439-5346	CC0
-mesh:D001547	skos:exactMatch	chebi:CHEBI:22698	Benzaldehydes	benzaldehydes	orcid:0000-0001-9439-5346	CC0
-mesh:D001549	skos:exactMatch	chebi:CHEBI:22702	Benzamides	benzamides	orcid:0000-0001-9439-5346	CC0
-mesh:D001552	skos:exactMatch	chebi:CHEBI:35676	Benzazepines	benzazepine	orcid:0000-0001-9439-5346	CC0
-mesh:D001553	skos:exactMatch	chebi:CHEBI:3023	Benzbromarone	benzbromarone	orcid:0000-0001-9439-5346	CC0
-mesh:D001557	skos:exactMatch	chebi:CHEBI:53348	Benzenesulfonates	benzenesulfonates	orcid:0000-0001-9439-5346	CC0
-mesh:D001562	skos:exactMatch	chebi:CHEBI:22715	Benzimidazoles	benzimidazoles	orcid:0000-0001-9439-5346	CC0
-mesh:D001564	skos:exactMatch	chebi:CHEBI:29865	Benzo(a)pyrene	benzo[a]pyrene	orcid:0000-0001-9439-5346	CC0
-mesh:D001569	skos:exactMatch	chebi:CHEBI:22720	Benzodiazepines	benzodiazepine	orcid:0000-0001-9439-5346	CC0
-mesh:D001581	skos:exactMatch	chebi:CHEBI:50265	Benzothiadiazines	benzothiadiazine	orcid:0000-0001-9439-5346	CC0
-mesh:D001590	skos:exactMatch	chebi:CHEBI:3048	Benztropine	benzatropine	orcid:0000-0001-9439-5346	CC0
-mesh:D001592	skos:exactMatch	chebi:CHEBI:22743	Benzyl Alcohols	benzyl alcohols	orcid:0000-0001-9439-5346	CC0
-mesh:D001594	skos:exactMatch	chebi:CHEBI:3056	Benzyl Viologen	Benzyl viologen	orcid:0000-0001-9439-5346	CC0
-mesh:D001599	skos:exactMatch	chebi:CHEBI:16118	Berberine	berberine	orcid:0000-0001-9439-5346	CC0
-mesh:D001600	skos:exactMatch	chebi:CHEBI:22754	Berberine Alkaloids	berberine alkaloid	orcid:0000-0001-9439-5346	CC0
-mesh:D001640	skos:exactMatch	chebi:CHEBI:3092	Bicuculline	bicuculline	orcid:0000-0001-9439-5346	CC0
-mesh:D001645	skos:exactMatch	chebi:CHEBI:53662	Biguanides	biguanides	orcid:0000-0001-9439-5346	CC0
-mesh:D001708	skos:exactMatch	chebi:CHEBI:15373	Biopterin	biopterin	orcid:0000-0001-9439-5346	CC0
-mesh:D001710	skos:exactMatch	chebi:CHEBI:15956	Biotin	biotin	orcid:0000-0001-9439-5346	CC0
-mesh:D001726	skos:exactMatch	chebi:CHEBI:3125	Bisacodyl	Bisacodyl	orcid:0000-0001-9439-5346	CC0
-mesh:D001735	skos:exactMatch	chebi:CHEBI:3131	Bithionol	bithionol	orcid:0000-0001-9439-5346	CC0
-mesh:D001737	skos:exactMatch	chebi:CHEBI:18138	Biuret	biuret	orcid:0000-0001-9439-5346	CC0
-mesh:D001839	skos:exactMatch	chebi:CHEBI:80229	Bombesin	Bombesin	orcid:0000-0001-9439-5346	CC0
-mesh:D001865	skos:exactMatch	chebi:CHEBI:77742	Bongkrekic Acid	bongkrekic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D001880	skos:exactMatch	chebi:CHEBI:33589	Boranes	boranes	orcid:0000-0001-9439-5346	CC0
-mesh:D001881	skos:exactMatch	chebi:CHEBI:22910	Borates	borates	orcid:0000-0001-9439-5346	CC0
-mesh:D001888	skos:exactMatch	chebi:CHEBI:59765	Boric Acids	boric acids	orcid:0000-0001-9439-5346	CC0
-mesh:D001889	skos:exactMatch	chebi:CHEBI:38270	Borinic Acids	borinic acids	orcid:0000-0001-9439-5346	CC0
-mesh:D001897	skos:exactMatch	chebi:CHEBI:38269	Boronic Acids	boronic acids	orcid:0000-0001-9439-5346	CC0
-mesh:D001960	skos:exactMatch	chebi:CHEBI:31302	Bromazepam	Bromazepam	orcid:0000-0001-9439-5346	CC0
-mesh:D002027	skos:exactMatch	chebi:CHEBI:3210	Bufotenin	bufotenin	orcid:0000-0001-9439-5346	CC0
-mesh:D002040	skos:exactMatch	chebi:CHEBI:6438	Levobunolol	levobunolol	orcid:0000-0001-9439-5346	CC0
-mesh:D002045	skos:exactMatch	chebi:CHEBI:3215	Bupivacaine	bupivacaine	orcid:0000-0001-9439-5346	CC0
-mesh:D002047	skos:exactMatch	chebi:CHEBI:3216	Buprenorphine	buprenorphine	orcid:0000-0001-9439-5346	CC0
-mesh:D002049	skos:exactMatch	chebi:CHEBI:3221	Burimamide	Burimamide	orcid:0000-0001-9439-5346	CC0
-mesh:D002065	skos:exactMatch	chebi:CHEBI:3223	Buspirone	buspirone	orcid:0000-0001-9439-5346	CC0
-mesh:D002074	skos:exactMatch	chebi:CHEBI:22951	Butanones	butanone	orcid:0000-0001-9439-5346	CC0
-mesh:D002077	skos:exactMatch	chebi:CHEBI:3242	Butorphanol	butorphanol	orcid:0000-0001-9439-5346	CC0
-mesh:D002092	skos:exactMatch	chebi:CHEBI:41055	Butyrylthiocholine	butyrylthiocholine	orcid:0000-0001-9439-5346	CC0
-mesh:D002103	skos:exactMatch	chebi:CHEBI:18127	Cadaverine	cadaverine	orcid:0000-0001-9439-5346	CC0
-mesh:D002104	skos:exactMatch	chebi:CHEBI:22977	Cadmium	cadmium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D002110	skos:exactMatch	chebi:CHEBI:27732	Caffeine	caffeine	orcid:0000-0001-9439-5346	CC0
-mesh:D002164	skos:exactMatch	chebi:CHEBI:36773	Camphor	camphor	orcid:0000-0001-9439-5346	CC0
-mesh:D002166	skos:exactMatch	chebi:CHEBI:27656	Camptothecin	camptothecin	orcid:0000-0001-9439-5346	CC0
-mesh:D002174	skos:exactMatch	chebi:CHEBI:354984	Candicidin	candicidin	orcid:0000-0001-9439-5346	CC0
-mesh:D002186	skos:exactMatch	chebi:CHEBI:67194	Cannabinoids	cannabinoid	orcid:0000-0001-9439-5346	CC0
-mesh:D002187	skos:exactMatch	chebi:CHEBI:3360	Cannabinol	Cannabinol	orcid:0000-0001-9439-5346	CC0
-mesh:D002193	skos:exactMatch	chebi:CHEBI:64213	Cantharidin	cantharidin	orcid:0000-0001-9439-5346	CC0
-mesh:D002211	skos:exactMatch	chebi:CHEBI:3374	Capsaicin	capsaicin	orcid:0000-0001-9439-5346	CC0
-mesh:D002220	skos:exactMatch	chebi:CHEBI:3387	Carbamazepine	carbamazepine	orcid:0000-0001-9439-5346	CC0
-mesh:D002129	skos:exactMatch	chebi:CHEBI:60579	Calcium Oxalate	calcium oxalate	orcid:0000-0001-9439-5346	CC0
-mesh:D002261	skos:exactMatch	chebi:CHEBI:3405	Carboxin	carboxin	orcid:0000-0001-9439-5346	CC0
-mesh:D002260	skos:exactMatch	chebi:CHEBI:3403	Carboprost	carboprost	orcid:0000-0001-9439-5346	CC0
-mesh:D002323	skos:exactMatch	chebi:CHEBI:3414	Carfecillin	carfecillin	orcid:0000-0001-9439-5346	CC0
-mesh:D002328	skos:exactMatch	chebi:CHEBI:3419	Carisoprodol	carisoprodol	orcid:0000-0001-9439-5346	CC0
-mesh:D002330	skos:exactMatch	chebi:CHEBI:3423	Carmustine	carmustine	orcid:0000-0001-9439-5346	CC0
-mesh:D002336	skos:exactMatch	chebi:CHEBI:15727	Carnosine	carnosine	orcid:0000-0001-9439-5346	CC0
-mesh:D002351	skos:exactMatch	chebi:CHEBI:3435	Carrageenan	carrageenan	orcid:0000-0001-9439-5346	CC0
-mesh:D002354	skos:exactMatch	chebi:CHEBI:3437	Carteolol	carteolol	orcid:0000-0001-9439-5346	CC0
-mesh:D002395	skos:exactMatch	chebi:CHEBI:33567	Catecholamines	catecholamine	orcid:0000-0001-9439-5346	CC0
-mesh:D002396	skos:exactMatch	chebi:CHEBI:33566	Catechols	catechols	orcid:0000-0001-9439-5346	CC0
-mesh:D002412	skos:exactMatch	chebi:CHEBI:36916	Cations	cation	orcid:0000-0001-9439-5346	CC0
-mesh:D002433	skos:exactMatch	chebi:CHEBI:3478	Cefaclor	cefaclor	orcid:0000-0001-9439-5346	CC0
-mesh:D002438	skos:exactMatch	chebi:CHEBI:3493	Cefoperazone	cefoperazone	orcid:0000-0001-9439-5346	CC0
-mesh:D002440	skos:exactMatch	chebi:CHEBI:209807	Cefoxitin	cefoxitin	orcid:0000-0001-9439-5346	CC0
-mesh:D002441	skos:exactMatch	chebi:CHEBI:3507	Cefsulodin	cefsulodin	orcid:0000-0001-9439-5346	CC0
-mesh:D002444	skos:exactMatch	chebi:CHEBI:3515	Cefuroxime	cefuroxime	orcid:0000-0001-9439-5346	CC0
-mesh:D002475	skos:exactMatch	chebi:CHEBI:17057	Cellobiose	cellobiose	orcid:0000-0001-9439-5346	CC0
-mesh:D002492	skos:exactMatch	chebi:CHEBI:35488	Central Nervous System Depressants	central nervous system depressant	orcid:0000-0001-9439-5346	CC0
-mesh:D002504	skos:exactMatch	chebi:CHEBI:6712	Meclofenoxate	Meclofenoxate	orcid:0000-0001-9439-5346	CC0
-mesh:D002506	skos:exactMatch	chebi:CHEBI:3534	Cephalexin	cephalexin	orcid:0000-0001-9439-5346	CC0
-mesh:D002509	skos:exactMatch	chebi:CHEBI:3537	Cephaloridine	cefaloridine	orcid:0000-0001-9439-5346	CC0
-mesh:D002513	skos:exactMatch	chebi:CHEBI:55429	Cephamycins	cephamycin	orcid:0000-0001-9439-5346	CC0
-mesh:D002515	skos:exactMatch	chebi:CHEBI:3547	Cephradine	cephradine	orcid:0000-0001-9439-5346	CC0
-mesh:D002518	skos:exactMatch	chebi:CHEBI:17761	Ceramides	ceramide	orcid:0000-0001-9439-5346	CC0
-mesh:D002554	skos:exactMatch	chebi:CHEBI:23079	Cerebrosides	cerebroside	orcid:0000-0001-9439-5346	CC0
-mesh:D002569	skos:exactMatch	chebi:CHEBI:171741	Cerulenin	cerulenin	orcid:0000-0001-9439-5346	CC0
-mesh:D002599	skos:exactMatch	chebi:CHEBI:27618	Chalcone	chalcone	orcid:0000-0001-9439-5346	CC0
-mesh:D002606	skos:exactMatch	chebi:CHEBI:91090	Charcoal	charcoal	orcid:0000-0001-9439-5346	CC0
-mesh:D002629	skos:exactMatch	chebi:CHEBI:23092	Chemosterilants	chemosterilant	orcid:0000-0001-9439-5346	CC0
-mesh:D002635	skos:exactMatch	chebi:CHEBI:16755	Chenodeoxycholic Acid	chenodeoxycholic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D002686	skos:exactMatch	chebi:CHEBI:17029	Chitin	chitin	orcid:0000-0001-9439-5346	CC0
-mesh:D002698	skos:exactMatch	chebi:CHEBI:81902	Chloralose	Chloralose	orcid:0000-0001-9439-5346	CC0
-mesh:D002701	skos:exactMatch	chebi:CHEBI:17698	Chloramphenicol	chloramphenicol	orcid:0000-0001-9439-5346	CC0
-mesh:D002716	skos:exactMatch	chebi:CHEBI:81850	Chlormequat	chlormequat	orcid:0000-0001-9439-5346	CC0
-mesh:D002722	skos:exactMatch	chebi:CHEBI:23132	Chlorobenzenes	chlorobenzenes	orcid:0000-0001-9439-5346	CC0
-mesh:D002723	skos:exactMatch	chebi:CHEBI:23133	Chlorobenzoates	chlorobenzoate	orcid:0000-0001-9439-5346	CC0
-mesh:D002733	skos:exactMatch	chebi:CHEBI:23150	Chlorophenols	chlorophenol	orcid:0000-0001-9439-5346	CC0
-mesh:D002735	skos:exactMatch	chebi:CHEBI:38206	Chlorophyllides	chlorophyllide	orcid:0000-0001-9439-5346	CC0
-mesh:D002738	skos:exactMatch	chebi:CHEBI:3638	Chloroquine	chloroquine	orcid:0000-0001-9439-5346	CC0
-mesh:D002743	skos:exactMatch	chebi:CHEBI:3642	Chlorphenesin	chlorphenesin	orcid:0000-0001-9439-5346	CC0
-mesh:D002746	skos:exactMatch	chebi:CHEBI:3647	Chlorpromazine	chlorpromazine	orcid:0000-0001-9439-5346	CC0
-mesh:D002748	skos:exactMatch	chebi:CHEBI:34630	Chlorpropham	chlorpropham	orcid:0000-0001-9439-5346	CC0
-mesh:D002710	skos:exactMatch	chebi:CHEBI:3614	Chlorhexidine	chlorhexidine	orcid:0000-0001-9439-5346	CC0
-mesh:D009681	skos:exactMatch	go:GO:0000741	Nuclear Fusion	karyogamy	orcid:0000-0003-4423-4370	CC0
-mesh:D010588	skos:exactMatch	go:GO:0045335	Phagosomes	phagocytic vesicle	orcid:0000-0003-4423-4370	CC0
-mesh:D010863	skos:exactMatch	go:GO:0097195	Piloerection	pilomotor reflex	orcid:0000-0003-4423-4370	CC0
-mesh:D011132	skos:exactMatch	go:GO:0005844	Polyribosomes	polysome	orcid:0000-0003-4423-4370	CC0
-mesh:D011768	skos:exactMatch	go:GO:0045254	Pyruvate Dehydrogenase Complex	pyruvate dehydrogenase complex	orcid:0000-0003-4423-4370	CC0
-mesh:D010427	skos:exactMatch	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-mesh:D008893	skos:exactMatch	go:GO:0060156	Milk Ejection	milk ejection reflex	orcid:0000-0003-4423-4370	CC0
-mesh:D009411	skos:exactMatch	go:GO:0043679	Nerve Endings	axon terminus	orcid:0000-0003-4423-4370	CC0
-mesh:D008066	skos:exactMatch	go:GO:0016042	Lipolysis	lipid catabolic process	orcid:0000-0003-4423-4370	CC0
-mesh:D015922	skos:exactMatch	go:GO:0062167	Complement C1q	complement component C1q complex	orcid:0000-0003-4423-4370	CC0
-mesh:D013082	skos:exactMatch	go:GO:0036126	Sperm Tail	sperm flagellum	orcid:0000-0003-4423-4370	CC0
-mesh:D017735	skos:exactMatch	go:GO:0019042	Virus Latency	viral latency	orcid:0000-0003-4423-4370	CC0
-mesh:D019065	skos:exactMatch	go:GO:0019068	Virus Assembly	virion assembly	orcid:0000-0003-4423-4370	CC0
-mesh:D019897	skos:exactMatch	go:GO:0042597	Periplasm	periplasmic space	orcid:0000-0003-4423-4370	CC0
-mesh:D020219	skos:exactMatch	go:GO:0051216	Chondrogenesis	cartilage development	orcid:0000-0003-4423-4370	CC0
-mesh:D020541	skos:exactMatch	go:GO:0015030	Coiled Bodies	Cajal body	orcid:0000-0003-4423-4370	CC0
-mesh:D042583	skos:exactMatch	go:GO:0001946	Lymphangiogenesis	lymphangiogenesis	orcid:0000-0003-4423-4370	CC0
-mesh:D022001	skos:exactMatch	go:GO:0005925	Focal Adhesions	focal adhesion	orcid:0000-0003-4423-4370	CC0
-mesh:D022101	skos:exactMatch	go:GO:0005815	Microtubule-Organizing Center	microtubule organizing center	orcid:0000-0003-4423-4370	CC0
-mesh:D023902	skos:exactMatch	go:GO:0007129	Chromosome Pairing	synapsis	orcid:0000-0003-4423-4370	CC0
-mesh:D045346	skos:exactMatch	go:GO:0009512	Cytochrome b6f Complex	cytochrome b6f complex	orcid:0000-0003-4423-4370	CC0
-mesh:D021982	skos:exactMatch	go:GO:0030055	Cell-Matrix Junctions	cell-substrate junction	orcid:0000-0003-4423-4370	CC0
-mesh:D050261	skos:exactMatch	go:GO:0005980	Glycogenolysis	glycogen catabolic process	orcid:0000-0003-4423-4370	CC0
-mesh:D051738	skos:exactMatch	go:GO:0000808	Origin Recognition Complex	origin recognition complex	orcid:0000-0003-4423-4370	CC0
-mesh:D053038	skos:exactMatch	go:GO:0009372	Quorum Sensing	quorum sensing	orcid:0000-0003-4423-4370	CC0
-mesh:D053205	skos:exactMatch	go:GO:0090406	Pollen Tube	pollen tube	orcid:0000-0003-4423-4370	CC0
-mesh:D053298	skos:exactMatch	go:GO:0034360	Chylomicron Remnants	chylomicron remnant	orcid:0000-0003-4423-4370	CC0
-mesh:C081483	skos:exactMatch	go:GO:0070505	tryphine	pollen coat	orcid:0000-0003-4423-4370	CC0
-mesh:C118437	skos:exactMatch	go:GO:0032021	negative elongation factor	NELF complex	orcid:0000-0003-4423-4370	CC0
-mesh:D000077279	skos:exactMatch	go:GO:0046944	Protein Carbamylation	protein carbamoylation	orcid:0000-0003-4423-4370	CC0
-mesh:D000177	skos:exactMatch	go:GO:0001669	Acrosome	acrosomal vesicle	orcid:0000-0003-4423-4370	CC0
-mesh:D000917	skos:exactMatch	go:GO:0002377	Antibody Formation	immunoglobulin production	orcid:0000-0003-4423-4370	CC0
-mesh:D003214	skos:exactMatch	go:GO:0008306	Conditioning, Classical	associative learning	orcid:0000-0003-4423-4370	CC0
-mesh:D005106	skos:exactMatch	go:GO:0035640	Exploratory Behavior	exploration behavior	orcid:0000-0003-4423-4370	CC0
-mesh:D005407	skos:exactMatch	go:GO:0005929	Flagella	cilium	orcid:0000-0003-4423-4370	CC0
-mesh:D007401	skos:exactMatch	go:GO:0030325	Interrenal Gland	adrenal gland development	orcid:0000-0003-4423-4370	CC0
-mesh:D005498	skos:exactMatch	go:GO:0001541	Follicular Phase	ovarian follicle development	orcid:0000-0003-4423-4370	CC0
-mesh:D000374	skos:exactMatch	go:GO:0002118	Aggression	aggressive behavior	orcid:0000-0003-4423-4370	CC0
-mesh:D000920	skos:exactMatch	go:GO:0001788	Antibody-Dependent Cell Cytotoxicity	antibody-dependent cellular cytotoxicity	orcid:0000-0003-4423-4370	CC0
-mesh:D007113	skos:exactMatch	go:GO:0045087	Immunity, Innate	innate immune response	orcid:0000-0003-4423-4370	CC0
-mesh:D014074	skos:exactMatch	go:GO:0034505	Tooth Calcification	tooth mineralization	orcid:0000-0003-4423-4370	CC0
-mesh:D017201	skos:exactMatch	go:GO:0019076	Virus Shedding	viral release from host cell	orcid:0000-0003-4423-4370	CC0
-mesh:D055697	skos:exactMatch	go:GO:0050909	Taste Perception	sensory perception of taste	orcid:0000-0003-4423-4370	CC0
-mesh:D054261	skos:exactMatch	go:GO:0001841	Neurulation	neural tube formation	orcid:0000-0003-4423-4370	CC0
-mesh:D053444	skos:exactMatch	go:GO:0060080	Inhibitory Postsynaptic Potentials	inhibitory postsynaptic potential	orcid:0000-0003-4423-4370	CC0
-mesh:D056245	skos:exactMatch	go:GO:0016581	Mi-2 Nucleosome Remodeling and Deacetylase Complex	NuRD complex	orcid:0000-0003-4423-4370	CC0
-mesh:D056827	skos:exactMatch	go:GO:0036452	Endosomal Sorting Complexes Required for Transport	ESCRT complex	orcid:0000-0003-4423-4370	CC0
-mesh:D058207	skos:exactMatch	go:GO:0016925	Sumoylation	protein sumoylation	orcid:0000-0003-4423-4370	CC0
-mesh:D057131	skos:exactMatch	go:GO:0042783	Immune Evasion	evasion of host immune response	orcid:0000-0003-4423-4370	CC0
-mesh:D060746	skos:exactMatch	go:GO:0036503	Endoplasmic Reticulum-Associated Degradation	ERAD pathway	orcid:0000-0003-4423-4370	CC0
-mesh:D063326	skos:exactMatch	go:GO:0000178	Exosome Multienzyme Ribonuclease Complex	exosome (RNase complex)	orcid:0000-0003-4423-4370	CC0
-mesh:D064113	skos:exactMatch	go:GO:0099048	CRISPR-Cas Systems	CRISPR-cas system	orcid:0000-0003-4423-4370	CC0
-mesh:D064173	skos:exactMatch	go:GO:0005680	Anaphase-Promoting Complex-Cyclosome	anaphase-promoting complex	orcid:0000-0003-4423-4370	CC0
-mesh:D064210	skos:exactMatch	go:GO:0019748	Secondary Metabolism	secondary metabolic process	orcid:0000-0003-4423-4370	CC0
-mesh:D064527	skos:exactMatch	go:GO:0009647	Etiolation	skotomorphogenesis	orcid:0000-0003-4423-4370	CC0
-mesh:D013014	skos:exactMatch	go:GO:0009432	SOS Response (Genetics)	SOS response	orcid:0000-0003-4423-4370	CC0
-mesh:D002952	skos:exactMatch	go:GO:0006099	Citric Acid Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-mesh:D010012	skos:exactMatch	go:GO:0001503	Osteogenesis	ossification	orcid:0000-0003-4423-4370	CC0
-mesh:D011499	skos:exactMatch	go:GO:0043687	Protein Processing, Post-Translational	post-translational protein modification	orcid:0000-0003-4423-4370	CC0
-mesh:D014554	skos:exactMatch	go:GO:0060073	Urination	micturition	orcid:0000-0003-4423-4370	CC0
-mesh:D048750	skos:exactMatch	go:GO:0000280	Cell Nucleus Division	nuclear division	orcid:0000-0003-4423-4370	CC0
-mesh:D053843	skos:exactMatch	go:GO:0006298	DNA Mismatch Repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-mesh:C498714	skos:exactMatch	go:GO:0005742	TOM translocase	mitochondrial outer membrane translocase complex	orcid:0000-0003-4423-4370	CC0
-mesh:C048844	skos:exactMatch	efo:0005030	anti-IgG	anti-IgG	orcid:0000-0003-4423-4370	CC0
-mesh:C056900	skos:exactMatch	efo:0003266	neuromedin U	neuromedin U	orcid:0000-0003-4423-4370	CC0
-mesh:D056655	skos:exactMatch	hgnc:2535	Cathepsin H	CTSH	orcid:0000-0001-9439-5346	CC0
-mesh:D055312	skos:exactMatch	hgnc:2481	Cystatin A	CSTA	orcid:0000-0001-9439-5346	CC0
-mesh:D055313	skos:exactMatch	hgnc:2482	Cystatin B	CSTB	orcid:0000-0001-9439-5346	CC0
-mesh:D055316	skos:exactMatch	hgnc:2475	Cystatin C	CST3	orcid:0000-0001-9439-5346	CC0
-mesh:D055332	skos:exactMatch	hgnc:2478	Cystatin M	CST6	orcid:0000-0001-9439-5346	CC0
-kegg.pathway:map00030	skos:exactMatch	go:GO:0006098	Pentose phosphate pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00052	skos:exactMatch	go:GO:0006012	Galactose metabolism	galactose metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00061	skos:exactMatch	go:GO:0006633	Fatty acid biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00062	skos:exactMatch	go:GO:0030497	Fatty acid elongation	fatty acid elongation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00071	skos:exactMatch	go:GO:0009062	Fatty acid degradation	fatty acid catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00100	skos:exactMatch	go:GO:0006694	Steroid biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00190	skos:exactMatch	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00195	skos:exactMatch	go:GO:0015979	Photosynthesis	photosynthesis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00220	skos:exactMatch	go:GO:0006526	Arginine biosynthesis	arginine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00240	skos:exactMatch	go:GO:0006206	Pyrimidine metabolism	pyrimidine nucleobase metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00254	skos:exactMatch	go:GO:0045122	Aflatoxin biosynthesis	aflatoxin biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00281	skos:exactMatch	go:GO:1903447	Geraniol degradation	geraniol catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00300	skos:exactMatch	go:GO:0009085	Lysine biosynthesis	lysine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00310	skos:exactMatch	go:GO:0006554	Lysine degradation	lysine catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00331	skos:exactMatch	go:GO:0033050	Clavulanic acid biosynthesis	clavulanic acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00332	skos:exactMatch	go:GO:1901769	Carbapenem biosynthesis	carbapenem biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00340	skos:exactMatch	go:GO:0006547	Histidine metabolism	histidine metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00350	skos:exactMatch	go:GO:0006570	Tyrosine metabolism	tyrosine metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00362	skos:exactMatch	go:GO:0043639	Benzoate degradation	benzoate catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00380	skos:exactMatch	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00410	skos:exactMatch	go:GO:0019482	beta-Alanine metabolism	beta-alanine metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00460	skos:exactMatch	go:GO:0033052	Cyanoamino acid metabolism	cyanoamino acid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00473	skos:exactMatch	go:GO:0046436	D-Alanine metabolism	D-alanine metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00480	skos:exactMatch	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00510	skos:exactMatch	go:GO:0006487	N-Glycan biosynthesis	protein N-linked glycosylation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00521	skos:exactMatch	go:GO:0019872	Streptomycin biosynthesis	streptomycin biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00531	skos:exactMatch	go:GO:0006027	Glycosaminoglycan degradation	glycosaminoglycan catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00540	skos:exactMatch	go:GO:0009103	Lipopolysaccharide biosynthesis	lipopolysaccharide biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00550	skos:exactMatch	go:GO:0009252	Peptidoglycan biosynthesis	peptidoglycan biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04110	skos:exactMatch	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04144	skos:exactMatch	go:GO:0006897	Endocytosis	endocytosis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00561	skos:exactMatch	go:GO:0046486	Glycerolipid metabolism	glycerolipid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00562	skos:exactMatch	go:GO:0043647	Inositol phosphate metabolism	inositol phosphate metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00564	skos:exactMatch	go:GO:0006650	Glycerophospholipid metabolism	glycerophospholipid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00565	skos:exactMatch	go:GO:0046485	Ether lipid metabolism	ether lipid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00590	skos:exactMatch	go:GO:0019369	Arachidonic acid metabolism	arachidonic acid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00591	skos:exactMatch	go:GO:0043651	Linoleic acid metabolism	linoleic acid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00592	skos:exactMatch	go:GO:0036109	alpha-Linolenic acid metabolism	alpha-linolenic acid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00600	skos:exactMatch	go:GO:0006665	Sphingolipid metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00620	skos:exactMatch	go:GO:0006090	Pyruvate metabolism	pyruvate metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00622	skos:exactMatch	go:GO:0042184	Xylene degradation	xylene catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00623	skos:exactMatch	go:GO:0042203	Toluene degradation	toluene catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00626	skos:exactMatch	go:GO:1901170	Naphthalene degradation	naphthalene catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00633	skos:exactMatch	go:GO:0046263	Nitrotoluene degradation	nitrotoluene catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00640	skos:exactMatch	go:GO:0019541	Propanoate metabolism	propionate metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00643	skos:exactMatch	go:GO:0042207	Styrene degradation	styrene catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00680	skos:exactMatch	go:GO:0015947	Methane metabolism	methane metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00730	skos:exactMatch	go:GO:0006772	Thiamine metabolism	thiamine metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00740	skos:exactMatch	go:GO:0006771	Riboflavin metabolism	riboflavin metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00750	skos:exactMatch	go:GO:0042816	Vitamin B6 metabolism	vitamin B6 metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00780	skos:exactMatch	go:GO:0006768	Biotin metabolism	biotin metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00785	skos:exactMatch	go:GO:0009106	Lipoic acid metabolism	lipoate metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00790	skos:exactMatch	go:GO:0046656	Folate biosynthesis	folic acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00791	skos:exactMatch	go:GO:0019381	Atrazine degradation	atrazine catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00830	skos:exactMatch	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00901	skos:exactMatch	go:GO:0035835	Indole alkaloid biosynthesis	indole alkaloid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00902	skos:exactMatch	go:GO:0016099	Monoterpenoid biosynthesis	monoterpenoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00904	skos:exactMatch	go:GO:0016102	Diterpenoid biosynthesis	diterpenoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00905	skos:exactMatch	go:GO:0016132	Brassinosteroid biosynthesis	brassinosteroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00906	skos:exactMatch	go:GO:0016117	Carotenoid biosynthesis	carotenoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00908	skos:exactMatch	go:GO:0033398	Zeatin biosynthesis	zeatin biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00920	skos:exactMatch	go:GO:0006790	Sulfur metabolism	sulfur compound metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00930	skos:exactMatch	go:GO:0019384	Caprolactam degradation	caprolactam catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00940	skos:exactMatch	go:GO:0009699	Phenylpropanoid biosynthesis	phenylpropanoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00941	skos:exactMatch	go:GO:0009813	Flavonoid biosynthesis	flavonoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00942	skos:exactMatch	go:GO:0009718	Anthocyanin biosynthesis	anthocyanin-containing compound biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00943	skos:exactMatch	go:GO:0009717	Isoflavonoid biosynthesis	isoflavonoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00950	skos:exactMatch	go:GO:0033075	Isoquinoline alkaloid biosynthesis	isoquinoline alkaloid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00966	skos:exactMatch	go:GO:0019761	Glucosinolate biosynthesis	glucosinolate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00984	skos:exactMatch	go:GO:0006706	Steroid degradation	steroid catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map01212	skos:exactMatch	go:GO:0006631	Fatty acid metabolism	fatty acid metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04920	skos:exactMatch	go:GO:0033210	Adipocytokine signaling pathway	leptin-mediated signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map02024	skos:exactMatch	go:GO:0009372	Quorum sensing	quorum sensing	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03030	skos:exactMatch	go:GO:0006260	DNA replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03320	skos:exactMatch	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04071	skos:exactMatch	go:GO:0090520	Sphingolipid signaling pathway	sphingolipid mediated signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04012	skos:exactMatch	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04218	skos:exactMatch	go:GO:0090398	Cellular senescence	cellular senescence	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04917	skos:exactMatch	go:GO:0038161	Prolactin signaling pathway	prolactin signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04310	skos:exactMatch	go:GO:0016055	Wnt signaling pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03440	skos:exactMatch	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04390	skos:exactMatch	go:GO:0035329	Hippo signaling pathway	hippo signaling	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04210	skos:exactMatch	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04217	skos:exactMatch	go:GO:0070266	Necroptosis	necroptotic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04217	skos:exactMatch	mesh:D000079302	Necroptosis	Necroptosis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04216	skos:exactMatch	mesh:D000079403	Ferroptosis	Ferroptosis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04216	skos:exactMatch	go:GO:0097707	Ferroptosis	ferroptosis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00970	skos:exactMatch	go:GO:0043039	Aminoacyl-tRNA biosynthesis	tRNA aminoacylation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03013	skos:exactMatch	go:GO:0050658	RNA transport	RNA transport	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03018	skos:exactMatch	go:GO:0006401	RNA degradation	RNA catabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04115	skos:exactMatch	go:GO:0030330	p53 signaling pathway	DNA damage response, signal transduction by p53 class mediator	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04260	skos:exactMatch	go:GO:0060048	Cardiac muscle contraction	cardiac muscle contraction	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04270	skos:exactMatch	go:GO:0014829	Vascular smooth muscle contraction	vascular smooth muscle contraction	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04330	skos:exactMatch	go:GO:0007219	Notch signaling pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04340	skos:exactMatch	go:GO:0007224	Hedgehog signaling pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04360	skos:exactMatch	go:GO:0007411	Axon guidance	axon guidance	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04361	skos:exactMatch	go:GO:0031103	Axon regeneration	axon regeneration	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04380	skos:exactMatch	go:GO:0030316	Osteoclast differentiation	osteoclast differentiation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04611	skos:exactMatch	go:GO:0030168	Platelet activation	platelet activation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04612	skos:exactMatch	go:GO:0019882	Antigen processing and presentation	antigen processing and presentation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03430	skos:exactMatch	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04620	skos:exactMatch	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04621	skos:exactMatch	go:GO:0035872	NOD-like receptor signaling pathway	nucleotide-binding domain, leucine rich repeat containing receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04650	skos:exactMatch	go:GO:0042267	Natural killer cell mediated cytotoxicity	natural killer cell mediated cytotoxicity	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04660	skos:exactMatch	go:GO:0050852	T cell receptor signaling pathway	T cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04662	skos:exactMatch	go:GO:0050853	B cell receptor signaling pathway	B cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04710	skos:exactMatch	go:GO:0007623	Circadian rhythm	circadian rhythm	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04721	skos:exactMatch	go:GO:0099504	Synaptic vesicle cycle	synaptic vesicle cycle	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04722	skos:exactMatch	go:GO:0038179	Neurotrophin signaling pathway	neurotrophin signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04744	skos:exactMatch	go:GO:0007602	Phototransduction	phototransduction	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04911	skos:exactMatch	go:GO:0030073	Insulin secretion	insulin secretion	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04920	skos:exactMatch	go:GO:0033209	Adipocytokine signaling pathway	tumor necrosis factor-mediated signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04920	skos:exactMatch	go:GO:0033211	Adipocytokine signaling pathway	adiponectin-activated signaling pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04979	skos:exactMatch	go:GO:0008203	Cholesterol metabolism	cholesterol metabolic process	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04971	skos:exactMatch	go:GO:0001696	Gastric acid secretion	gastric acid secretion	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04714	skos:exactMatch	mesh:D022722	Thermogenesis	Thermogenesis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04720	skos:exactMatch	mesh:D017774	Long-term potentiation	Long-Term Potentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP100	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1002	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1009	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1011	speciesSpecific	go:GO:0050852	TCR Signaling Pathway	T cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1014	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1016	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1018	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1020	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1023	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1024	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1025	speciesSpecific	go:GO:0050853	B Cell Receptor Signaling Pathway	B cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP103	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1032	speciesSpecific	mesh:D000070576	NLR Proteins	NLR Proteins	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1050	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1053	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP999	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP964	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1083	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1290	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1254	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1200	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1539	speciesSpecific	go:GO:0001525	Angiogenesis	angiogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1393	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1351	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP179	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP429	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2862	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4758	speciesSpecific	mesh:D009404	Nephrotic syndrome	Nephrotic Syndrome	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1022	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1026	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1028	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1029	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1034	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1035	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1036	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1044	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1064	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1065	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1067	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1070	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1073	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1075	speciesSpecific	go:GO:0046655	Folate Metabolism	folic acid metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1086	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1101	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1105	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1119	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1126	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1135	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1142	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1148	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1152	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1153	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1141	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP116	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1186	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1189	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1203	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1204	speciesSpecific	go:GO:0006298	Mismatch Repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1079	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP109	speciesSpecific	go:GO:0006258	UDP-Glucose Conversion	UDP-glucose catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1105	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1105	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1118	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1133	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1205	speciesSpecific	go:GO:0035825	Homologous Recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1217	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1221	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1233	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1240	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1248	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1257	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1258	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1227	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1261	speciesSpecific	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1262	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1263	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1259	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1264	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1270	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1282	speciesSpecific	go:GO:0032259	Methylation	methylation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1283	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1292	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1295	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1296	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1297	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1299	speciesSpecific	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP13	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1300	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1301	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1302	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1308	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1309	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1314	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1223	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1229	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP123	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1230	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1231	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1232	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1247	speciesSpecific	go:GO:0032259	Methylation	methylation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP125	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1316	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP132	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1331	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1331	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1331	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1335	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1339	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1343	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1345	speciesSpecific	go:GO:0050852	T Cell Receptor Signaling Pathway	T cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1348	speciesSpecific	go:GO:0030521	Androgen Receptor Signaling Pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1349	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1352	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1355	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1366	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1372	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP138	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1383	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1384	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1387	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1388	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP14	speciesSpecific	go:GO:0005986	Sucrose Biosynthesis	sucrose biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP142	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1449	speciesSpecific	go:GO:0034121	Regulation of toll-like receptor signaling pathway	regulation of toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1453	speciesSpecific	go:GO:0040025	Vulval development	vulval development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP146	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1489	speciesSpecific	go:GO:0031929	TOR signaling	TOR signaling	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1495	speciesSpecific	go:GO:0006544	Glycine Metabolism	glycine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP150	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1518	speciesSpecific	go:GO:0006532	Aspartate Biosynthesis	aspartate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1531	speciesSpecific	go:GO:0042359	Vitamin D Metabolism	vitamin D metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1533	speciesSpecific	go:GO:0009235	Vitamin B12 Metabolism	cobalamin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1538	speciesSpecific	go:GO:0009813	Flavonoid Biosynthesis	flavonoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP154	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1541	speciesSpecific	mesh:D004734	Energy Metabolism	Energy Metabolism	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP155	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP155	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP155	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP156	speciesSpecific	go:GO:0006094	Gluconeogenesis	gluconeogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP158	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP160	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1600	speciesSpecific	go:GO:0018933	Nicotine Metabolism	nicotine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP164	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP165	speciesSpecific	go:GO:0000162	Tryptophan Biosynthesis	tryptophan biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP171	speciesSpecific	go:GO:0034355	NAD Salvage Pathway	NAD salvage	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP172	speciesSpecific	go:GO:0042213	m-cresol degradation	m-cresol catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP173	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP175	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP176	speciesSpecific	go:GO:0046655	Folate Metabolism	folic acid metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1771	speciesSpecific	go:GO:0006657	Kennedy pathway	CDP-choline pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP178	speciesSpecific	go:GO:0006550	Isoleucine Degradation	isoleucine catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP18	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP180	speciesSpecific	go:GO:0009098	Leucine Biosynthesis	leucine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP181	speciesSpecific	go:GO:0019334	P-cymene Degradation	p-cymene catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP183	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP186	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP188	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP19	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP192	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP196	speciesSpecific	go:GO:0006750	Glutathione Biosynthesis	glutathione biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2	speciesSpecific	go:GO:0009099	Valine Biosynthesis	valine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP200	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2037	speciesSpecific	go:GO:0038161	Prolactin Signaling Pathway	prolactin signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP159	speciesSpecific	go:GO:0019277	UDP-N-Acetylgalactosamine Biosynthesis	UDP-N-acetylgalactosamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1591	speciesSpecific	go:GO:0007507	Heart Development	heart development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP1596	speciesSpecific	efo:0005882	Iron Homeostasis	iron ion homeostasis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2067	speciesSpecific	go:GO:0007507	Heart Development	heart development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP208	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP211	speciesSpecific	go:GO:0030509	BMP signaling pathway	BMP signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP214	speciesSpecific	go:GO:0006086	Pyruvate Dehydrogenase Pathway	acetyl-CoA biosynthetic process from pyruvate	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP216	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2224	speciesSpecific	go:GO:1904070	Ascaroside Biosynthesis	ascaroside biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2276	speciesSpecific	go:GO:0010001	Glial Cell Differentiation	glial cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2279	speciesSpecific	go:GO:0048316	Seed Development	seed development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2316	speciesSpecific	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2318	speciesSpecific	go:GO:0019395	Fatty acid oxidation	fatty acid oxidation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP236	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP236	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP236	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP241	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2313	speciesSpecific	mesh:D000375	Aging	Aging	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2313	speciesSpecific	go:GO:0007568	Aging	aging	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP23	speciesSpecific	go:GO:0050853	B Cell Receptor Signaling Pathway	B cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP228	speciesSpecific	go:GO:0019692	Deoxyribose phosphate metabolism	deoxyribose phosphate metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2436	speciesSpecific	go:GO:0042417	Dopamine metabolism	dopamine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP250	speciesSpecific	go:GO:0009097	Isoleucine Biosynthesis	isoleucine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP251	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP253	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP254	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP261	speciesSpecific	go:GO:0006545	Glycine biosynthesis	glycine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2621	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP844	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP96	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4787	speciesSpecific	go:GO:0001649	Osteoblast differentiation	osteoblast differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2863	speciesSpecific	go:GO:0006099	Krebs cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3184	speciesSpecific	go:GO:0001525	Angiogenesis	angiogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP282	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP295	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2622	speciesSpecific	go:GO:0005982	Starch Metabolism	starch metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP269	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP270	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP275	speciesSpecific	go:GO:0006526	Arginine Biosynthesis	arginine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP281	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2826	speciesSpecific	go:GO:0050783	Cocaine metabolism	cocaine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP266	speciesSpecific	go:GO:0019432	Triglyceride Biosynthesis	triglyceride biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP264	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2623	speciesSpecific	go:GO:0005985	Sucrose Metabolism	sucrose metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP224	speciesSpecific	go:GO:0019564	Aerobic Glycerol Catabolism	aerobic glycerol catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2849	speciesSpecific	go:GO:0060218	Hematopoietic Stem Cell Differentiation	hematopoietic stem cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2872	speciesSpecific	go:GO:0050872	White fat cell differentiation	white fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP29	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP301	speciesSpecific	go:GO:0006569	Tryptophan Degradation	tryptophan catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP302	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP305	speciesSpecific	go:GO:0008211	Glucocorticoid Metabolism	glucocorticoid metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP291	speciesSpecific	go:GO:0007530	Sex determination	sex determination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2912	speciesSpecific	go:GO:0014829	Vascular smooth muscle contraction	vascular smooth muscle contraction	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP290	speciesSpecific	go:GO:0006596	Polyamine Biosynthesis	polyamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP2851	speciesSpecific	go:GO:0009873	Ethylene signaling pathway	ethylene-activated signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP280	speciesSpecific	go:GO:0019415	Carbon monoxide dehydrogenase pathway	acetate biosynthetic process from carbon monoxide	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3256	speciesSpecific	go:GO:0031929	TOR Signaling	TOR signaling	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP306	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP310	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3118	speciesSpecific	go:GO:0015844	Monoamine Transport	monoamine transport	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3119	speciesSpecific	go:GO:0006974	DNA Damage Response	cellular response to DNA damage stimulus	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP312	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3132	speciesSpecific	go:GO:0034121	Regulation of toll-like receptor signaling pathway	regulation of toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3134	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3142	speciesSpecific	go:GO:0006544	Glycine Metabolism	glycine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3155	speciesSpecific	go:GO:0042417	Dopamine metabolism	dopamine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3162	speciesSpecific	go:GO:0042359	Vitamin D Metabolism	vitamin D metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3168	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3203	speciesSpecific	go:GO:0010001	Glial Cell Differentiation	glial cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3185	speciesSpecific	go:GO:0018933	Nicotine Metabolism	nicotine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP316	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3193	speciesSpecific	go:GO:0009235	Vitamin B12 Metabolism	cobalamin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3194	speciesSpecific	go:GO:0032933	SREBP signalling	SREBP signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP987	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP994	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP987	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP987	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP983	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP977	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3197	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3211	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP323	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3232	speciesSpecific	go:GO:0006665	Sphingolipid Metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3247	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3248	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP328	speciesSpecific	go:GO:0000256	Allantoin Degradation	allantoin catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3280	speciesSpecific	go:GO:0007507	Heart Development	heart development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP331	speciesSpecific	go:GO:0009088	Threonine Biosynthesis	threonine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP336	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP341	speciesSpecific	go:GO:0038092	Nodal Signaling Pathway	nodal signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP345	speciesSpecific	go:GO:0006546	Glycine Degradation	glycine catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP367	speciesSpecific	go:GO:0012501	Programmed Cell Death	programmed cell death	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP347	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP354	speciesSpecific	go:GO:0006552	Leucine Degradation	leucine catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP357	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP360	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP369	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP370	speciesSpecific	go:GO:0006665	Sphingolipid Metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP376	speciesSpecific	mesh:D012084	Renin - Angiotensin System	Renin-Angiotensin System	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP38	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3891	speciesSpecific	go:GO:0018910	Benzene metabolism	benzene metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP390	speciesSpecific	go:GO:0019496	Serine-isocitrate lyase pathway	serine-isocitrate lyase pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP3942	speciesSpecific	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP398	speciesSpecific	go:GO:0005992	Trehalose Anabolism	trehalose biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4020	speciesSpecific	go:GO:0035357	PPAR Signaling Pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4022	speciesSpecific	go:GO:0006206	Pyrimidine metabolism	pyrimidine nucleobase metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP403	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP404	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP408	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP411	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP412	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4149	speciesSpecific	go:GO:0050872	White fat cell differentiation	white fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP421	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP422	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4249	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4313	speciesSpecific	mesh:D000079403	Ferroptosis	Ferroptosis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4313	speciesSpecific	go:GO:0097707	Ferroptosis	ferroptosis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP432	speciesSpecific	go:GO:0006530	Asparagine degradation	asparagine catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4321	speciesSpecific	mesh:D022722	Thermogenesis	Thermogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP434	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP435	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP436	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP446	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4506	speciesSpecific	go:GO:0006570	Tyrosine Metabolism	tyrosine metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP451	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP46	speciesSpecific	go:GO:0009087	Methionine Degradation	methionine catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP461	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP463	speciesSpecific	go:GO:0019653	Purine Fermentation	anaerobic purine nucleobase catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP465	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP466	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP467	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP469	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP470	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP474	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP476	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP478	speciesSpecific	go:GO:0005980	Glycogen Catabolism	glycogen catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP4784	speciesSpecific	go:GO:0030166	Proteoglycan biosynthesis	proteoglycan biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP484	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP490	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP492	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP496	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP504	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP513	speciesSpecific	go:GO:0042423	Catecholamine synthesis	catecholamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP514	speciesSpecific	go:GO:0000105	Histidine Biosynthesis	histidine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP517	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP519	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP522	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP528	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP529	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP533	speciesSpecific	go:GO:0009085	Lysine Biosynthesis	lysine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP538	speciesSpecific	go:GO:0006571	Tyrosine Biosynthesis	tyrosine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP54	speciesSpecific	go:GO:0006527	Arginine degradation	arginine catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP542	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP545	speciesSpecific	go:GO:0006956	Complement Activation	complement activation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP55	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP550	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP551	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP561	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP564	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP565	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP568	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP574	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP575	speciesSpecific	go:GO:0009061	Anaerobic respiration	anaerobic respiration	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP59	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP60	speciesSpecific	go:GO:0042203	Toluene degradation	toluene catabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP618	speciesSpecific	go:GO:0009908	Flower Development	flower development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP623	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP626	speciesSpecific	go:GO:0009688	Abscisic Acid Biosynthesis	abscisic acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP627	speciesSpecific	go:GO:0019432	Triacylglycerol Biosynthesis	triglyceride biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP63	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP632	speciesSpecific	go:GO:0008203	Cholesterol metabolism	cholesterol metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP66	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP661	speciesSpecific	go:GO:0042593	Glucose Homeostasis	glucose homeostasis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP67	speciesSpecific	go:GO:0006529	Asparagine Biosynthesis	asparagine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP673	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP697	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP699	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP7	speciesSpecific	go:GO:0000097	Sulfur Amino Acid biosynthesis	sulfur amino acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP707	speciesSpecific	go:GO:0006974	DNA Damage Response	cellular response to DNA damage stimulus	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP727	speciesSpecific	go:GO:0015844	Monoamine Transport	monoamine transport	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP75	speciesSpecific	go:GO:0002224	Toll-like Receptor Signaling Pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP757	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP76	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP77	speciesSpecific	go:GO:0006537	Glutamate biosynthesis	glutamate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP785	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP787	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP79	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP790	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP793	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP796	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP798	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP802	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP804	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP805	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP81	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP833	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP835	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP84	speciesSpecific	go:GO:0009435	NAD Biosynthesis	NAD biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP848	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP85	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP86	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP865	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP869	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP869	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP869	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP87	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP897	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP899	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP9	speciesSpecific	go:GO:0008654	Phospholipid Biosynthesis	phospholipid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP905	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP906	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP909	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP91	speciesSpecific	go:GO:0019395	Fatty acid oxidation	fatty acid oxidation	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP912	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP917	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP925	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP952	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP955	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP967	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP969	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP97	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-wikipathways:WP391	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-109581	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-109582	speciesSpecific	go:GO:0007599	Hemostasis	hemostasis	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-109704	speciesSpecific	go:GO:0014065	PI3K Cascade	phosphatidylinositol 3-kinase signaling	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-114608	speciesSpecific	go:GO:0002576	Platelet degranulation	platelet degranulation	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-1187000	speciesSpecific	go:GO:0009566	Fertilization	fertilization	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-1234174	speciesSpecific	go:GO:0071456	Cellular response to hypoxia	cellular response to hypoxia	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-189451	speciesSpecific	go:GO:0006783	Heme biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-157579	speciesSpecific	go:GO:0000723	Telomere Maintenance	telomere maintenance	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-196807	speciesSpecific	go:GO:1901847	Nicotinate metabolism	nicotinate metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-196783	speciesSpecific	go:GO:0015937	Coenzyme A biosynthesis	coenzyme A biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-BTA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-CEL-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-CFA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-DDI-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-DME-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-DRE-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-GGA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-MMU-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-PFA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-RNO-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-SCE-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-SPO-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-SSC-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-XTR-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9646399	speciesSpecific	go:GO:0035973	Aggrephagy	aggrephagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-109581	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-351143	speciesSpecific	go:GO:0097055	Agmatine biosynthesis	agmatine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8964540	speciesSpecific	go:GO:0006522	Alanine metabolism	alanine metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-193048	speciesSpecific	go:GO:0006702	Androgen biosynthesis	androgen biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9612973	speciesSpecific	go:GO:0006914	Autophagy	autophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-422475	speciesSpecific	go:GO:0007411	Axon guidance	axon guidance	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73929	speciesSpecific	go:GO:0006285	Base-Excision Repair, AP Site Formation	base-excision repair, AP site formation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5576891	speciesSpecific	go:GO:0061337	Cardiac conduction	cardiac conduction	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-200425	speciesSpecific	go:GO:0009437	Carnitine metabolism	carnitine metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-71262	speciesSpecific	go:GO:0045329	Carnitine synthesis	carnitine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-209905	speciesSpecific	go:GO:0042423	Catecholamine biosynthesis	catecholamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1640170	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-69620	speciesSpecific	go:GO:0000075	Cell Cycle Checkpoints	cell cycle checkpoint	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-446728	speciesSpecific	go:GO:0034330	Cell junction organization	cell junction organization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1222541	speciesSpecific	go:GO:0045454	Cell redox homeostasis	cell redox homeostasis	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-421270	speciesSpecific	go:GO:0045216	Cell-cell junction organization	cell-cell junction organization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2559583	speciesSpecific	go:GO:0090398	Cellular Senescence	cellular senescence	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-3371556	speciesSpecific	go:GO:0034605	Cellular response to heat stress	cellular response to heat	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1234174	speciesSpecific	go:GO:0071456	Cellular response to hypoxia	cellular response to hypoxia	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9613829	speciesSpecific	mesh:D000080642	Chaperone Mediated Autophagy	Chaperone-Mediated Autophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-191273	speciesSpecific	go:GO:0006695	Cholesterol biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-6807047	speciesSpecific	go:GO:0033489	Cholesterol biosynthesis via desmosterol	cholesterol biosynthetic process via desmosterol	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-6798163	speciesSpecific	go:GO:0042426	Choline catabolism	choline catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2142753	speciesSpecific	go:GO:0019369	Arachidonic acid metabolism	arachidonic acid metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5620912	speciesSpecific	go:GO:0097711	Anchoring of the basal body to the plasma membrane	ciliary basal body-plasma membrane docking	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5617833	speciesSpecific	go:GO:0060271	Cilium Assembly	cilium assembly	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8963901	speciesSpecific	go:GO:0034371	Chylomicron remodeling	chylomicron remodeling	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8963888	speciesSpecific	go:GO:0034378	Chylomicron assembly	chylomicron assembly	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-156582	speciesSpecific	mesh:D000107	Acetylation	Acetylation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-6807062	speciesSpecific	go:GO:0033490	Cholesterol biosynthesis via lathosterol	cholesterol biosynthetic process via lathosterol	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2022870	speciesSpecific	go:GO:0030206	Chondroitin sulfate biosynthesis	chondroitin sulfate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-4839726	speciesSpecific	go:GO:0006325	Chromatin organization	chromatin organization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-400253	speciesSpecific	mesh:D057906	Circadian Clock	Circadian Clocks	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8856828	speciesSpecific	go:GO:0072583	Clathrin-mediated endocytosis	clathrin-dependent endocytosis	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-196783	speciesSpecific	go:GO:0015937	Coenzyme A biosynthesis	coenzyme A biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1442490	speciesSpecific	go:GO:0030574	Collagen degradation	collagen catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1474290	speciesSpecific	go:GO:0032964	Collagen formation	collagen biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-166658	speciesSpecific	go:GO:0006956	Complement cascade	complement activation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-71288	speciesSpecific	go:GO:0006600	Creatine metabolism	creatine metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8949613	speciesSpecific	go:GO:0042407	Cristae formation	cristae formation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73894	speciesSpecific	go:GO:0006281	DNA Repair	DNA repair	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-69306	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5334118	speciesSpecific	go:GO:0006306	DNA methylation	DNA methylation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-68952	speciesSpecific	go:GO:0006270	DNA replication initiation	DNA replication initiation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-69190	speciesSpecific	go:GO:0022616	DNA strand elongation	DNA strand elongation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-429914	speciesSpecific	go:GO:0000288	Deadenylation-dependent mRNA decay	nuclear-transcribed mRNA catabolic process, deadenylation-dependent decay	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73927	speciesSpecific	go:GO:0045007	Depurination	depurination	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73928	speciesSpecific	go:GO:0045008	Depyrimidination	depyrimidination	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2022923	speciesSpecific	go:GO:0030208	Dermatan sulfate biosynthesis	dermatan sulfate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5688426	speciesSpecific	go:GO:0016579	Deubiquitination	protein deubiquitination	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8935690	speciesSpecific	go:GO:0007586	Digestion	digestion	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2468052	speciesSpecific	go:GO:0034085	Establishment of Sister Chromatid Cohesion	establishment of sister chromatid cohesion	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-193144	speciesSpecific	go:GO:0006703	Estrogen biosynthesis	estrogen biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-71384	speciesSpecific	go:GO:0006069	Ethanol oxidation	ethanol oxidation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1474244	speciesSpecific	go:GO:0030198	Extracellular matrix organization	extracellular matrix organization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8978868	speciesSpecific	go:GO:0006631	Fatty acid metabolism	fatty acid metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1187000	speciesSpecific	go:GO:0009566	Fertilization	fertilization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5652227	speciesSpecific	go:GO:0046370	Fructose biosynthesis	fructose biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70350	speciesSpecific	go:GO:0006001	Fructose catabolism	fructose catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5652084	speciesSpecific	go:GO:0006000	Fructose metabolism	fructose metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-69236	speciesSpecific	go:GO:0051318	G1 Phase	G1 phase	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-69615	speciesSpecific	go:GO:0044783	G1/S DNA Damage Checkpoints	G1 DNA damage checkpoint	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-68911	speciesSpecific	go:GO:0051319	G2 Phase	G2 phase	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70370	speciesSpecific	go:GO:0019388	Galactose catabolism	galactose catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-190861	speciesSpecific	go:GO:0016264	Gap junction assembly	gap junction assembly	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-211000	speciesSpecific	go:GO:0031047	Gene Silencing by RNA	gene silencing by RNA	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70171	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-189483	speciesSpecific	go:GO:0042167	Heme degradation	heme catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-3322077	speciesSpecific	go:GO:0005978	Glycogen synthesis	glycogen biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-194002	speciesSpecific	go:GO:0006704	Glucocorticoid biosynthesis	glucocorticoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70263	speciesSpecific	go:GO:0006094	Gluconeogenesis	gluconeogenesis	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70326	speciesSpecific	go:GO:0006006	Glucose metabolism	glucose metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1483206	speciesSpecific	go:GO:0046474	Glycerophospholipid biosynthesis	glycerophospholipid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-6814848	speciesSpecific	go:GO:0046475	Glycerophospholipid catabolism	glycerophospholipid catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-6783984	speciesSpecific	go:GO:0006546	Glycine degradation	glycine catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8982491	speciesSpecific	go:GO:0005977	Glycogen metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1630316	speciesSpecific	go:GO:0030203	Glycosaminoglycan metabolism	glycosaminoglycan metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1660662	speciesSpecific	go:GO:0006687	Glycosphingolipid metabolism	glycosphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8963896	speciesSpecific	go:GO:0034380	HDL assembly	high-density lipoprotein particle assembly	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8964011	speciesSpecific	go:GO:0034384	HDL clearance	high-density lipoprotein particle clearance	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8964058	speciesSpecific	go:GO:0034375	HDL remodeling	high-density lipoprotein particle remodeling	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-189451	speciesSpecific	go:GO:0006783	Heme biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-109582	speciesSpecific	go:GO:0007599	Hemostasis	hemostasis	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70921	speciesSpecific	go:GO:0006548	Histidine catabolism	histidine catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2142845	speciesSpecific	go:GO:0030212	Hyaluronan metabolism	hyaluronan metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-168256	speciesSpecific	mesh:D007107	Immune System	Immune System	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1483249	speciesSpecific	go:GO:0043647	Inositol phosphate metabolism	inositol phosphate metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-264876	speciesSpecific	go:GO:0030070	Insulin processing	insulin processing	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-77387	speciesSpecific	go:GO:0038020	Insulin receptor recycling	insulin receptor recycling	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8963676	speciesSpecific	go:GO:0050892	Intestinal absorption	intestinal absorption	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8981373	speciesSpecific	go:GO:0106001	Intestinal hexose absorption	intestinal hexose absorption	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8963678	speciesSpecific	go:GO:0098856	Intestinal lipid absorption	intestinal lipid absorption	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5620924	speciesSpecific	go:GO:0042073	Intraflagellar transport	intraciliary transport	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5578775	speciesSpecific	go:GO:0050801	Ion homeostasis	ion homeostasis	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2022854	speciesSpecific	go:GO:0018146	Keratan sulfate biosynthesis	keratan sulfate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2022857	speciesSpecific	go:GO:0042340	Keratan sulfate degradation	keratan sulfate catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-6805567	speciesSpecific	go:GO:0031424	Keratinization	keratinization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-74182	speciesSpecific	go:GO:1902224	Ketone body metabolism	ketone body metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8964038	speciesSpecific	go:GO:0034383	LDL clearance	low-density lipoprotein particle clearance	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8964041	speciesSpecific	go:GO:0034374	LDL remodeling	low-density lipoprotein particle remodeling	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5653890	speciesSpecific	go:GO:0005989	Lactose synthesis	lactose biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9615710	speciesSpecific	go:GO:0061738	Late endosomal microautophagy	late endosomal microautophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8964572	speciesSpecific	go:GO:0034389	Lipid particle organization	lipid droplet organization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9613354	speciesSpecific	go:GO:0061724	Lipophagy	lipophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9620244	speciesSpecific	mesh:D017774	Long-term potentiation	Long-Term Potentiation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-71064	speciesSpecific	go:GO:0006554	Lysine catabolism	lysine catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-68886	speciesSpecific	go:GO:0000279	M Phase	M phase	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1632852	speciesSpecific	mesh:D000080550	Macroautophagy	Macroautophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1632852	speciesSpecific	go:GO:0016236	Macroautophagy	macroautophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1500620	speciesSpecific	mesh:D008540	Meiosis	Meiosis	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1500620	speciesSpecific	go:GO:0051321	Meiosis	meiotic cell cycle	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1430728	speciesSpecific	go:GO:0008152	Metabolism	metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-156581	speciesSpecific	go:GO:0032259	Methylation	methylation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-193993	speciesSpecific	go:GO:0006705	Mineralocorticoid biosynthesis	mineralocorticoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5358508	speciesSpecific	go:GO:0006298	Mismatch Repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1268020	speciesSpecific	go:GO:0006626	Mitochondrial protein import	protein targeting to mitochondrion	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-163316	speciesSpecific	go:GO:0006393	Mitochondrial transcription termination	termination of mitochondrial transcription	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5368287	speciesSpecific	go:GO:0032543	Mitochondrial translation	mitochondrial translation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5389840	speciesSpecific	go:GO:0070125	Mitochondrial translation elongation	mitochondrial translational elongation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5662702	speciesSpecific	go:GO:0042438	Melanin biosynthesis	melanin biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1237112	speciesSpecific	go:GO:0019509	Methionine salvage pathway	L-methionine salvage from methylthioadenosine	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5368286	speciesSpecific	go:GO:0070124	Mitochondrial translation initiation	mitochondrial translational initiation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5419276	speciesSpecific	go:GO:0070126	Mitochondrial translation termination	mitochondrial translational termination	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5205647	speciesSpecific	go:GO:0000423	Mitophagy	mitophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5205647	speciesSpecific	go:GO:0000422	Mitophagy	autophagy of mitochondrion	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-68882	speciesSpecific	go:GO:0000090	Mitotic Anaphase	mitotic anaphase	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-68881	speciesSpecific	go:GO:0007091	Mitotic Metaphase/Anaphase Transition	metaphase/anaphase transition of mitotic cell cycle	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-68877	speciesSpecific	go:GO:0000236	Mitotic Prometaphase	mitotic prometaphase	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-68875	speciesSpecific	go:GO:0000088	Mitotic Prophase	mitotic prophase	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-69618	speciesSpecific	go:GO:0071174	Mitotic Spindle Checkpoint	mitotic spindle checkpoint	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-397014	speciesSpecific	go:GO:0006936	Muscle contraction	muscle contraction	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-525793	speciesSpecific	go:GO:0007519	Myogenesis	skeletal muscle tissue development	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-525793	speciesSpecific	go:GO:0042692	Myogenesis	muscle cell differentiation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-389542	speciesSpecific	go:GO:0006740	NADPH regeneration	NADPH regeneration	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-167060	speciesSpecific	go:GO:0032455	NGF processing	nerve growth factor processing	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9675108	speciesSpecific	go:GO:0007399	Nervous system development	nervous system development	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-6798695	speciesSpecific	go:GO:0043312	Neutrophil degranulation	neutrophil degranulation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-196807	speciesSpecific	go:GO:1901847	Nicotinate metabolism	nicotinate metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2980766	speciesSpecific	go:GO:0051081	Nuclear Envelope Breakdown	nuclear envelope disassembly	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-72766	speciesSpecific	go:GO:0006412	Translation	translation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8956320	speciesSpecific	go:GO:0046112	Nucleobase biosynthesis	nucleobase biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8956319	speciesSpecific	go:GO:0046113	Nucleobase catabolism	nucleobase catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-774815	speciesSpecific	go:GO:0006334	Nucleosome assembly	nucleosome assembly	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8956321	speciesSpecific	go:GO:0043173	Nucleotide salvage	nucleotide salvage	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9664873	speciesSpecific	go:GO:0000425	Pexophagy	pexophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-561048	speciesSpecific	go:GO:0015711	Organic anion transport	organic anion transport	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-549127	speciesSpecific	go:GO:0015695	Organic cation transport	organic cation transport	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-109704	speciesSpecific	go:GO:0014065	PI3K Cascade	phosphatidylinositol 3-kinase signaling	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-71336	speciesSpecific	go:GO:0006098	Pentose phosphate pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1483257	speciesSpecific	go:GO:0006644	Phospholipid metabolism	phospholipid metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-114608	speciesSpecific	go:GO:0002576	Platelet degranulation	platelet degranulation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-389977	speciesSpecific	go:GO:0007023	Post-chaperonin tubulin folding pathway	post-chaperonin tubulin folding pathway	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-597592	speciesSpecific	go:GO:0043687	Post-translational protein modification	post-translational protein modification	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5357801	speciesSpecific	go:GO:0012501	Programmed Cell Death	programmed cell death	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70688	speciesSpecific	go:GO:0006562	Proline catabolism	proline catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-71032	speciesSpecific	go:GO:1902859	Propionyl-CoA catabolism	propionyl-CoA catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-391251	speciesSpecific	go:GO:0006457	Protein folding	protein folding	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9609507	speciesSpecific	go:GO:0008104	Protein localization	protein localization	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8876725	speciesSpecific	go:GO:0006479	Protein methylation	protein methylation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5676934	speciesSpecific	go:GO:0030091	Protein repair	protein repair	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8852135	speciesSpecific	go:GO:0016567	Protein ubiquitination	protein ubiquitination	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73817	speciesSpecific	go:GO:0009168	Purine ribonucleoside monophosphate biosynthesis	purine ribonucleoside monophosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-74217	speciesSpecific	go:GO:0043101	Purine salvage	purine-containing compound salvage	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73614	speciesSpecific	go:GO:0008655	Pyrimidine salvage	pyrimidine-containing compound salvage	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70268	speciesSpecific	go:GO:0006090	Pyruvate metabolism	pyruvate metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5213460	speciesSpecific	go:GO:0070266	RIPK1-mediated regulated necrosis	necroptotic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73863	speciesSpecific	go:GO:0006363	RNA Polymerase I Transcription Termination	termination of RNA polymerase I transcription	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73856	speciesSpecific	go:GO:0006369	RNA Polymerase II Transcription Termination	termination of RNA polymerase II transcription	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-73980	speciesSpecific	go:GO:0006386	RNA Polymerase III Transcription Termination	termination of RNA polymerase III transcription	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-977606	speciesSpecific	go:GO:0030449	Regulation of Complement cascade	regulation of complement activation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-422356	speciesSpecific	go:GO:0050796	Regulation of insulin secretion	regulation of insulin secretion	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-453276	speciesSpecific	go:GO:0007346	Regulation of mitotic cell cycle	regulation of mitotic cell cycle	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1474165	speciesSpecific	go:GO:0000003	Reproduction	reproduction	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5660526	speciesSpecific	go:GO:0010038	Response to metal ions	response to metal ion	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-69242	speciesSpecific	go:GO:0051320	S Phase	S phase	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2990846	speciesSpecific	mesh:D058207	SUMOylation	Sumoylation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2990846	speciesSpecific	go:GO:0016925	SUMOylation	protein sumoylation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9663891	speciesSpecific	go:GO:0061912	Selective autophagy	selective autophagy	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1799339	speciesSpecific	go:GO:0006614	SRP-dependent cotranslational protein targeting to membrane	SRP-dependent cotranslational protein targeting to membrane	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-2408557	speciesSpecific	go:GO:0016260	Selenocysteine synthesis	selenocysteine biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-162582	speciesSpecific	go:GO:0007165	Signal Transduction	signal transduction	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-445355	speciesSpecific	go:GO:0006939	Smooth Muscle Contraction	smooth muscle contraction	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-428157	speciesSpecific	go:GO:0006665	Sphingolipid metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-390522	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-1614635	speciesSpecific	go:GO:0000096	Sulfur amino acid metabolism	sulfur amino acid metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-157579	speciesSpecific	go:GO:0000723	Telomere Maintenance	telomere maintenance	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8849175	speciesSpecific	go:GO:0006567	Threonine catabolism	threonine catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-75944	speciesSpecific	go:GO:0006390	Transcription from mitochondrial promoters	mitochondrial transcription	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-75109	speciesSpecific	go:GO:0019432	Triglyceride biosynthesis	triglyceride biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-163560	speciesSpecific	go:GO:0019433	Triglyceride catabolism	triglyceride catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8979227	speciesSpecific	go:GO:0006641	Triglyceride metabolism	triglyceride metabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-71240	speciesSpecific	go:GO:0006569	Tryptophan catabolism	tryptophan catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8963684	speciesSpecific	go:GO:0006572	Tyrosine catabolism	tyrosine catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-70635	speciesSpecific	go:GO:0000050	Urea cycle	urea cycle	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-77108	speciesSpecific	go:GO:0046952	Utilization of Ketone Bodies	ketone body catabolic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8866423	speciesSpecific	go:GO:0034379	VLDL assembly	very-low-density lipoprotein particle assembly	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-8964046	speciesSpecific	go:GO:0034447	VLDL clearance	very-low-density lipoprotein particle clearance	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-5653656	speciesSpecific	go:GO:0016192	Vesicle-mediated transport	vesicle-mediated transport	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-9640463	speciesSpecific	go:GO:0010025	Wax biosynthesis	wax biosynthetic process	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-72187	speciesSpecific	go:GO:0031124	mRNA 3'-end processing	mRNA 3'-end processing	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-72086	speciesSpecific	go:GO:0006370	mRNA Capping	7-methylguanosine mRNA capping	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-72312	speciesSpecific	go:GO:0006364	rRNA processing	rRNA processing	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-379724	speciesSpecific	go:GO:0043039	tRNA Aminoacylation	tRNA aminoacylation	orcid:0000-0003-4423-4370	CC0
-reactome:R-HSA-72306	speciesSpecific	go:GO:0008033	tRNA processing	tRNA processing	orcid:0000-0003-4423-4370	CC0
-mesh:D000080242	skos:exactMatch	chebi:CHEBI:40304	8-Hydroxy-2'-Deoxyguanosine	8-hydroxy-2'-deoxyguanosine	orcid:0000-0001-9439-5346	CC0
-mesh:D000317	skos:exactMatch	chebi:CHEBI:37890	Adrenergic alpha-Antagonists	alpha-adrenergic antagonist	orcid:0000-0001-9439-5346	CC0
-mesh:D000316	skos:exactMatch	chebi:CHEBI:35569	Adrenergic alpha-Agonists	alpha-adrenergic agonist	orcid:0000-0001-9439-5346	CC0
-mesh:D000318	skos:exactMatch	chebi:CHEBI:35522	Adrenergic beta-Agonists	beta-adrenergic agonist	orcid:0000-0001-9439-5346	CC0
-mesh:D000319	skos:exactMatch	chebi:CHEBI:35530	Adrenergic beta-Antagonists	beta-adrenergic antagonist	orcid:0000-0001-9439-5346	CC0
-mesh:D000433	skos:exactMatch	chebi:CHEBI:28831	1-Propanol	propan-1-ol	orcid:0000-0001-9439-5346	CC0
-mesh:D000803	skos:exactMatch	chebi:CHEBI:2718	Angiotensin I	Angiotensin I	orcid:0000-0001-9439-5346	CC0
-mesh:D000805	skos:exactMatch	chebi:CHEBI:89666	Angiotensin III	Angiotensin III	orcid:0000-0001-9439-5346	CC0
-mesh:D000779	skos:exactMatch	chebi:CHEBI:36333	Anesthetics, Local	local anaesthetic	orcid:0000-0001-9439-5346	CC0
-mesh:D000894	skos:exactMatch	chebi:CHEBI:35475	Anti-Inflammatory Agents, Non-Steroidal	non-steroidal anti-inflammatory drug	orcid:0000-0001-9439-5346	CC0
-mesh:D000988	skos:exactMatch	chebi:CHEBI:145047	Antispermatogenic Agents	antispermatogenic agent	orcid:0000-0001-9439-5346	CC0
-mesh:D000993	skos:exactMatch	chebi:CHEBI:36050	Antitreponemal Agents	antitreponemal drug	orcid:0000-0001-9439-5346	CC0
-mesh:D001378	skos:exactMatch	chebi:CHEBI:35726	Azasteroids	aza-steroid	orcid:0000-0001-9439-5346	CC0
-mesh:D001455	skos:exactMatch	chebi:CHEBI:28908	Bambermycins	bambermycin	orcid:0000-0001-9439-5346	CC0
-mesh:D001603	skos:exactMatch	chebi:CHEBI:33391	Berkelium	berkelium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D001608	skos:exactMatch	chebi:CHEBI:30501	Beryllium	beryllium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D001615	skos:exactMatch	chebi:CHEBI:10415	beta-Endorphin	beta-endorphin	orcid:0000-0001-9439-5346	CC0
-mesh:D001895	skos:exactMatch	chebi:CHEBI:27560	Boron	boron atom	orcid:0000-0001-9439-5346	CC0
-mesh:D001969	skos:exactMatch	chebi:CHEBI:37149	Bromobenzenes	bromobenzenes	orcid:0000-0001-9439-5346	CC0
-mesh:D001971	skos:exactMatch	chebi:CHEBI:3181	Bromocriptine	bromocriptine	orcid:0000-0001-9439-5346	CC0
-mesh:D001977	skos:exactMatch	chebi:CHEBI:3183	Brompheniramine	brompheniramine	orcid:0000-0001-9439-5346	CC0
-mesh:D001978	skos:exactMatch	chebi:CHEBI:59424	Bromphenol Blue	bromophenol blue	orcid:0000-0001-9439-5346	CC0
-mesh:D001993	skos:exactMatch	chebi:CHEBI:35523	Bronchodilator Agents	bronchodilator agent	orcid:0000-0001-9439-5346	CC0
-mesh:D002118	skos:exactMatch	chebi:CHEBI:22984	Calcium	calcium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D002120	skos:exactMatch	chebi:CHEBI:38807	Calcium Channel Agonists	calcium channel agonist	orcid:0000-0001-9439-5346	CC0
-mesh:D002125	skos:exactMatch	chebi:CHEBI:3309	Calcium Gluconate	Calcium Gluconate	orcid:0000-0001-9439-5346	CC0
-mesh:D002142	skos:exactMatch	chebi:CHEBI:33392	Californium	californium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D002227	skos:exactMatch	chebi:CHEBI:48513	Carbazoles	carbazoles	orcid:0000-0001-9439-5346	CC0
-mesh:D002235	skos:exactMatch	chebi:CHEBI:34611	Carbofuran	carbofuran	orcid:0000-0001-9439-5346	CC0
-mesh:D002244	skos:exactMatch	chebi:CHEBI:27594	Carbon	carbon atom	orcid:0000-0001-9439-5346	CC0
-mesh:D002245	skos:exactMatch	chebi:CHEBI:16526	Carbon Dioxide	carbon dioxide	orcid:0000-0001-9439-5346	CC0
-mesh:D002254	skos:exactMatch	chebi:CHEBI:23016	Carbonates	carbonates	orcid:0000-0001-9439-5346	CC0
-mesh:D002308	skos:exactMatch	chebi:CHEBI:28494	Cardiolipins	cardiolipin	orcid:0000-0001-9439-5346	CC0
-mesh:D002301	skos:exactMatch	chebi:CHEBI:83970	Cardiac Glycosides	cardiac glycoside	orcid:0000-0001-9439-5346	CC0
-mesh:D002298	skos:exactMatch	chebi:CHEBI:74634	Cardenolides	cardenolides	orcid:0000-0001-9439-5346	CC0
-mesh:D002273	skos:exactMatch	chebi:CHEBI:50903	Carcinogens	carcinogenic agent	orcid:0000-0001-9439-5346	CC0
-mesh:D002740	skos:exactMatch	chebi:CHEBI:3640	Chlorothiazide	chlorothiazide	orcid:0000-0001-9439-5346	CC0
-mesh:D002745	skos:exactMatch	chebi:CHEBI:3646	Chlorphentermine	Chlorphentermine	orcid:0000-0001-9439-5346	CC0
-mesh:D002491	skos:exactMatch	chebi:CHEBI:35470	Central Nervous System Agents	central nervous system drug	orcid:0000-0001-9439-5346	CC0
-mesh:D002784	skos:exactMatch	chebi:CHEBI:16113	Cholesterol	cholesterol	orcid:0000-0001-9439-5346	CC0
-mesh:D002794	skos:exactMatch	chebi:CHEBI:15354	Choline	choline	orcid:0000-0001-9439-5346	CC0
-mesh:D002857	skos:exactMatch	chebi:CHEBI:28073	Chromium	chromium atom	orcid:0000-0001-9439-5346	CC0
-mesh:D002867	skos:exactMatch	chebi:CHEBI:23238	Chromones	chromones	orcid:0000-0001-9439-5346	CC0
-mesh:D002863	skos:exactMatch	chebi:CHEBI:75050	Chromogenic Compounds	chromogenic compound	orcid:0000-0001-9439-5346	CC0
-mesh:D002801	skos:exactMatch	chebi:CHEBI:50241	Cholinesterase Reactivators	cholinesterase reactivator	orcid:0000-0001-9439-5346	CC0
-mesh:D002939	skos:exactMatch	chebi:CHEBI:100241	Ciprofloxacin	ciprofloxacin	orcid:0000-0001-9439-5346	CC0
-mesh:D002934	skos:exactMatch	chebi:CHEBI:36091	Cinnamates	cinnamates	orcid:0000-0001-9439-5346	CC0
-mesh:D002930	skos:exactMatch	chebi:CHEBI:51323	Cinchona Alkaloids	cinchona alkaloid	orcid:0000-0001-9439-5346	CC0
-mesh:D003006	skos:exactMatch	chebi:CHEBI:59115	Clopenthixol	clopenthixol	orcid:0000-0001-9439-5346	CC0
-mesh:D002997	skos:exactMatch	chebi:CHEBI:47780	Clomipramine	clomipramine	orcid:0000-0001-9439-5346	CC0
-mesh:D002996	skos:exactMatch	chebi:CHEBI:3752	Clomiphene	clomiphene	orcid:0000-0001-9439-5346	CC0
-mesh:D002994	skos:exactMatch	chebi:CHEBI:3750	Clofibrate	clofibrate	orcid:0000-0001-9439-5346	CC0
-mesh:D003022	skos:exactMatch	chebi:CHEBI:3764	Clotrimazole	clotrimazole	orcid:0000-0001-9439-5346	CC0
-mesh:D003023	skos:exactMatch	chebi:CHEBI:49566	Cloxacillin	cloxacillin	orcid:0000-0001-9439-5346	CC0
-mesh:D003024	skos:exactMatch	chebi:CHEBI:3766	Clozapine	clozapine	orcid:0000-0001-9439-5346	CC0
-mesh:D003038	skos:exactMatch	chebi:CHEBI:23341	Cobamides	cobamides	orcid:0000-0001-9439-5346	CC0
-mesh:D003042	skos:exactMatch	chebi:CHEBI:27958	Cocaine	cocaine	orcid:0000-0001-9439-5346	CC0
-mesh:D003049	skos:exactMatch	chebi:CHEBI:35818	Coccidiostats	coccidiostat	orcid:0000-0001-9439-5346	CC0
-mesh:D003061	skos:exactMatch	chebi:CHEBI:16714	Codeine	codeine	orcid:0000-0001-9439-5346	CC0
-mesh:D003065	skos:exactMatch	chebi:CHEBI:15346	Coenzyme A	coenzyme A	orcid:0000-0001-9439-5346	CC0
-mesh:D003067	skos:exactMatch	chebi:CHEBI:23354	Coenzymes	coenzyme	orcid:0000-0001-9439-5346	CC0
-mesh:D003070	skos:exactMatch	chebi:CHEBI:16213	Coformycin	coformycin	orcid:0000-0001-9439-5346	CC0
-mesh:D003084	skos:exactMatch	chebi:CHEBI:3814	Colestipol	colestipol	orcid:0000-0001-9439-5346	CC0
-mesh:D003094	skos:exactMatch	chebi:CHEBI:3815	Collagen	Collagen	orcid:0000-0001-9439-5346	CC0
-mesh:D003224	skos:exactMatch	chebi:CHEBI:34653	Congo Red	Congo Red	orcid:0000-0001-9439-5346	CC0
-mesh:D003300	skos:exactMatch	chebi:CHEBI:28694	Copper	copper atom	orcid:0000-0001-9439-5346	CC0
-mesh:D003345	skos:exactMatch	chebi:CHEBI:16827	Corticosterone	corticosterone	orcid:0000-0001-9439-5346	CC0
-mesh:D003348	skos:exactMatch	chebi:CHEBI:16962	Cortisone	cortisone	orcid:0000-0001-9439-5346	CC0
-mesh:D003358	skos:exactMatch	chebi:CHEBI:64857	Cosmetics	cosmetic	orcid:0000-0001-9439-5346	CC0
-mesh:D003366	skos:exactMatch	chebi:CHEBI:3901	Cosyntropin	cosyntropin	orcid:0000-0001-9439-5346	CC0
-mesh:D003372	skos:exactMatch	chebi:CHEBI:3903	Coumaphos	coumaphos	orcid:0000-0001-9439-5346	CC0
-mesh:D003374	skos:exactMatch	chebi:CHEBI:23403	Coumarins	coumarins	orcid:0000-0001-9439-5346	CC0
-mesh:D003375	skos:exactMatch	chebi:CHEBI:3908	Coumestrol	coumestrol	orcid:0000-0001-9439-5346	CC0
-mesh:D003401	skos:exactMatch	chebi:CHEBI:16919	Creatine	creatine	orcid:0000-0001-9439-5346	CC0
-mesh:D003404	skos:exactMatch	chebi:CHEBI:16737	Creatinine	creatinine	orcid:0000-0001-9439-5346	CC0
-mesh:D003408	skos:exactMatch	chebi:CHEBI:25399	Cresols	cresol	orcid:0000-0001-9439-5346	CC0
-mesh:D003484	skos:exactMatch	chebi:CHEBI:16698	Cyanamide	cyanamide	orcid:0000-0001-9439-5346	CC0
-mesh:D003485	skos:exactMatch	chebi:CHEBI:23420	Cyanates	cyanates	orcid:0000-0001-9439-5346	CC0
-mesh:D003486	skos:exactMatch	chebi:CHEBI:23424	Cyanides	cyanides	orcid:0000-0001-9439-5346	CC0
-mesh:D003492	skos:exactMatch	chebi:CHEBI:17074	Cycasin	cycasin	orcid:0000-0001-9439-5346	CC0
-mesh:D003494	skos:exactMatch	chebi:CHEBI:82431	Cyclamates	Cyclamate	orcid:0000-0001-9439-5346	CC0
-mesh:D003501	skos:exactMatch	chebi:CHEBI:3994	Cyclizine	cyclizine	orcid:0000-0001-9439-5346	CC0
-mesh:D003505	skos:exactMatch	chebi:CHEBI:23456	Cyclodextrins	cyclodextrin	orcid:0000-0001-9439-5346	CC0
-mesh:D003506	skos:exactMatch	chebi:CHEBI:31446	Cyclofenil	Cyclofenil	orcid:0000-0001-9439-5346	CC0
-mesh:D003511	skos:exactMatch	chebi:CHEBI:23480	Cyclohexanols	cyclohexanols	orcid:0000-0001-9439-5346	CC0
-mesh:D003512	skos:exactMatch	chebi:CHEBI:23482	Cyclohexanones	cyclohexanones	orcid:0000-0001-9439-5346	CC0
-mesh:D003513	skos:exactMatch	chebi:CHEBI:27641	Cycloheximide	cycloheximide	orcid:0000-0001-9439-5346	CC0
-mesh:D003517	skos:exactMatch	chebi:CHEBI:23493	Cyclopentanes	cyclopentanes	orcid:0000-0001-9439-5346	CC0
-mesh:D003519	skos:exactMatch	chebi:CHEBI:4024	Cyclopentolate	cyclopentolate	orcid:0000-0001-9439-5346	CC0
-mesh:D003521	skos:exactMatch	chebi:CHEBI:51454	Cyclopropanes	cyclopropanes	orcid:0000-0001-9439-5346	CC0
-mesh:D003533	skos:exactMatch	chebi:CHEBI:4046	Cyproheptadine	cyproheptadine	orcid:0000-0001-9439-5346	CC0
-mesh:D003540	skos:exactMatch	chebi:CHEBI:17755	Cystathionine	cystathionine	orcid:0000-0001-9439-5346	CC0
-mesh:D003544	skos:exactMatch	chebi:CHEBI:21260	Cysteic Acid	cysteic acid	orcid:0000-0001-9439-5346	CC0
-mesh:D003545	skos:exactMatch	chebi:CHEBI:15356	Cysteine	cysteine	orcid:0000-0001-9439-5346	CC0
-mesh:D003548	skos:exactMatch	chebi:CHEBI:81392	Cysteinyldopa	Cysteinyldopa	orcid:0000-0001-9439-5346	CC0
-mesh:D003553	skos:exactMatch	chebi:CHEBI:17376	Cystine	cystine	orcid:0000-0001-9439-5346	CC0
-mesh:D003562	skos:exactMatch	chebi:CHEBI:17562	Cytidine	cytidine	orcid:0000-0001-9439-5346	CC0
-mesh:D003571	skos:exactMatch	chebi:CHEBI:23527	Cytochalasin B	cytochalasin B	orcid:0000-0001-9439-5346	CC0
-mesh:D003596	skos:exactMatch	chebi:CHEBI:16040	Cytosine	cytosine	orcid:0000-0001-9439-5346	CC0
-mesh:D003620	skos:exactMatch	chebi:CHEBI:4317	Dantrolene	dantrolene	orcid:0000-0001-9439-5346	CC0
-ncit:C1707	skos:exactMatch	chebi:CHEBI:10023	Voriconazole	voriconazole	orcid:0000-0003-4423-4370	CC0
-chebi:CHEBI:135931	skos:exactMatch	ncit:C73192	dexlansoprazole	Dexlansoprazole	orcid:0000-0003-4423-4370	CC0
-chebi:CHEBI:6375	skos:exactMatch	ncit:C29150	lansoprazole	Lansoprazole	orcid:0000-0003-4423-4370	CC0
-chebi:CHEBI:63598	skos:exactMatch	ncit:C1586	levofloxacin	Levofloxacin	orcid:0000-0003-4423-4370	CC0
-ncit:C65538	skos:exactMatch	chebi:CHEBI:50275	Esomeprazole	esomeprazole	orcid:0000-0003-4423-4370	CC0
-ncit:C2160	skos:exactMatch	chebi:CHEBI:52726	Proteasome Inhibitor	proteasome inhibitor	orcid:0000-0003-4423-4370	CC0
-mesh:D059765	skos:exactMatch	kegg.pathway:map03440	Homologous Recombination	Homologous recombination	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04360	skos:exactMatch	mesh:D000071437	Axon guidance	Axon Guidance	orcid:0000-0003-4423-4370	CC0
-mesh:D000078790	skos:exactMatch	kegg.pathway:map04911	Insulin Secretion	Insulin secretion	orcid:0000-0003-4423-4370	CC0
-mesh:D002453	skos:exactMatch	kegg.pathway:map04110	Cell Cycle	Cell cycle	orcid:0000-0003-4423-4370	CC0
-mesh:D004705	skos:exactMatch	kegg.pathway:map04144	Endocytosis	Endocytosis	orcid:0000-0003-4423-4370	CC0
-mesh:D060449	skos:exactMatch	kegg.pathway:map04310	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
-go:GO:0005816	skos:exactMatch	ncit:C13365	spindle pole body	Spindle Pole Body	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04710	skos:exactMatch	mesh:D002940	Circadian rhythm	Circadian Rhythm	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03030	skos:exactMatch	mesh:D004261	DNA replication	DNA Replication	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00190	skos:exactMatch	mesh:D010085	Oxidative phosphorylation	Oxidative Phosphorylation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00195	skos:exactMatch	mesh:D010788	Photosynthesis	Photosynthesis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04611	skos:exactMatch	mesh:D015539	Platelet activation	Platelet Activation	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04218	skos:exactMatch	mesh:D016922	Cellular senescence	Cellular Senescence	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map04210	skos:exactMatch	mesh:D017209	Apoptosis	Apoptosis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03013	skos:exactMatch	mesh:D034443	RNA transport	RNA Transport	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00030	skos:exactMatch	mesh:D010427	Pentose phosphate pathway	Pentose Phosphate Pathway	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map02024	skos:exactMatch	mesh:D053038	Quorum sensing	Quorum Sensing	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map03430	skos:exactMatch	mesh:D053843	Mismatch repair	DNA Mismatch Repair	orcid:0000-0003-4423-4370	CC0
-go:GO:0070266	skos:exactMatch	mesh:D000079302	necroptotic process	Necroptosis	orcid:0000-0003-4423-4370	CC0
-kegg.pathway:map00970	skos:exactMatch	mesh:D046249	Aminoacyl-tRNA biosynthesis	Transfer RNA Aminoacylation	orcid:0000-0003-4423-4370	CC0
-mesh:D000086382	skos:exactMatch	doid:DOID:0080600	COVID-19	COVID-19	orcid:0000-0001-9439-5346	CC0
-mesh:C437905	skos:exactMatch	uniprot:Q96PH6	DEFB118 protein, human	DEFB118	orcid:0000-0001-9439-5346	CC0
-mesh:C112641	skos:exactMatch	uniprot:O43583	DENR protein, human	DENR	orcid:0000-0001-9439-5346	CC0
-mesh:C494208	skos:exactMatch	uniprot:P60880	SNAP25 protein, human	SNAP25	orcid:0000-0001-9439-5346	CC0
-mesh:C494482	skos:exactMatch	uniprot:Q8NER1	TRPV1 protein, human	TRPV1	orcid:0000-0001-9439-5346	CC0
-mesh:C495270	skos:exactMatch	uniprot:P35222	CTNNB1 protein, human	CTNNB1	orcid:0000-0001-9439-5346	CC0
-mesh:C578038	skos:exactMatch	uniprot:Q02080	MEF2B protein, human	MEF2B	orcid:0000-0001-9439-5346	CC0
-mesh:C077171	skos:exactMatch	uniprot:P31629	HIVEP2 protein, human	HIVEP2	orcid:0000-0001-9439-5346	CC0
-mesh:C414177	skos:exactMatch	uniprot:P52569	SLC7A2 protein, human	SLC7A2	orcid:0000-0001-9439-5346	CC0
-mesh:C497937	skos:exactMatch	uniprot:P61764	STXBP1 protein, human	STXBP1	orcid:0000-0001-9439-5346	CC0
-mesh:C494841	skos:exactMatch	uniprot:Q12791	KCNMA1 protein, human	KCNMA1	orcid:0000-0001-9439-5346	CC0
-mesh:C108096	skos:exactMatch	uniprot:Q99643	SDHC protein, human	SDHC	orcid:0000-0001-9439-5346	CC0
-mesh:C511268	skos:exactMatch	uniprot:P31040	SDHA protein, human	SDHA	orcid:0000-0001-9439-5346	CC0
-mesh:C102467	skos:exactMatch	uniprot:Q99470	SDF2 protein, human	SDF2	orcid:0000-0001-9439-5346	CC0
-mesh:C494881	skos:exactMatch	uniprot:O75907	DGAT1 protein, human	DGAT1	orcid:0000-0001-9439-5346	CC0
-mesh:C580923	skos:exactMatch	uniprot:O95294	RASAL1 protein, human	RASAL1	orcid:0000-0001-9439-5346	CC0
-mesh:C580922	skos:exactMatch	uniprot:Q9NTJ3	SMC4 protein, human	SMC4	orcid:0000-0001-9439-5346	CC0
-mesh:C500151	skos:exactMatch	uniprot:Q9NX95	SYBU protein, human	SYBU	orcid:0000-0001-9439-5346	CC0
-mesh:C456359	skos:exactMatch	uniprot:Q969U7	PSMG2 protein, human	PSMG2	orcid:0000-0001-9439-5346	CC0
-mesh:C513866	skos:exactMatch	uniprot:Q8NE35	CPEB3 protein, human	CPEB3	orcid:0000-0001-9439-5346	CC0
-mesh:C489108	skos:exactMatch	uniprot:P05813	CRYBA1 protein, human	CRYBA1	orcid:0000-0001-9439-5346	CC0
-mesh:C490613	skos:exactMatch	uniprot:Q12955	ANK3 protein, human	ANK3	orcid:0000-0001-9439-5346	CC0
-mesh:C491904	skos:exactMatch	uniprot:O14617	AP3D1 protein, human	AP3D1	orcid:0000-0001-9439-5346	CC0
-mesh:C510070	skos:exactMatch	uniprot:P53677	AP3M2 protein, human	AP3M2	orcid:0000-0001-9439-5346	CC0
-mesh:C497872	skos:exactMatch	uniprot:P15408	FOSL2 protein, human	FOSL2	orcid:0000-0001-9439-5346	CC0
-mesh:C498630	skos:exactMatch	uniprot:Q9Y6V0	PCLO protein, human	PCLO	orcid:0000-0001-9439-5346	CC0
-mesh:C512817	skos:exactMatch	uniprot:O75493	CA11 protein, human	CA11	orcid:0000-0001-9439-5346	CC0
-mesh:C407644	skos:exactMatch	uniprot:Q9NP60	IL1RAPL2 protein, human	IL1RAPL2	orcid:0000-0001-9439-5346	CC0
-mesh:C403492	skos:exactMatch	uniprot:Q9UK73	FEM1B protein, human	FEM1B	orcid:0000-0001-9439-5346	CC0
-mesh:C485764	skos:exactMatch	uniprot:P35372	OPRM1 protein, human	OPRM1	orcid:0000-0001-9439-5346	CC0
-mesh:C109742	skos:exactMatch	uniprot:Q14BN4	SLMAP protein, human	SLMAP	orcid:0000-0001-9439-5346	CC0
-mesh:C402222	skos:exactMatch	uniprot:Q9NZJ7	MTCH1 protein, human	MTCH1	orcid:0000-0001-9439-5346	CC0
-mesh:C488761	skos:exactMatch	uniprot:Q6H3X3	RAET1G protein, human	RAET1G	orcid:0000-0001-9439-5346	CC0
-mesh:C488760	skos:exactMatch	uniprot:Q8TD07	RAET1E protein, human	RAET1E	orcid:0000-0001-9439-5346	CC0
-mesh:C490522	skos:exactMatch	uniprot:P78406	RAE1 protein, human	RAE1	orcid:0000-0001-9439-5346	CC0
-mesh:C419389	skos:exactMatch	uniprot:Q12797	ASPH protein, human	ASPH	orcid:0000-0001-9439-5346	CC0
-mesh:C508131	skos:exactMatch	uniprot:Q8WYH8	ING5 protein, human	ING5	orcid:0000-0001-9439-5346	CC0
-mesh:C504404	skos:exactMatch	uniprot:Q92563	SPOCK2 protein, human	SPOCK2	orcid:0000-0001-9439-5346	CC0
-mesh:C578040	skos:exactMatch	uniprot:Q06413	MEF2C protein, human	MEF2C	orcid:0000-0001-9439-5346	CC0
-mesh:C502025	skos:exactMatch	uniprot:Q9BZE1	MRPL37 protein, human	MRPL37	orcid:0000-0001-9439-5346	CC0
-mesh:C556354	skos:exactMatch	uniprot:P02765	AHSG protein, human	AHSG	orcid:0000-0001-9439-5346	CC0
-mesh:C519072	skos:exactMatch	uniprot:P11230	CHRNB1 protein, human	CHRNB1	orcid:0000-0001-9439-5346	CC0
-mesh:C519156	skos:exactMatch	uniprot:Q9H2K0	MTIF3 protein, human	MTIF3	orcid:0000-0001-9439-5346	CC0
-mesh:C518505	skos:exactMatch	uniprot:O96006	ZBED1 protein, human	ZBED1	orcid:0000-0001-9439-5346	CC0
-mesh:C578043	skos:exactMatch	uniprot:Q14814	MEF2D protein, human	MEF2D	orcid:0000-0001-9439-5346	CC0
-mesh:C463459	skos:exactMatch	uniprot:Q5JY77	GPRASP1 protein, human	GPRASP1	orcid:0000-0001-9439-5346	CC0
-mesh:C417919	skos:exactMatch	uniprot:Q9NQ84	GPRC5C protein, human	GPRC5C	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449619	skos:exactMatch	ncbiprotein:YP_009725297	Host translation inhibitor nsp1	leader protein	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449620	skos:exactMatch	ncbiprotein:YP_009725298	Non-structural protein 2	nsp2	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449621	skos:exactMatch	ncbiprotein:YP_009725299	Non-structural protein 3	nsp3	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449622	skos:exactMatch	ncbiprotein:YP_009725300	Non-structural protein 4	nsp4	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449623	skos:exactMatch	ncbiprotein:YP_009725301	3C-like proteinase	3C-like proteinase	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449624	skos:exactMatch	ncbiprotein:YP_009725302	Non-structural protein 6	nsp6	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449625	skos:exactMatch	ncbiprotein:YP_009725303	Non-structural protein 7	nsp7	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449626	skos:exactMatch	ncbiprotein:YP_009725304	Non-structural protein 8	nsp8	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449627	skos:exactMatch	ncbiprotein:YP_009725305	Non-structural protein 9	nsp9	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449628	skos:exactMatch	ncbiprotein:YP_009725306	Non-structural protein 10	nsp10	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449629	skos:exactMatch	ncbiprotein:YP_009725307	RNA-directed RNA polymerase	RNA-dependent RNA polymerase	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449630	skos:exactMatch	ncbiprotein:YP_009725308	Helicase	helicase	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449631	skos:exactMatch	ncbiprotein:YP_009725309	Proofreading exoribonuclease	3'-to-5' exonuclease	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449632	skos:exactMatch	ncbiprotein:YP_009725310	Uridylate-specific endoribonuclease	endoRNAse	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449633	skos:exactMatch	ncbiprotein:YP_009725311	2'-O-methyltransferase	2'-O-ribose methyltransferase	orcid:0000-0001-9439-5346	CC0
-pr:PR:000035726	skos:exactMatch	uniprot.chain:PRO_0000396174	ubiquitin (UBB)	Ubiquitin	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449635	skos:exactMatch	ncbiprotein:YP_009742608	Host translation inhibitor nsp1	leader protein	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449636	skos:exactMatch	ncbiprotein:YP_009742609	Non-structural protein 2	nsp2	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449637	skos:exactMatch	ncbiprotein:YP_009742610	Non-structural protein 3	nsp3	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449638	skos:exactMatch	ncbiprotein:YP_009742611	Non-structural protein 4	nsp4	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449639	skos:exactMatch	ncbiprotein:YP_009742612	3C-like proteinase	3C-like proteinase	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449640	skos:exactMatch	ncbiprotein:YP_009742613	Non-structural protein 6	nsp6	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449641	skos:exactMatch	ncbiprotein:YP_009742614	Non-structural protein 7	nsp7	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449642	skos:exactMatch	ncbiprotein:YP_009742615	Non-structural protein 8	nsp8	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449643	skos:exactMatch	ncbiprotein:YP_009742616	Non-structural protein 9	nsp9	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449644	skos:exactMatch	ncbiprotein:YP_009742617	Non-structural protein 10	nsp10	orcid:0000-0001-9439-5346	CC0
-uniprot.chain:PRO_0000449645	skos:exactMatch	ncbiprotein:YP_009725312	Non-structural protein 11	nsp11	orcid:0000-0001-9439-5346	CC0
+subject_id	predicate_id	object_id	subject_label	object_label	match_type	creator_id	license
+umls:C0001973	skos:narrower	mesh:D000435	Alcoholic Intoxication, Chronic	Alcoholic Intoxication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+umls:C0004352	skos:exactMatch	mesh:D001321	Autistic Disorder	Autistic Disorder	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+umls:C0006118	skos:exactMatch	mesh:D001932	Brain Neoplasms	Brain Neoplasms	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+umls:C0006142	skos:exactMatch	mesh:D001943	Malignant neoplasm of breast	Breast Neoplasms	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C108192	skos:exactMatch	chebi:CHEBI:101381	aloxistatin	aloxistatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pfam:PF01391	skos:exactMatch	mesh:D003094	Collagen	Collagen	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002465	skos:exactMatch	go:GO:0048870	Cell Movement	cell motility	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002914	skos:exactMatch	go:GO:0042627	Chylomicrons	chylomicron	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012374	skos:exactMatch	go:GO:0120200	Rod Cell Outer Segment	rod photoreceptor outer segment	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014158	skos:exactMatch	go:GO:0006351	Transcription, Genetic	transcription, DNA-templated	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014176	skos:exactMatch	go:GO:0006412	Protein Biosynthesis	translation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018919	skos:exactMatch	go:GO:0001525	Neovascularization, Physiologic	angiogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D048708	skos:exactMatch	go:GO:0016049	Cell Growth Processes	cell growth	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D058750	skos:exactMatch	go:GO:0001837	Epithelial-Mesenchymal Transition	epithelial to mesenchymal transition	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059767	skos:exactMatch	go:GO:0000725	Recombinational DNA Repair	recombinational repair	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016195	skos:exactMatch	go:GO:0051319	G2 Phase	G2 phase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497399	skos:exactMatch	uniprot:Q15797	SMAD1 protein, human	SMAD1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497782	skos:exactMatch	uniprot:Q15796	SMAD2 protein, human	SMAD2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497790	skos:exactMatch	uniprot:P84022	SMAD3 protein, human	SMAD3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497796	skos:exactMatch	uniprot:Q13485	SMAD4 protein, human	SMAD4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497797	skos:exactMatch	uniprot:Q99717	SMAD5 protein, human	SMAD5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497802	skos:exactMatch	uniprot:O43541	SMAD6 protein, human	SMAD6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497806	skos:exactMatch	uniprot:O15105	SMAD7 protein, human	SMAD7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005759	skos:exactMatch	ncit:C34632	Gastroenteritis	Gastroenteritis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005762	skos:exactMatch	ncit:C16603	Gastroenterology	Gastroenterology	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005756	skos:exactMatch	ncit:C26780	Gastritis	Gastritis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005755	skos:exactMatch	chebi:CHEBI:75436	Gastrins	gastrin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005753	skos:exactMatch	ncit:C32656	Gastric Mucosa	Gastric Mucosa	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005746	skos:exactMatch	go:GO:0035483	Gastric Emptying	gastric emptying	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005744	skos:exactMatch	ncit:C94192	Gastric Acid	Gastric Acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005743	skos:exactMatch	ncit:C15236	Gastrectomy	Gastrectomy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005735	skos:exactMatch	ncit:C122627	Garbage	Trash	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005729	skos:exactMatch	ncit:C3049	Ganglioneuroma	Ganglioneuroma	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005728	skos:exactMatch	ncit:C12467	Ganglia, Sympathetic	Sympathetic Ganglion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005708	skos:exactMatch	ncit:C66798	Gallium	Gallium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005707	skos:exactMatch	ncit:C63648	Gallic Acid	Gallic Acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005693	skos:exactMatch	ncit:C84723	Galactosemias	Galactosemia	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005690	skos:exactMatch	chebi:CHEBI:28260	Galactose	galactose	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005697	skos:exactMatch	chebi:CHEBI:24163	Galactosides	galactoside	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005687	skos:exactMatch	ncit:C113343	Galactorrhea	Galactorrhea	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005685	skos:exactMatch	chebi:CHEBI:37165	Galactans	galactan	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005684	skos:exactMatch	ncit:C75445	Gait	Gait	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005661	skos:exactMatch	chebi:CHEBI:131714	Furagin	furagin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005664	skos:exactMatch	chebi:CHEBI:5195	Furazolidone	furazolidone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005665	skos:exactMatch	chebi:CHEBI:47426	Furosemide	furosemide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005667	skos:exactMatch	ncit:C34629	Furunculosis	Furunculosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005669	skos:exactMatch	chebi:CHEBI:5199	Fusaric Acid	Fusaric acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005670	skos:exactMatch	ncit:C77185	Fusarium	Fusarium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005672	skos:exactMatch	ncit:C65793	Fusidic Acid	Fusidic Acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005673	skos:exactMatch	ncit:C76323	Fusobacterium	Fusobacterium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005674	skos:exactMatch	ncit:C84722	Fusobacterium Infections	Fusobacterium Infection	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005675	skos:exactMatch	ncit:C86401	Fusobacterium necrophorum	Fusobacterium necrophorum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005677	skos:exactMatch	chebi:CHEBI:61048	G(M1) Ganglioside	ganglioside GM1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005678	skos:exactMatch	ncit:C516	G(M2) Ganglioside	Ganglioside GM2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005681	skos:exactMatch	ncit:C16596	Gabon	Gabon	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005683	skos:exactMatch	ncit:C34630	Gagging	Gagging	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005639	skos:exactMatch	ncit:C61483	Frustration	Frustration	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005638	skos:exactMatch	ncit:C71972	Fruit	Fruit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005640	skos:exactMatch	chebi:CHEBI:81569	Follicle Stimulating Hormone	Follicle stimulating hormone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005641	skos:exactMatch	chebi:CHEBI:32188	Tegafur	Tegafur	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005627	skos:exactMatch	ncit:C34627	Frostbite	Frostbite	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005630	skos:exactMatch	chebi:CHEBI:28796	Fructans	fructan	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005625	skos:exactMatch	ncit:C23287	Frontal Lobe	Frontal Lobe	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005624	skos:exactMatch	ncit:C32635	Frontal Bone	Frontal Bone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005622	skos:exactMatch	ncit:C14362	Friend murine leukemia virus	Friend Murine Leukemia Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005621	skos:exactMatch	ncit:C84718	Friedreich Ataxia	Friedreich Ataxia	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005620	skos:exactMatch	ncit:C2347	Freund's Adjuvant	Freund's Adjuvant	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005616	skos:exactMatch	ncit:C16593	French Guiana	French Guiana	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005609	skos:exactMatch	ncit:C512	Free Radicals	Free Radical	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005602	skos:exactMatch	ncit:C16592	France	France	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005615	skos:exactMatch	ncit:C48160	Freezing	Freezing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005634	skos:exactMatch	ncit:C129394	Fructose-Bisphosphate Aldolase	Fructose-Bisphosphate Aldolase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005642	skos:exactMatch	ncit:C84721	Fuchs' Endothelial Dystrophy	Fuchs Endothelial Dystrophy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C095085	skos:exactMatch	uniprot:P32302	CXCR5 protein, human	CXCR5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497894	skos:exactMatch	uniprot:Q08722	CD47 protein, human	CD47	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497139	skos:exactMatch	uniprot:Q16760	DGKD protein, human	DGKD	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537126	skos:exactMatch	doid:DOID:0111438	Optic atrophy 5	optic atrophy 5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537127	skos:exactMatch	doid:DOID:0111435	Optic atrophy 6	optic atrophy 6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537117	skos:exactMatch	doid:DOID:0080549	LEOPARD syndrome, 2	LEOPARD syndrome 2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537115	skos:exactMatch	doid:DOID:0111507	Lenz Majewski hyperostotic dwarfism	Lenz-Majewski hyperostotic dwarfism	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537098	skos:exactMatch	doid:DOID:0050690	Brachyolmia	brachyolmia	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537162	skos:exactMatch	doid:DOID:6823	Pancreatoblastoma	pancreatoblastoma	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537202	skos:exactMatch	doid:DOID:0050974	Spinocerebellar ataxia 25	spinocerebellar ataxia type 25	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537203	skos:exactMatch	doid:DOID:0050975	Spinocerebellar ataxia 26	spinocerebellar ataxia type 26	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537199	skos:exactMatch	doid:DOID:0050971	Spinocerebellar ataxia 20	spinocerebellar ataxia type 20	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C537262	skos:exactMatch	ncit:C95436	Hereditary pancreatitis	Hereditary Pancreatitis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000622468	skos:exactMatch	uniprot:Q6PI78	TMEM65 protein, human	TMEM65	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000626007	skos:exactMatch	uniprot:O15481	MAGEB4 protein, human	MAGEB4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C493803	skos:exactMatch	uniprot:Q8WVX9	FAR1 protein, human	FAR1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000626466	skos:exactMatch	uniprot:O94919	ENDOD1 protein, human	ENDOD1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016985	skos:exactMatch	ncit:C86784	Streptococcus bovis	Streptococcus bovis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016990	skos:exactMatch	ncit:C86833	Ureaplasma urealyticum	Ureaplasma urealyticum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016993	skos:exactMatch	ncit:C76272	Chlamydophila pneumoniae	Chlamydophila pneumoniae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016997	skos:exactMatch	ncit:C86328	Coxiella burnetii	Coxiella burnetii	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016998	skos:exactMatch	ncit:C14296	Helicobacter	Helicobacter	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017000	skos:exactMatch	ncit:C86230	Campylobacter coli	Campylobacter coli	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017006	skos:exactMatch	ncit:C33497	Rotator Cuff	Rotator Cuff	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017011	skos:exactMatch	ncit:C86807	Streptococcus suis	Streptococcus suis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017023	skos:exactMatch	ncit:C100085	Coronary Angiography	Coronary Angiography	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017024	skos:exactMatch	ncit:C15360	Chemotherapy, Adjuvant	Adjuvant Chemotherapy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017041	skos:exactMatch	ncit:C142541	Ethics Committees	Ethics Committee	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017043	skos:exactMatch	ncit:C26717	Chalazion	Chalazion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017045	skos:exactMatch	ncit:C86483	Lactococcus	Lactococcus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017051	skos:exactMatch	ncit:C15252	Hospice Care	Hospice Care	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017058	skos:exactMatch	ncit:C67114	Mexican Americans	Mexican American	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017072	skos:exactMatch	ncit:C111122	Neostriatum	Neostriatum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017073	skos:exactMatch	ncit:C157793	Atherectomy	Atherectomy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017074	skos:exactMatch	ncit:C26725	Common Variable Immunodeficiency	Common Variable Immunodeficiency	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017081	skos:exactMatch	ncit:C51681	Cholecystectomy, Laparoscopic	Laparoscopic Cholecystectomy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017089	skos:exactMatch	ncit:C14100	Ankyrin Repeat	Ankyrin Repeat	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017092	skos:exactMatch	ncit:C84697	Porphyria, Erythropoietic	Erythropoietic Porphyria	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017101	skos:exactMatch	ncit:C14301	Bacteriophage P1	Bacteriophage P1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017114	skos:exactMatch	ncit:C84396	Liver Failure, Acute	Acute Liver Failure	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017026	skos:exactMatch	chebi:CHEBI:9367	Swainsonine	swainsonine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016966	skos:exactMatch	ncit:C86657	Porphyromonas gingivalis	Porphyromonas gingivalis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016967	skos:exactMatch	ncit:C86404	Fusobacterium nucleatum	Fusobacterium nucleatum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016960	skos:exactMatch	ncit:C86138	Agrobacterium tumefaciens	Agrobacterium tumefaciens	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016958	skos:exactMatch	ncit:C86705	Pseudomonas putida	Pseudomonas putida	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016957	skos:exactMatch	ncit:C86227	Burkholderia pseudomallei	Burkholderia pseudomallei	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016955	skos:exactMatch	ncit:C86524	Moraxella bovis	Moraxella bovis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016979	skos:exactMatch	ncit:C76373	Pasteurella multocida	Pasteurella multocida	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016980	skos:exactMatch	ncit:C86125	Aeromonas hydrophila	Aeromonas hydrophila	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016978	skos:exactMatch	ncit:C86508	Mannheimia haemolytica	Mannheimia haemolytica	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016981	skos:exactMatch	ncit:C86651	Plesiomonas	Plesiomonas	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016982	skos:exactMatch	ncit:C86513	Micrococcus luteus	Micrococcus luteus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016983	skos:exactMatch	ncit:C76311	Enterococcus	Enterococcus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016984	skos:exactMatch	ncit:C86369	Enterococcus faecium	Enterococcus faecium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017027	skos:exactMatch	ncit:C17444	Protein Tyrosine Phosphatases	Protein Tyrosine Phosphatase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017028	skos:exactMatch	ncit:C17445	Caregivers	Caregiver	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017035	skos:exactMatch	ncit:C62070	Pravastatin	Pravastatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016975	skos:exactMatch	ncit:C86409	Gardnerella	Gardnerella	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016970	skos:exactMatch	ncit:C86350	Eikenella	Eikenella	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016968	skos:exactMatch	ncit:C86850	Wolinella	Wolinella	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016919	skos:exactMatch	hp:HP:0032160	Meningitis, Cryptococcal	Cryptococcal meningitis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016918	skos:exactMatch	ncit:C128332	Arthritis, Reactive	Reactive Arthritis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016920	skos:exactMatch	ncit:C118297	Meningitis, Bacterial	Bacterial Meningitis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016923	skos:exactMatch	go:GO:0008219	Cell Death	cell death	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016924	skos:exactMatch	ncit:C86115	Actinomyces viscosus	Actinomyces viscosus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016912	skos:exactMatch	chebi:CHEBI:6443	Levonorgestrel	levonorgestrel	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016909	skos:exactMatch	ncit:C12824	Tibial Arteries	Tibial Artery	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016906	skos:exactMatch	hgnc:6029	Interleukin-9	IL9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016856	skos:exactMatch	ncit:C112397	Phlebovirus	Phlebovirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016859	skos:exactMatch	chebi:CHEBI:35856	Lipoxygenase Inhibitors	lipoxygenase inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016878	skos:exactMatch	ncit:C80303	POEMS Syndrome	POEMS Syndrome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016879	skos:exactMatch	ncit:C15359	Salvage Therapy	Salvage Therapy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016880	skos:exactMatch	ncit:C17442	Anisotropy	Anisotropy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016881	skos:exactMatch	ncit:C84891	Microsporidiosis	Microsporidiosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016883	skos:exactMatch	ncit:C50530	Diabetic Ketoacidosis	Diabetic Ketoacidosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016885	skos:exactMatch	ncit:C68708	United States Department of Agriculture	United States Department of Agriculture	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017122	skos:exactMatch	ncit:C14302	Bacteriophage T4	Bacteriophage T4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017127	skos:exactMatch	ncit:C106312	Glycation End Products, Advanced	Advanced Glycation End Product	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017128	skos:exactMatch	ncit:C52001	Embolectomy	Embolectomy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017129	skos:exactMatch	ncit:C128393	Anisakiasis	Anisakiasis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017131	skos:exactMatch	ncit:C52003	Thrombectomy	Thrombectomy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017130	skos:exactMatch	ncit:C51999	Angioplasty	Angioplasty	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017135	skos:exactMatch	ncit:C47476	Desogestrel	Desogestrel	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017136	skos:exactMatch	go:GO:0006811	Ion Transport	ion transport	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017144	skos:exactMatch	ncit:C154589	Focus Groups	Focus Group	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017245	skos:exactMatch	ncit:C71630	Foscarnet	Foscarnet	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017242	skos:exactMatch	ncit:C97211	Complement Factor H	Complement Factor H	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017252	skos:exactMatch	ncit:C38897	CD3 Complex	CD3 Complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017255	skos:exactMatch	ncit:C985	Acitretin	Acitretin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017257	skos:exactMatch	chebi:CHEBI:8774	Ramipril	ramipril	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017259	skos:exactMatch	chebi:CHEBI:81389	Dimaprit	Dimaprit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017241	skos:exactMatch	ncit:C84885	MELAS Syndrome	MELAS Syndrome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017239	skos:exactMatch	chebi:CHEBI:45863	Paclitaxel	paclitaxel	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017229	skos:exactMatch	ncit:C128396	Enterobiasis	Enterobiasis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017228	skos:exactMatch	ncit:C20428	Hepatocyte Growth Factor	Hepatocyte Growth Factor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017240	skos:exactMatch	ncit:C101328	Mitochondrial Myopathies	Mitochondrial Myopathy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017270	skos:exactMatch	hgnc:6667	Lipoprotein(a)	LPA	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017271	skos:exactMatch	ncit:C84654	Craniomandibular Disorders	Craniomandibular Disorder	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017273	skos:exactMatch	chebi:CHEBI:5523	Goserelin	Goserelin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017274	skos:exactMatch	chebi:CHEBI:7445	Nafarelin	Nafarelin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017275	skos:exactMatch	chebi:CHEBI:6073	Isradipine	Isradipine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017279	skos:exactMatch	ncit:C1223	Selenocysteine	Selenocysteine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017280	skos:exactMatch	ncit:C28258	Condoms	Condom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000037273	skos:exactMatch	uniprot.chain:PRO_0000013209	sonic hedgehog protein N-product	Sonic hedgehog protein N-product	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025578	skos:exactMatch	uniprot.chain:PRO_0000000090	soluble APP-beta	Soluble APP-beta	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025577	skos:exactMatch	uniprot.chain:PRO_0000000089	soluble APP-alpha	Soluble APP-alpha	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035908	skos:exactMatch	uniprot.chain:PRO_0000413735	serine/threonine-protein kinase 4 37kDa subunit	Serine/threonine-protein kinase 4 37kDa subunit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035906	skos:exactMatch	uniprot.chain:PRO_0000413713	serine/threonine-protein kinase 3 36kDa subunit	Serine/threonine-protein kinase 3 36kDa subunit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025588	skos:exactMatch	uniprot.chain:PRO_0000000096	P3(40)	P3(40)	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025587	skos:exactMatch	uniprot.chain:PRO_0000000095	P3(42)	P3(42)	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000001757	skos:exactMatch	uniprot.chain:PRO_0000030311	nuclear factor NF-kappa-B p50 subunit	Nuclear factor NF-kappa-B p50 subunit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025586	skos:exactMatch	uniprot.chain:PRO_0000000097	gamma-secretase C-terminal fragment 59	Gamma-secretase C-terminal fragment 59	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025589	skos:exactMatch	uniprot.chain:PRO_0000000099	gamma-secretase C-terminal fragment 50	Gamma-secretase C-terminal fragment 50	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025585	skos:exactMatch	uniprot.chain:PRO_0000000098	gamma-secretase C-terminal fragment 57	Gamma-secretase C-terminal fragment 57	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050115	skos:exactMatch	uniprot.chain:PRO_0000042262	heparanase 50 kDa subunit	Heparanase 50 kDa subunit	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025582	skos:exactMatch	uniprot.chain:PRO_0000384574	C80	C80	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025581	skos:exactMatch	uniprot.chain:PRO_0000000094	C83	C83	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000025580	skos:exactMatch	uniprot.chain:PRO_0000000091	C99	C99	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C514899	skos:exactMatch	uniprot:P48147	PREP protein, human	PREP	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C077914	skos:exactMatch	uniprot:Q01954	BNC1 protein, human	BNC1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497562	skos:exactMatch	uniprot:P40938	RFC3 protein, human	RFC3	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C456923	skos:exactMatch	uniprot:Q8N0V4	LGI2 protein, human	LGI2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C480021	skos:exactMatch	uniprot:P30838	ALDH3A1 protein, human	ALDH3A1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C581575	skos:exactMatch	uniprot:Q9BT17	MTG1 protein, human	MTG1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C079091	skos:exactMatch	uniprot:Q02410	APBA1 protein, human	APBA1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C493728	skos:exactMatch	uniprot:Q01196	RUNX1 protein, human	RUNX1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C488098	skos:exactMatch	uniprot:Q96CM4	NXNL1 protein, human	NXNL1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C492913	skos:exactMatch	uniprot:P38398	BRCA1 protein, human	BRCA1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000621508	skos:exactMatch	uniprot:P55085	F2RL1 protein, human	F2RL1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C490780	skos:exactMatch	uniprot:Q9UNN5	FAF1 protein, human	FAF1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497563	skos:exactMatch	uniprot:P35249	RFC4 protein, human	RFC4	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496061	skos:exactMatch	uniprot:P49023	PXN protein, human	PXN	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497651	skos:exactMatch	uniprot:Q00597	FANCC protein, human	FANCC	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C489785	skos:exactMatch	uniprot:Q9NR77	PXMP2 protein, human	PXMP2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C489803	skos:exactMatch	uniprot:Q9NP90	RAB9B protein, human	RAB9B	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497564	skos:exactMatch	uniprot:P40937	RFC5 protein, human	RFC5	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C512648	skos:exactMatch	uniprot:Q9Y266	NUDC protein, human	NUDC	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C431383	skos:exactMatch	uniprot:Q96JC9	EAF1 protein, human	EAF1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C070699	skos:exactMatch	uniprot:Q14512	FGFBP1 protein, human	FGFBP1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000592900	skos:exactMatch	uniprot:Q86VR8	FJX1 protein, human	FJX1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C098179	skos:exactMatch	uniprot:Q13045	FLII protein, human	FLII	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C530652	skos:exactMatch	uniprot:Q9UIV8	SERPINB13 protein, human	SERPINB13	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C492570	skos:exactMatch	uniprot:P22674	CCNO protein, human	CCNO	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C094154	skos:exactMatch	uniprot:P55082	MFAP3 protein, human	MFAP3	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C578035	skos:exactMatch	uniprot:Q02078	MEF2A protein, human	MEF2A	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496469	skos:exactMatch	uniprot:Q5TCQ9	MAGI3 protein, human	MAGI3	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035910	skos:exactMatch	uniprot.chain:PRO_0000002981	coagulation factor V light chain	Coagulation factor V light chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000005909	speciesSpecific	pr:PR:000050120	Complement C3 alpha chain	complement C3 alpha chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050114	skos:exactMatch	uniprot.chain:PRO_0000042260	heparanase 8 kDa subunit	Heparanase 8 kDa subunit	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050188	skos:exactMatch	uniprot.chain:PRO_0000014901	polymeric immunoglobulin receptor secretory component	Secretory component	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C495815	skos:exactMatch	uniprot:Q9Y281	CFL2 protein, human	CFL2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497121	skos:exactMatch	uniprot:Q02447	SP3 protein, human	SP3	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C091671	skos:exactMatch	uniprot:P46094	XCR1 protein, human	XCR1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C099100	skos:exactMatch	uniprot:Q9BRK5	SDF4 protein, human	SDF4	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000631507	skos:exactMatch	uniprot:Q9H8S5	CNTD2 protein, human	CNTD2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497453	skos:exactMatch	uniprot:P41134	ID1 protein, human	ID1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497442	skos:exactMatch	uniprot:Q16665	HIF1A protein, human	HIF1A	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C115114	skos:exactMatch	uniprot:Q9H2X6	HIPK2 protein, human	HIPK2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C109102	skos:exactMatch	uniprot:Q9H422	HIPK3 protein, human	HIPK3	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C526744	skos:exactMatch	uniprot:Q9NR71	ASAH2 protein, human	ASAH2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000656407	skos:exactMatch	uniprot:Q96H12	MSANTD3 protein, human	MSANTD3	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000656449	skos:exactMatch	uniprot:Q9NRY5	FAM114A2 protein, human	FAM114A2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496590	skos:exactMatch	uniprot:P49406	MRPL19 protein, human	MRPL19	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C519405	skos:exactMatch	uniprot:Q9Y5T4	DNAJC15 protein, human	DNAJC15	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C486655	skos:exactMatch	uniprot:Q96LC9	BMF protein, human	BMF	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C439386	skos:exactMatch	uniprot:Q9BYW1	SLC2A11 protein, human	SLC2A11	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C103258	skos:exactMatch	uniprot:Q14566	MCM6 protein, human	MCM6	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C502654	skos:exactMatch	uniprot:Q8IXM3	MRPL41 protein, human	MRPL41	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C100930	skos:exactMatch	uniprot:Q13405	MRPL49 protein, human	MRPL49	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C089821	skos:exactMatch	uniprot:Q96HJ5	MS4A3 protein, human	MS4A3	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C424714	skos:exactMatch	uniprot:Q96JQ5	MS4A4A protein, human	MS4A4A	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050122	skos:exactMatch	uniprot.chain:PRO_0000005910	C3 anaphylatoxin	C3a anaphylatoxin	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C054369	skos:exactMatch	uniprot:P10636	MAPT protein, human	MAPT	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001064	skos:exactMatch	ncit:C35145	Appendicitis	Appendicitis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072000	skos:exactMatch	ncit:C17678	NF-KappaB Inhibitor alpha	NF-Kappa-B Inhibitor Alpha	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001062	skos:exactMatch	ncit:C51687	Appendectomy	Appendectomy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003785	skos:exactMatch	ncit:C63715	Dental Pulp Capping	Dental Pulp Capping	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001065	skos:exactMatch	ncit:C12380	Appendix	Appendix	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000075927	skos:exactMatch	ncit:C25772	KRIT1 Protein	Krev Interaction Trapped Protein 1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C012566	skos:exactMatch	ncit:C2639	taurolidine	Taurolidine	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013654	skos:exactMatch	chebi:CHEBI:15891	Taurine	taurine	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013656	skos:exactMatch	chebi:CHEBI:28865	Taurocholic Acid	taurocholic acid	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013657	skos:exactMatch	chebi:CHEBI:9410	Taurodeoxycholic Acid	taurodeoxycholic acid	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013658	skos:exactMatch	chebi:CHEBI:36259	Taurolithocholic Acid	taurolithocholic acid	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050069	skos:exactMatch	uniprot.chain:PRO_0000005002	voltage-dependent calcium channel subunit delta-1	Voltage-dependent calcium channel subunit delta-1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050130	skos:exactMatch	uniprot.chain:PRO_0000005914	complement C3g fragment	Complement C3g fragment	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050127	skos:exactMatch	uniprot.chain:PRO_0000005913	complement C3dg fragment	Complement C3dg fragment	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050131	skos:exactMatch	uniprot.chain:PRO_0000005915	complement C3d fragment	Complement C3d fragment	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050119	skos:exactMatch	uniprot.chain:PRO_0000005908	complement C3 beta chain	Complement C3 beta chain	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050124	skos:exactMatch	uniprot.chain:PRO_0000005911	complement C3b alpha' chain	Complement C3b alpha' chain	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035934	skos:exactMatch	uniprot.chain:PRO_0000027759	coagulation factor IXa heavy chain	Coagulation factor IXa heavy chain	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000003367	skos:exactMatch	uniprot.chain:PRO_0000005731	chondrocalcin	Chondrocalcin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050089	skos:exactMatch	uniprot.chain:PRO_0000004641	caspase-9 subunit p35	Caspase-9 subunit p35	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050090	skos:exactMatch	uniprot.chain:PRO_0000004643	caspase-9 subunit p10	Caspase-9 subunit p10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002459	skos:exactMatch	uniprot.chain:PRO_0000004617	caspase-7 subunit p20	Caspase-7 subunit p20	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002458	skos:exactMatch	uniprot.chain:PRO_0000004619	caspase-7 subunit p11	Caspase-7 subunit p11	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002457	skos:exactMatch	uniprot.chain:PRO_0000004609	caspase-6 subunit p18	Caspase-6 subunit p18	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002456	skos:exactMatch	uniprot.chain:PRO_0000004611	caspase-6 subunit p11	Caspase-6 subunit p11	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002451	skos:exactMatch	uniprot.chain:PRO_0000004542	caspase-2 subunit p18	Caspase-2 subunit p18	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002452	skos:exactMatch	uniprot.chain:PRO_0000004544	caspase-2 subunit p13	Caspase-2 subunit p13	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036012	skos:exactMatch	uniprot.chain:PRO_0000420659	angiotensin 1-9	Angiotensin 1-9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036013	skos:exactMatch	uniprot.chain:PRO_0000420660	angiotensin 1-7	Angiotensin 1-7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050121	skos:exactMatch	uniprot.chain:PRO_0000430430	C3-beta-c	C3-beta-c	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002453	skos:exactMatch	uniprot.chain:PRO_0000004545	caspase-2 subunit p12	Caspase-2 subunit p12	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035724	skos:exactMatch	uniprot.chain:PRO_0000396434	60S ribosomal protein L40	60S ribosomal protein L40	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035936	skos:exactMatch	uniprot.chain:PRO_0000027791	activated factor Xa heavy chain	Activated factor Xa heavy chain	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066293	skos:exactMatch	ncit:C33463	Renshaw Cells	Renshaw Cell	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066292	skos:exactMatch	go:GO:0005811	Lipid Droplets	lipid droplet	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066271	skos:exactMatch	ncit:C32550	External Capsule	External Capsule	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066270	skos:exactMatch	ncit:C93209	Social Capital	Social Capital	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066261	skos:exactMatch	ncit:C105920	Epigen	Epigen	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066259	skos:exactMatch	ncit:C20432	Betacellulin	Betacellulin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036062	skos:exactMatch	uniprot.chain:PRO_0000004629	caspase-8 isoform 1 cleaved 1	Caspase-8 subunit p18	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036064	skos:exactMatch	uniprot.chain:PRO_0000004631	caspase-8 isoform 1 cleaved 2	Caspase-8 subunit p10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002449	skos:exactMatch	uniprot.chain:PRO_0000004522	caspase-1 isoform 1 cleaved 1	Caspase-1 subunit p20	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066248	skos:exactMatch	ncit:C87668	High Fructose Corn Syrup	High Fructose Corn Syrup	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066247	skos:exactMatch	hgnc:3432	Receptor, ErbB-4	ERBB4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066126	skos:exactMatch	ncit:C27994	Cardiotoxicity	Cardiotoxicity	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066127	skos:exactMatch	ncit:C33892	White Matter	White Matter	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066128	skos:exactMatch	ncit:C32695	Gray Matter	Gray Matter	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066166	skos:exactMatch	ncit:C168385	Pectus Carinatum	Pectus Carinatum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066186	skos:exactMatch	ncit:C32391	Costal Cartilage	Costal Cartilage	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066191	skos:exactMatch	ncit:C154777	Sensorimotor Cortex	Sensorimotor Cortex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066233	skos:exactMatch	ncit:C18740	Psychology, Developmental	Developmental Psychology	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066235	skos:exactMatch	ncit:C146991	Fluorine-19 Magnetic Resonance Imaging	Fluorine-19 Magnetic Resonance Imaging	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066066	skos:exactMatch	ncit:C49164	Response Evaluation Criteria in Solid Tumors	Response Evaluation Criteria in Solid Tumors	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066027	skos:exactMatch	ncit:C159659	Transplant Recipients	Transplant Recipient	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066007	skos:exactMatch	ncit:C90478	Toxicokinetics	Toxicokinetics	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065927	skos:exactMatch	efo:0005191	Waist-Height Ratio	waist height ratio	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065886	skos:exactMatch	efo:0010642	Neurodevelopmental Disorders	Neurodevelopmental disorder	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065866	skos:exactMatch	ncit:C33218	Optic Tract	Optic Tract	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065850	skos:exactMatch	ncit:C32291	Cerebral Peduncle	Cerebral Peduncle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065843	skos:exactMatch	ncit:C32409	Cerebral Crus	Crus Cerebri	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065819	skos:exactMatch	ncit:C1707	Voriconazole	Voriconazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065842	skos:exactMatch	ncit:C97341	Pars Compacta	Pars Compacta	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065631	skos:exactMatch	doid:DOID:4481	Rhinitis, Allergic	allergic rhinitis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065707	skos:exactMatch	ncit:C99056	Schizencephaly	Schizencephaly	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065527	skos:exactMatch	ncit:C157799	Brachial Plexus Block	Brachial Plexus Block	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065108	skos:exactMatch	ncit:C2088	Ornithine Decarboxylase Inhibitors	Ornithine Decarboxylase Inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065168	skos:exactMatch	chebi:CHEBI:68557	Bradykinin Receptor Antagonists	bradykinin receptor antagonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065170	skos:exactMatch	ncit:C92730	Pregnancy, Angular	Angular Pregnancy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065171	skos:exactMatch	chebi:CHEBI:50792	Estrogen Receptor Antagonists	estrogen receptor antagonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065173	skos:exactMatch	ncit:C92761	Pregnancy, Cornual	Cornual Pregnancy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065207	skos:exactMatch	ncit:C171516	Middle East Respiratory Syndrome Coronavirus	Middle East Respiratory Syndrome Coronavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065290	skos:exactMatch	efo:0007949	Acute-On-Chronic Liver Failure	acute-on-chronic liver failure	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065306	skos:exactMatch	ncit:C35392	Corneal Injuries	Corneal Injury	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065326	skos:exactMatch	ncit:C157359	Children's Health Insurance Program	Children's Health Insurance Program	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065426	skos:exactMatch	ncit:C132068	Cytoreduction Surgical Procedures	Cytoreductive Surgery	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065102	skos:exactMatch	ncit:C20822	Licensed Practical Nurses	Licensed Practical Nurse	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064966	skos:exactMatch	ncit:C17653	British Virgin Islands	Virgin Islands, British	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064888	skos:exactMatch	ncit:C16084	Observational Study	Observational Study	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064886	skos:exactMatch	ncit:C47824	Dataset	Data Set	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064878	skos:exactMatch	ncit:C142748	Web Browser	Web Browser	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064847	skos:exactMatch	ncit:C19341	Multimodal Imaging	Multimodal Imaging	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064890	skos:exactMatch	ncit:C171586	Social Determinants of Health	Social Determinants of Health	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064794	skos:exactMatch	chebi:CHEBI:135646	Lorajmine	lorajmine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064750	skos:exactMatch	chebi:CHEBI:8768	Rabeprazole	rabeprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064748	skos:exactMatch	ncit:C73192	Dexlansoprazole	Dexlansoprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064747	skos:exactMatch	ncit:C29150	Lansoprazole	Lansoprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064751	skos:exactMatch	chebi:CHEBI:35276	Ammonium Compounds	ammonium compound	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064791	skos:exactMatch	ncit:C65369	Desoxycorticosterone Acetate	Desoxycorticosterone Acetate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065026	skos:exactMatch	ncit:C77962	Hope	Hope	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064696	skos:exactMatch	ncit:C66870	Zuclomiphene	Zuclomiphene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064695	skos:exactMatch	ncit:C28211	Enclomiphene	Enclomiphene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064692	skos:exactMatch	ncit:C29104	Hyoscyamine	Hyoscyamine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064704	skos:exactMatch	ncit:C1586	Levofloxacin	Levofloxacin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064705	skos:exactMatch	ncit:C76546	Racepinephrine	Racepinephrine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064730	skos:exactMatch	ncit:C1333	Dexrazoxane	Dexrazoxane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064906	skos:exactMatch	ncit:C93098	Qigong	Qigong	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064591	skos:exactMatch	ncit:C60701	Allografts	Allograft	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064652	skos:exactMatch	ncit:C32183	Basal Bodies	Basal Body	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064650	skos:exactMatch	ncit:C20883	Home Health Nursing	Home Health Nursing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064648	skos:exactMatch	ncit:C17602	Critical Care Nursing	Critical Care Nursing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064706	skos:exactMatch	hp:HP:0031801	Vocal Cord Dysfunction	Vocal cord dysfunction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064386	skos:exactMatch	efo:0009615	Ankle Fractures	ankle fracture	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064346	skos:exactMatch	ncit:C87054	Sagittal Abdominal Diameter	Sagittal Abdominal Diameter	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064232	skos:exactMatch	ncit:C121547	Visual Analog Scale	Visual Analog Scale	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064209	skos:exactMatch	ncit:C28269	Phytochemicals	Phytochemical	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064208	skos:exactMatch	ncit:C86135	Aggregatibacter segnis	Aggregatibacter segnis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064206	skos:exactMatch	ncit:C86132	Aggregatibacter	Aggregatibacter	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064207	skos:exactMatch	ncit:C86134	Aggregatibacter aphrophilus	Aggregatibacter aphrophilus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064166	skos:exactMatch	ncit:C69183	Vaccine Potency	Vaccine Potency	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064048	skos:exactMatch	ncit:C13365	Spindle Pole Bodies	Spindle Pole Body	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064047	skos:exactMatch	go:GO:0000922	Spindle Poles	spindle pole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064068	skos:exactMatch	ncit:C45426	Collagenous Sprue	Collagenous Sprue	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064090	skos:exactMatch	ncit:C9184	Intraocular Lymphoma	Intraocular Lymphoma	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064096	skos:exactMatch	ncit:C30006	Aurora Kinase A	Aurora Kinase A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064098	skos:exactMatch	ncit:C65538	Esomeprazole	Esomeprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064107	skos:exactMatch	ncit:C68596	Aurora Kinase B	Aurora Kinase B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064108	skos:exactMatch	ncit:C95267	Aurora Kinase C	Aurora Kinase C	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063990	skos:exactMatch	ncit:C43520	Gene Ontology	Gene Ontology	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063826	skos:exactMatch	ncit:C123740	Kosovo	Kosovo	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063806	skos:exactMatch	ncit:C27009	Myalgia	Myalgia	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063766	skos:exactMatch	ncit:C84449	Pediatric Obesity	Childhood Obesity	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063646	skos:exactMatch	ncit:C18078	Carcinogenesis	Carcinogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063325	skos:exactMatch	chebi:CHEBI:32220	Tiapride Hydrochloride	Tiapride hydrochloride	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063386	skos:exactMatch	chebi:CHEBI:67072	Cannabinoid Receptor Agonists	cannabinoid receptor agonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063426	skos:exactMatch	ncit:C15422	Human Migration	Human Migration	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063546	skos:exactMatch	go:GO:0020011	Apicoplasts	apicoplast	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063388	skos:exactMatch	chebi:CHEBI:67197	Endocannabinoids	endocannabinoid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063088	skos:exactMatch	chebi:CHEBI:17102	Phosphoramides	phosphoramide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063005	skos:exactMatch	ncit:C18229	Health Information Systems	Health Information System	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063126	skos:exactMatch	ncit:C157795	Balloon Valvuloplasty	Balloon Valvuloplasty	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062907	skos:exactMatch	chebi:CHEBI:30744	Oxaloacetic Acid	oxaloacetic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062745	skos:exactMatch	ncit:C118593	Junctional Adhesion Molecule A	Junctional Adhesion Molecule A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062689	skos:exactMatch	ncit:C27483	Lipoblastoma	Lipoblastoma	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062559	skos:exactMatch	hgnc:10582	NAV1.8 Voltage-Gated Sodium Channel	SCN10A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062408	skos:exactMatch	ncit:C80249	Breakfast	Breakfast	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062409	skos:exactMatch	ncit:C80250	Lunch	Lunch	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062485	skos:exactMatch	ncit:C121558	Breath Holding	Breath Holding	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062445	skos:exactMatch	hgnc:2032	Claudin-1	CLDN1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062446	skos:exactMatch	hgnc:2041	Claudin-2	CLDN2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062465	skos:exactMatch	hgnc:2045	Claudin-3	CLDN3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062506	skos:exactMatch	hgnc:2046	Claudin-4	CLDN4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062507	skos:exactMatch	hgnc:2047	Claudin-5	CLDN5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066249	skos:exactMatch	ncit:C41365	Craving	Craving	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064703	skos:exactMatch	ncit:C71290	Family Nurse Practitioners	Family Nurse Practitioner	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064690	skos:exactMatch	chebi:CHEBI:77567	Wakefulness-Promoting Agents	eugeroic	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020169	skos:exactMatch	ncit:C18153	Caspases	Caspase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020170	skos:exactMatch	hgnc:1499	Caspase 1	CASP1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053148	skos:exactMatch	hgnc:1504	Caspase 3	CASP3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053178	skos:exactMatch	hgnc:1507	Caspase 6	CASP6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053455	skos:exactMatch	hgnc:1500	Caspase 10	CASP10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053456	skos:exactMatch	hgnc:1502	Caspase 14	CASP14	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C033246	skos:exactMatch	ncit:C121971	prostaglandin E3	Prostaglandin E3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011448	skos:exactMatch	chebi:CHEBI:49023	Prostaglandin Antagonists	prostaglandin antagonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011453	skos:exactMatch	ncit:C782	Prostaglandins	Prostaglandin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011454	skos:exactMatch	chebi:CHEBI:26334	Prostaglandins A	prostaglandins A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011456	skos:exactMatch	chebi:CHEBI:26335	Prostaglandins B	prostaglandins B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011457	skos:exactMatch	chebi:CHEBI:26337	Prostaglandins D	prostaglandins D	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011458	skos:exactMatch	chebi:CHEBI:26338	Prostaglandins E	prostaglandins E	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011460	skos:exactMatch	chebi:CHEBI:26340	Prostaglandins F	prostaglandins F	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011462	skos:exactMatch	chebi:CHEBI:26343	Prostaglandins G	prostaglandins G	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011463	skos:exactMatch	chebi:CHEBI:26344	Prostaglandins H	prostaglandins H	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015230	skos:exactMatch	chebi:CHEBI:15555	Prostaglandin D2	prostaglandin D2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D044062	skos:exactMatch	chebi:CHEBI:26345	Prostaglandins I	prostaglandins I	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D044262	skos:exactMatch	chebi:CHEBI:15554	Prostaglandin H2	prostaglandin H2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000606551	skos:exactMatch	ncit:C152185	remdesivir	Remdesivir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000623728	skos:exactMatch	ncit:C112409	Rhinovirus C	Rhinovirus C	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000623735	skos:exactMatch	ncit:C112408	Rhinovirus B	Rhinovirus B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000623787	skos:exactMatch	ncit:C112407	Rhinovirus A	Rhinovirus A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000592662	skos:exactMatch	ncit:C171848	DORAVIRINE	Doravirine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C063638	skos:exactMatch	ncit:C82253	lobucavir	Lobucavir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C066100	skos:exactMatch	ncit:C118556	poliovirus receptor	Poliovirus Receptor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C053001	skos:exactMatch	ncit:C61526	adefovir	Adefovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C083858	skos:exactMatch	ncit:C73147	emivirine	Emivirine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C087098	skos:exactMatch	ncit:C26677	virulizin	Virulizin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C098320	skos:exactMatch	ncit:C29027	efavirenz	Efavirenz	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C107733	skos:exactMatch	ncit:C1786	cyanovirin N	Cyanovirin-N	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C414210	skos:exactMatch	ncit:C81611	peramivir	Peramivir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C400401	skos:exactMatch	ncit:C82254	maribavir	Maribavir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C118874	skos:exactMatch	ncit:C82255	rupintrivir	Rupintrivir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C453221	skos:exactMatch	ncit:C136516	pritelivir	Pritelivir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C462182	skos:exactMatch	ncit:C81605	favipiravir	Favipiravir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C481671	skos:exactMatch	ncit:C73205	Dapivirine	Dapivirine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497721	skos:exactMatch	ncit:C66453	pradefovir	Pradefovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C505045	skos:exactMatch	ncit:C81606	Tecovirimat	Tecovirimat	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C549273	skos:exactMatch	ncit:C114981	daclatasvir	Daclatasvir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C525733	skos:exactMatch	ncit:C90587	brincidofovir	Brincidofovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068696	skos:exactMatch	ncit:C76929	Rilpivirine	Rilpivirine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068698	skos:exactMatch	ncit:C29490	Tenofovir	Tenofovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068898	skos:exactMatch	ncit:C73823	Raltegravir Potassium	Raltegravir Potassium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069446	skos:exactMatch	ncit:C28835	Atazanavir Sulfate	Atazanavir Sulfate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069454	skos:exactMatch	chebi:CHEBI:367163	Darunavir	darunavir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069474	skos:exactMatch	ncit:C101263	Sofosbuvir	Sofosbuvir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069616	skos:exactMatch	ncit:C129015	Simeprevir	Simeprevir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071243	skos:exactMatch	ncit:C128423	Zika Virus Infection	Zika Virus Infection	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071244	skos:exactMatch	ncit:C128553	Zika Virus	Zika Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072230	skos:exactMatch	ncit:C120598	Sustained Virologic Response	Sustained Virologic Response	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072596	skos:exactMatch	ncit:C116608	Hepatitis A Virus Cellular Receptor 1	Hepatitis A Virus Cellular Receptor 1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072597	skos:exactMatch	ncit:C104278	Hepatitis A Virus Cellular Receptor 2	Hepatitis A Virus Cellular Receptor 2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000073638	skos:exactMatch	ncit:C119319	Alphacoronavirus	Alphacoronavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000073640	skos:exactMatch	ncit:C113207	Betacoronavirus	Betacoronavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000073642	skos:exactMatch	ncit:C122313	Gammacoronavirus	Gammacoronavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077483	skos:exactMatch	ncit:C28235	Valacyclovir	Valacyclovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077560	skos:exactMatch	ncit:C2105	Enfuvirtide	Enfuvirtide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077562	skos:exactMatch	ncit:C2629	Valganciclovir	Valganciclovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077592	skos:exactMatch	ncit:C73144	Maraviroc	Maraviroc	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077595	skos:exactMatch	ncit:C29044	Famciclovir	Famciclovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000080309	skos:exactMatch	ncit:C169106	Environmental DNA	Environmental DNA	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077404	skos:exactMatch	ncit:C1600	Cidofovir	Cidofovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000076142	skos:exactMatch	ncit:C18468	Virtual Reality	Virtual Reality	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000212	skos:exactMatch	ncit:C205	Acyclovir	Acyclovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000257	skos:exactMatch	ncit:C115149	Adenoviridae Infections	Adenovirus Infection	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000524	skos:exactMatch	ncit:C112030	Alphavirus	Alphavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000998	skos:exactMatch	ncit:C281	Antiviral Agents	Antiviral Agent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001103	skos:exactMatch	ncit:C112230	Arboviruses	Arbovirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001739	skos:exactMatch	ncit:C89820	BK Virus	BK Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001355	skos:exactMatch	ncit:C14186	Alpharetrovirus	Alpharetrovirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002043	skos:exactMatch	ncit:C112028	Bunyaviridae	Bunyaviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002139	skos:exactMatch	ncit:C14304	Caliciviridae	Caliciviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003236	skos:exactMatch	ncit:C34509	Conjunctivitis, Viral	Viral Conjunctivitis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003716	skos:exactMatch	ncit:C112036	Dengue Virus	Dengue Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004263	skos:exactMatch	ncit:C14199	DNA Tumor Viruses	DNA Tumor Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004267	skos:exactMatch	ncit:C14200	DNA Viruses	DNA Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004777	skos:exactMatch	ncit:C16551	Environment	Environment	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004781	skos:exactMatch	ncit:C16552	Environmental Exposure	Environmental Exposure	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004860	skos:exactMatch	ncit:C14205	Infectious Anemia Virus, Equine	Equine Infectious Anemia Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005416	skos:exactMatch	ncit:C14208	Flavivirus	Flavivirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019213	skos:exactMatch	ncit:C14326	Rubulavirus	Rubulavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012229	skos:exactMatch	ncit:C77200	Rhinovirus	Rhinovirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012209	skos:exactMatch	ncit:C112027	Rhabdoviridae	Rhabdoviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012254	skos:exactMatch	ncit:C807	Ribavirin	Ribavirin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012328	skos:exactMatch	ncit:C14269	RNA Viruses	RNA Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012412	skos:exactMatch	ncit:C77198	Rubella virus	Rubella Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012901	skos:exactMatch	ncit:C96527	Variola virus	Variola Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013155	skos:exactMatch	ncit:C14276	Spleen Focus-Forming Viruses	Spleen Focus-Forming Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014035	skos:exactMatch	ncit:C77197	Togaviridae	Togaviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012190	skos:exactMatch	ncit:C14268	Retroviridae	Retroviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012087	skos:exactMatch	ncit:C112026	Reoviridae	Reoviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011212	skos:exactMatch	ncit:C14261	Poxviridae	Poxvirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011120	skos:exactMatch	ncit:C14260	Polyomavirus	Polyomavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010942	skos:exactMatch	ncit:C14257	Plant Viruses	Plant Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009975	skos:exactMatch	ncit:C53453	Orthomyxoviridae	Orthomyxoviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010252	skos:exactMatch	ncit:C14255	Paramyxoviridae	Paramyxoviridae	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010285	skos:exactMatch	ncit:C112401	Pseudocowpox Virus	Pseudocowpox Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010849	skos:exactMatch	ncit:C14256	Picornaviridae	Picornavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011054	skos:exactMatch	ncit:C91715	Poliovirus Vaccine, Inactivated	Inactivated Poliovirus Vaccine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014036	skos:exactMatch	ncit:C85192	Togaviridae Infections	Togaviridae Infection	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014484	skos:exactMatch	ncit:C17236	United States Environmental Protection Agency	Environmental Protection Agency	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D045403	skos:exactMatch	ncit:C112290	Henipavirus	Henipavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D029322	skos:exactMatch	ncit:C112362	Norovirus	Norovirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014772	skos:exactMatch	ncit:C95945	Viroids	Viroid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014773	skos:exactMatch	ncit:C17256	Virology	Virology	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014774	skos:exactMatch	ncit:C28198	Virulence	Virulence	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014780	skos:exactMatch	ncit:C14283	Viruses	Virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014903	skos:exactMatch	ncit:C43473	West Virginia	West Virginia	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014768	skos:exactMatch	ncit:C43472	Virginia	Virginia	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014767	skos:exactMatch	ncit:C17255	United States Virgin Islands	Virgin Islands, U.S.	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015774	skos:exactMatch	chebi:CHEBI:465284	Ganciclovir	ganciclovir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050268	skos:exactMatch	uniprot.chain:PRO_0000449648	spike protein S2 (SARS-CoV-2)	Spike protein S2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050267	skos:exactMatch	uniprot.chain:PRO_0000449647	spike protein S1 (SARS-CoV-2)	Spike protein S1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050278	skos:exactMatch	uniprot.chain:PRO_0000449627	non-structural protein 9 (SARS-CoV-2)	Non-structural protein 9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050277	skos:exactMatch	uniprot.chain:PRO_0000449626	non-structural protein 8 (SARS-CoV-2)	Non-structural protein 8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050276	skos:exactMatch	uniprot.chain:PRO_0000449625	non-structural protein 7 (SARS-CoV-2)	Non-structural protein 7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050275	skos:exactMatch	uniprot.chain:PRO_0000449624	non-structural protein 6 (SARS-CoV-2)	Non-structural protein 6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050273	skos:exactMatch	uniprot.chain:PRO_0000449622	non-structural protein 4 (SARS-CoV-2)	Non-structural protein 4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050272	skos:exactMatch	uniprot.chain:PRO_0000449621	non-structural protein 3 (SARS-CoV-2)	Non-structural protein 3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050271	skos:exactMatch	uniprot.chain:PRO_0000449620	non-structural protein 2 (SARS-CoV-2)	Non-structural protein 2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050280	skos:exactMatch	uniprot.chain:PRO_0000449645	non-structural protein 11 (SARS-CoV-2)	Non-structural protein 11	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050279	skos:exactMatch	uniprot.chain:PRO_0000449628	non-structural protein 10 (SARS-CoV-2)	Non-structural protein 10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050270	skos:exactMatch	uniprot.chain:PRO_0000449619	host translation inhibitor nsp1 (SARS-CoV-2)	Host translation inhibitor nsp1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050285	skos:exactMatch	uniprot.chain:PRO_0000449630	helicase (SARS-CoV-2)	Helicase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050274	skos:exactMatch	uniprot.chain:PRO_0000449623	3C-like proteinase (SARS-CoV-2)	3C-like proteinase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050288	skos:exactMatch	uniprot.chain:PRO_0000449633	2'-O-methyltransferase (SARS-CoV-2)	2'-O-methyltransferase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036008	skos:exactMatch	uniprot.chain:PRO_0000032457	angiotensin I	Angiotensin-1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036009	skos:exactMatch	uniprot.chain:PRO_0000032458	angiotensin II	Angiotensin-2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036010	skos:exactMatch	uniprot.chain:PRO_0000032459	angiotensin III	Angiotensin-3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000036011	skos:exactMatch	uniprot.chain:PRO_0000420663	angiotensin IV	Angiotensin-4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050135	skos:exactMatch	uniprot.chain:PRO_0000005909	complement C3 alpha chain (human)	Complement C3 alpha chain	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002450	skos:exactMatch	uniprot.chain:PRO_0000004524	caspase-1 isoform 1 cleaved 2	Caspase-1 subunit p10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002454	skos:exactMatch	uniprot.chain:PRO_0000004572	caspase-3 isoform 1 cleaved 1	Caspase-3 subunit p12	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002455	skos:exactMatch	uniprot.chain:PRO_0000004571	caspase-3 isoform 1 cleaved 2	Caspase-3 subunit p17	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050084	skos:exactMatch	uniprot.chain:PRO_0000367048	155 kDa platelet multimerin (human)	155 kDa platelet multimerin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035718	skos:exactMatch	uniprot.chain:PRO_0000396478	40S ribosomal protein S27a	40S ribosomal protein S27a	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050083	skos:exactMatch	uniprot.chain:PRO_0000367047	platelet glycoprotein Ia* (human)	Platelet glycoprotein Ia*	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050284	skos:exactMatch	uniprot.chain:PRO_0000449629	RNA-directed RNA polymerase (SARS-CoV-2)	RNA-directed RNA polymerase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002439	skos:exactMatch	uniprot.chain:PRO_0000223233	BH3-interacting domain death agonist isoform 1 cleaved 1	BH3-interacting domain death agonist p15	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002440	skos:exactMatch	uniprot.chain:PRO_0000223232	BH3-interacting domain death agonist isoform 1 cleaved 2	BH3-interacting domain death agonist p13	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000002441	skos:exactMatch	uniprot.chain:PRO_0000223231	BH3-interacting domain death agonist isoform 1 cleaved 3	BH3-interacting domain death agonist p11	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066258	skos:exactMatch	hgnc:651	Amphiregulin	AREG	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066260	skos:exactMatch	hgnc:3443	Epiregulin	EREG	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066257	skos:exactMatch	hgnc:3059	Heparin-binding EGF-like Growth Factor	HBEGF	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050287	skos:exactMatch	uniprot.chain:PRO_0000449632	uridylate-specific endoribonuclease (SARS-CoV-2)	Uridylate-specific endoribonuclease	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D045473	skos:exactMatch	ncit:C112432	SARS Virus	SARS Coronavirus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000656484	skos:exactMatch	ncit:C169076	severe acute respiratory syndrome coronavirus 2	SARS Coronavirus 2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000657245	skos:exactMatch	doid:DOID:0080600	COVID-19	COVID-19	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050269	skos:exactMatch	uniprot.chain:PRO_0000449649	spike protein S2' (SARS-CoV-2)	Spike protein S2'	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050266	skos:exactMatch	uniprot.chain:PRO_0000449646	spike glycoprotein, signal peptide removed form (SARS-CoV-2)	Spike glycoprotein	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000050265	skos:exactMatch	uniprot.chain:PRO_0000449654	ORF7a protein, signal peptide removed form (SARS-CoV-2)	ORF7a protein	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065098	skos:exactMatch	chebi:CHEBI:48406	Catechol O-Methyltransferase Inhibitors	EC 2.1.1.6 (catechol O-methyltransferase) inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065093	skos:exactMatch	chebi:CHEBI:35625	beta-Lactamase Inhibitors	EC 3.5.2.6 (beta-lactamase) inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064801	skos:exactMatch	chebi:CHEBI:50469	Phospholipase A2 Inhibitors	EC 3.1.1.4 (phospholipase A2) inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064546	skos:exactMatch	hgnc:9395	Protein Kinase C beta	PRKCB	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064424	skos:exactMatch	ncit:C18059	Tobacco Use	Tobacco Use	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063926	skos:exactMatch	ncit:C112208	Drug Hypersensitivity Syndrome	Drug Hypersensitivity Syndrome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062385	skos:exactMatch	chebi:CHEBI:24675	Hydroxybenzoates	hydroxybenzoate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062405	skos:exactMatch	ncit:C157765	Motivational Interviewing	Motivational Interviewing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062407	skos:exactMatch	ncit:C80248	Meals	Meal	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062625	skos:exactMatch	ncit:C8985	Cystadenofibroma	Cystadenofibroma	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062645	skos:exactMatch	ncit:C99521	Percutaneous Coronary Intervention	Percutaneous Coronary Intervention	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062685	skos:exactMatch	doid:DOID:0111556	Steatocystoma Multiplex	steatocystoma multiplex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062765	skos:exactMatch	hgnc:14686	Junctional Adhesion Molecule B	JAM2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062786	skos:exactMatch	hgnc:15532	Junctional Adhesion Molecule C	JAM3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D061988	skos:exactMatch	ncit:C2160	Proteasome Inhibitors	Proteasome Inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D061986	skos:exactMatch	ncit:C18096	MCF-7 Cells	MCF7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D061965	skos:exactMatch	chebi:CHEBI:50664	Matrix Metalloproteinase Inhibitors	matrix metalloproteinase inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062245	skos:exactMatch	ncit:C127112	RxNorm	RxNorm	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062187	skos:exactMatch	ncit:C21023	Spinal Cord Stimulation	Spinal Cord Stimulation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062085	skos:exactMatch	ncit:C88924	RNA, Long Noncoding	LincRNA	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062071	skos:exactMatch	ncit:C114939	Infant, Extremely Premature	Extremely Preterm Infant	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062048	skos:exactMatch	ncit:C116496	Narrow Band Imaging	Narrow Band Imaging	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062365	skos:exactMatch	chebi:CHEBI:22494	Aminobenzoates	aminobenzoate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062346	skos:exactMatch	ncit:C18885	Molecular Medicine	Molecular Medicine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D061466	skos:exactMatch	chebi:CHEBI:31781	Lopinavir	lopinavir	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000001	skos:exactMatch	chebi:CHEBI:3305	Calcimycin	Calcimycin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000019	skos:exactMatch	chebi:CHEBI:50691	Abortifacient Agents	abortifacient	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068180	skos:exactMatch	chebi:CHEBI:31236	Aripiprazole	aripiprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068338	skos:exactMatch	chebi:CHEBI:68478	Everolimus	everolimus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068576	skos:exactMatch	chebi:CHEBI:5938	Interferon beta-1b	Interferon beta-1b	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068679	skos:exactMatch	chebi:CHEBI:31536	Emtricitabine	emtricitabine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000068796	skos:exactMatch	chebi:CHEBI:83296	Orexin Receptor Antagonists	orexin receptor antagonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069059	skos:exactMatch	chebi:CHEBI:39548	Atorvastatin	atorvastatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069349	skos:exactMatch	chebi:CHEBI:63607	Linezolid	linezolid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069557	skos:exactMatch	chebi:CHEBI:746859	Travoprost	travoprost	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000070	skos:exactMatch	chebi:CHEBI:2379	Acebutolol	acebutolol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072318	skos:exactMatch	chebi:CHEBI:38922	Dibenzofurans	dibenzofurans	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072376	skos:exactMatch	chebi:CHEBI:53030	Oxysterols	oxysterol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072664	skos:exactMatch	chebi:CHEBI:50188	Provitamins	provitamin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000073	skos:exactMatch	chebi:CHEBI:22156	Acenaphthenes	acenaphthenes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000074382	skos:exactMatch	chebi:CHEBI:76413	Greenhouse Gases	greenhouse gas	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000075163	skos:exactMatch	chebi:CHEBI:33963	Metallocenes	metallocene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077145	skos:exactMatch	chebi:CHEBI:45373	Sulfanilamide	sulfanilamide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077149	skos:exactMatch	chebi:CHEBI:9130	Sevoflurane	sevoflurane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077150	skos:exactMatch	chebi:CHEBI:31941	Oxaliplatin	oxaliplatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077157	skos:exactMatch	chebi:CHEBI:50924	Sorafenib	sorafenib	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077205	skos:exactMatch	chebi:CHEBI:8228	Pioglitazone	pioglitazone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077208	skos:exactMatch	chebi:CHEBI:8802	Remifentanil	remifentanil	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077210	skos:exactMatch	chebi:CHEBI:38940	Sunitinib	sunitinib	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077222	skos:exactMatch	chebi:CHEBI:15384	Limonene	limonene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077236	skos:exactMatch	chebi:CHEBI:63631	Topiramate	topiramate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077261	skos:exactMatch	chebi:CHEBI:3441	Carvedilol	carvedilol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077266	skos:exactMatch	chebi:CHEBI:63611	Moxifloxacin	moxifloxacin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077271	skos:exactMatch	chebi:CHEBI:36704	Imiquimod	imiquimod	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077276	skos:exactMatch	chebi:CHEBI:15948	Lycopene	lycopene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077287	skos:exactMatch	chebi:CHEBI:6437	Levetiracetam	levetiracetam	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072338	skos:exactMatch	chebi:CHEBI:134046	Dibenzofurans, Polychlorinated	polychlorinated dibenzofuran	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072317	skos:exactMatch	chebi:CHEBI:36682	Polychlorinated Dibenzodioxins	polychlorinated dibenzodioxine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077290	skos:exactMatch	chebi:CHEBI:61379	Harmala Alkaloids	harmala alkaloid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077289	skos:exactMatch	chebi:CHEBI:6413	Letrozole	letrozole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077288	skos:exactMatch	chebi:CHEBI:9753	Troglitazone	troglitazone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077335	skos:exactMatch	chebi:CHEBI:4445	Desflurane	desflurane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077336	skos:exactMatch	chebi:CHEBI:474180	Caspofungin	caspofungin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077339	skos:exactMatch	chebi:CHEBI:6402	Leflunomide	leflunomide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077405	skos:exactMatch	chebi:CHEBI:5959	Irbesartan	irbesartan	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077409	skos:exactMatch	chebi:CHEBI:9398	Tamsulosin	tamsulosin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077333	skos:exactMatch	chebi:CHEBI:9434	Telmisartan	telmisartan	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077422	skos:exactMatch	chebi:CHEBI:35720	Enrofloxacin	enrofloxacin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077465	skos:exactMatch	chebi:CHEBI:3286	Cabergoline	cabergoline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077466	skos:exactMatch	chebi:CHEBI:9605	Tirofiban	tirofiban	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077484	skos:exactMatch	chebi:CHEBI:63637	Vemurafenib	vemurafenib	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077545	skos:exactMatch	chebi:CHEBI:31547	Eplerenone	eplerenone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077553	skos:exactMatch	chebi:CHEBI:31530	Edaravone	edaravone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077554	skos:exactMatch	chebi:CHEBI:6149	Levobupivacaine	levobupivacaine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077583	skos:exactMatch	chebi:CHEBI:8713	Quinapril	quinapril	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077590	skos:exactMatch	chebi:CHEBI:6958	Mivacurium	Mivacurium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077609	skos:exactMatch	chebi:CHEBI:90748	O-(Chloroacetylcarbamoyl)fumagillol	O-(chloroacetylcarbamoyl)fumagillol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077613	skos:exactMatch	chebi:CHEBI:6339	Etoricoxib	etoricoxib	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077723	skos:exactMatch	chebi:CHEBI:478164	Cefepime	cefepime	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077731	skos:exactMatch	chebi:CHEBI:43968	Meropenem	meropenem	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078183	skos:exactMatch	chebi:CHEBI:38459	Oxindoles	oxindoles	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078102	skos:exactMatch	chebi:CHEBI:156095	Lumefantrine	lumefantrine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077922	skos:exactMatch	chebi:CHEBI:39185	Thiamethoxam	thiamethoxam	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077771	skos:exactMatch	chebi:CHEBI:6817	Methantheline	Methantheline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077770	skos:exactMatch	chebi:CHEBI:135948	Amifampridine	amifampridine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077769	skos:exactMatch	chebi:CHEBI:8862	Rilmenidine	Rilmenidine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078223	skos:exactMatch	chebi:CHEBI:18293	5-Methoxypsoralen	5-methoxypsoralen	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078328	skos:exactMatch	chebi:CHEBI:4995	Felbamate	felbamate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078330	skos:exactMatch	chebi:CHEBI:7824	Oxcarbazepine	oxcarbazepine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078604	skos:exactMatch	chebi:CHEBI:90414	Secretagogues	secretagogue	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078785	skos:exactMatch	chebi:CHEBI:6950	Mirtazapine	mirtazapine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078789	skos:exactMatch	chebi:CHEBI:60552	Polyacetylene Polymer	polyacetylene polymer	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000079	skos:exactMatch	chebi:CHEBI:15343	Acetaldehyde	acetaldehyde	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000080	skos:exactMatch	chebi:CHEBI:59769	Acetals	acetal	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000080084	skos:exactMatch	chebi:CHEBI:64068	Calicheamicins	calicheamicin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000081	skos:exactMatch	chebi:CHEBI:22160	Acetamides	acetamides	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000081026	skos:exactMatch	chebi:CHEBI:26199	Polyprenols	polyprenol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000081503	skos:exactMatch	chebi:CHEBI:51185	Organoiron Compounds	organoiron compound	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000086	skos:exactMatch	chebi:CHEBI:27690	Acetazolamide	acetazolamide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000093	skos:exactMatch	chebi:CHEBI:15688	Acetoin	acetoin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000096	skos:exactMatch	chebi:CHEBI:15347	Acetone	acetone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000098	skos:exactMatch	chebi:CHEBI:22187	Acetophenones	acetophenones	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000109	skos:exactMatch	chebi:CHEBI:15355	Acetylcholine	acetylcholine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000114	skos:exactMatch	chebi:CHEBI:27518	Acetylene	acetylene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000156	skos:exactMatch	chebi:CHEBI:22211	Aconitic Acid	aconitic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000157	skos:exactMatch	chebi:CHEBI:2430	Aconitine	aconitine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000165	skos:exactMatch	chebi:CHEBI:51739	Acridine Orange	acridine orange	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000166	skos:exactMatch	chebi:CHEBI:22213	Acridines	acridines	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000171	skos:exactMatch	chebi:CHEBI:15368	Acrolein	acrolein	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000145	skos:exactMatch	chebi:CHEBI:26643	Acids, Aldehydic	aldehydic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000178	skos:exactMatch	chebi:CHEBI:22216	Acrylamides	acrylamides	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000181	skos:exactMatch	chebi:CHEBI:28217	Acrylonitrile	acrylonitrile	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000186	skos:exactMatch	chebi:CHEBI:33337	Actinium	actinium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000225	skos:exactMatch	chebi:CHEBI:16708	Adenine	adenine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000241	skos:exactMatch	chebi:CHEBI:16335	Adenosine	adenosine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000255	skos:exactMatch	chebi:CHEBI:15422	Adenosine Triphosphate	ATP	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000325	skos:exactMatch	chebi:CHEBI:48962	Adrenodoxin	adrenodoxin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000345	skos:exactMatch	chebi:CHEBI:60788	Affinity Labels	affinity label	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000376	skos:exactMatch	chebi:CHEBI:17431	Agmatine	agmatine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000404	skos:exactMatch	chebi:CHEBI:28462	Ajmaline	ajmaline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000409	skos:exactMatch	chebi:CHEBI:16449	Alanine	alanine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000420	skos:exactMatch	chebi:CHEBI:2549	Albuterol	albuterol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000431	skos:exactMatch	chebi:CHEBI:16236	Ethanol	ethanol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000432	skos:exactMatch	chebi:CHEBI:17790	Methanol	methanol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000443	skos:exactMatch	chebi:CHEBI:55313	Alcuronium	alcuronium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000447	skos:exactMatch	chebi:CHEBI:17478	Aldehydes	aldehyde	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000448	skos:exactMatch	chebi:CHEBI:2555	Aldicarb	aldicarb	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000450	skos:exactMatch	chebi:CHEBI:27584	Aldosterone	aldosterone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000466	skos:exactMatch	chebi:CHEBI:33646	Alkadienes	alkadiene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000473	skos:exactMatch	chebi:CHEBI:18310	Alkanes	alkane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000479	skos:exactMatch	chebi:CHEBI:33255	Alkylmercury Compounds	alkylmercury compound	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000481	skos:exactMatch	chebi:CHEBI:15676	Allantoin	allantoin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000485	skos:exactMatch	chebi:CHEBI:50904	Allergens	allergen	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000493	skos:exactMatch	chebi:CHEBI:40279	Allopurinol	allopurinol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000500	skos:exactMatch	chebi:CHEBI:31189	Allylestrenol	Allylestrenol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000523	skos:exactMatch	chebi:CHEBI:763	Algestone	algestone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000525	skos:exactMatch	chebi:CHEBI:2611	Alprazolam	alprazolam	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000547	skos:exactMatch	chebi:CHEBI:2618	Amantadine	amantadine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000576	skos:exactMatch	chebi:CHEBI:33389	Americium	americium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000583	skos:exactMatch	chebi:CHEBI:2637	Amikacin	amikacin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000584	skos:exactMatch	chebi:CHEBI:2639	Amiloride	amiloride	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000605	skos:exactMatch	chebi:CHEBI:22478	Amino Alcohols	amino alcohol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000606	skos:exactMatch	chebi:CHEBI:28963	Amino Sugars	amino sugar	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000609	skos:exactMatch	chebi:CHEBI:51803	Aminoacridines	aminoacridines	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000625	skos:exactMatch	chebi:CHEBI:40823	Aminooxyacetic Acid	aminooxyacetic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000628	skos:exactMatch	chebi:CHEBI:2659	Aminophylline	aminophylline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000631	skos:exactMatch	chebi:CHEBI:38207	Aminopyridines	aminopyridine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000634	skos:exactMatch	chebi:CHEBI:36709	Aminoquinolines	aminoquinoline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000639	skos:exactMatch	chebi:CHEBI:2666	Amitriptyline	amitriptyline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000640	skos:exactMatch	chebi:CHEBI:40036	Amitrole	amitrole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000641	skos:exactMatch	chebi:CHEBI:16134	Ammonia	ammonia	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000644	skos:exactMatch	chebi:CHEBI:35273	Quaternary Ammonium Compounds	quaternary ammonium salt	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000655	skos:exactMatch	chebi:CHEBI:2674	Amodiaquine	amodiaquine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000658	skos:exactMatch	chebi:CHEBI:2676	Amoxicillin	amoxicillin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000661	skos:exactMatch	chebi:CHEBI:2679	Amphetamine	amphetamine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000662	skos:exactMatch	chebi:CHEBI:35338	Amphetamines	amphetamines	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000667	skos:exactMatch	chebi:CHEBI:28971	Ampicillin	ampicillin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000654	skos:exactMatch	chebi:CHEBI:2673	Amobarbital	amobarbital	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000638	skos:exactMatch	chebi:CHEBI:2663	Amiodarone	amiodarone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000701	skos:exactMatch	chebi:CHEBI:35482	Analgesics, Opioid	opioid analgesic	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000968	skos:exactMatch	chebi:CHEBI:2762	Antimycin A	antimycin A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000931	skos:exactMatch	chebi:CHEBI:50247	Antidotes	antidote	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000983	skos:exactMatch	chebi:CHEBI:31225	Antipyrine	antipyrine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000982	skos:exactMatch	chebi:CHEBI:59683	Antipruritics	antipruritic drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000981	skos:exactMatch	chebi:CHEBI:35820	Antiprotozoal Agents	antiprotozoal drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000980	skos:exactMatch	chebi:CHEBI:35684	Antiplatyhelmintic Agents	antiplatyhelmintic drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000935	skos:exactMatch	chebi:CHEBI:35718	Antifungal Agents	antifungal agent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000934	skos:exactMatch	chebi:CHEBI:77973	Antifoaming Agents	antifoaming agent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000933	skos:exactMatch	chebi:CHEBI:48675	Antifibrinolytic Agents	antifibrinolytic drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000924	skos:exactMatch	chebi:CHEBI:35821	Anticholesteremic Agents	anticholesteremic drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000897	skos:exactMatch	chebi:CHEBI:49201	Anti-Ulcer Agents	anti-ulcer drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001074	skos:exactMatch	chebi:CHEBI:34938	Propoxur	propoxur	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001059	skos:exactMatch	chebi:CHEBI:13850	Apoproteins	apoprotein	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001052	skos:exactMatch	chebi:CHEBI:2784	Apoferritins	Apoferritin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000995	skos:exactMatch	chebi:CHEBI:33231	Antitubercular Agents	antitubercular agent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001120	skos:exactMatch	chebi:CHEBI:29016	Arginine	arginine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001147	skos:exactMatch	chebi:CHEBI:49477	Arsanilic Acid	arsanilic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001151	skos:exactMatch	chebi:CHEBI:27563	Arsenic	arsenic atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001153	skos:exactMatch	chebi:CHEBI:9016	Arsphenamine	arsphenamine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001252	skos:exactMatch	chebi:CHEBI:74783	Astringents	astringent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001278	skos:exactMatch	chebi:CHEBI:2913	Atractyloside	Atractyloside	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001279	skos:exactMatch	chebi:CHEBI:2914	Atracurium	atracurium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001280	skos:exactMatch	chebi:CHEBI:15930	Atrazine	atrazine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001285	skos:exactMatch	chebi:CHEBI:16684	Atropine	atropine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001430	skos:exactMatch	chebi:CHEBI:48081	Bacteriocins	bacteriocin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001429	skos:exactMatch	chebi:CHEBI:38201	Bacteriochlorophylls	bacteriochlorophyll	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001414	skos:exactMatch	chebi:CHEBI:28669	Bacitracin	bacitracin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001391	skos:exactMatch	chebi:CHEBI:37533	Azo Compounds	azo compound	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001384	skos:exactMatch	chebi:CHEBI:38777	Azetidines	azetidines	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001565	skos:exactMatch	chebi:CHEBI:22718	Benzoates	benzoates	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001566	skos:exactMatch	chebi:CHEBI:116735	Benzocaine	benzocaine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001554	skos:exactMatch	chebi:CHEBI:16716	Benzene	benzene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001556	skos:exactMatch	chebi:CHEBI:24536	Hexachlorocyclohexane	hexachlorocyclohexane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001573	skos:exactMatch	chebi:CHEBI:17682	Benzoin	benzoin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001577	skos:exactMatch	chebi:CHEBI:22726	Benzophenones	benzophenones	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001583	skos:exactMatch	chebi:CHEBI:46700	Benzoxazoles	benzoxazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001589	skos:exactMatch	chebi:CHEBI:3044	Benzphetamine	benzphetamine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001572	skos:exactMatch	chebi:CHEBI:35259	Benzofurans	benzofurans	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065808	skos:exactMatch	go:GO:0060134	Prepulse Inhibition	prepulse inhibition	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065819	skos:exactMatch	chebi:CHEBI:10023	Voriconazole	voriconazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065766	skos:exactMatch	doid:DOID:0080301	Atypical Hemolytic Uremic Syndrome	atypical hemolytic-uremic syndrome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064704	skos:exactMatch	chebi:CHEBI:63598	Levofloxacin	levofloxacin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064747	skos:exactMatch	chebi:CHEBI:6375	Lansoprazole	lansoprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064748	skos:exactMatch	chebi:CHEBI:135931	Dexlansoprazole	dexlansoprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064107	skos:exactMatch	hgnc:11390	Aurora Kinase B	AURKB	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064098	skos:exactMatch	chebi:CHEBI:50275	Esomeprazole	esomeprazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064096	skos:exactMatch	hgnc:11393	Aurora Kinase A	AURKA	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064048	skos:exactMatch	go:GO:0005816	Spindle Pole Bodies	spindle pole body	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D061346	skos:exactMatch	efo:0009111	Laser Capture Microdissection	laser capture microdissection	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D061988	skos:exactMatch	chebi:CHEBI:52726	Proteasome Inhibitors	proteasome inhibitor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D062556	skos:exactMatch	hgnc:10597	NAV1.7 Voltage-Gated Sodium Channel	SCN9A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059748	skos:exactMatch	go:GO:0006508	Proteolysis	proteolysis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059765	skos:exactMatch	go:GO:0035825	Homologous Recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059370	skos:exactMatch	go:GO:0034337	RNA Folding	RNA folding	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059246	skos:exactMatch	efo:0009840	Tachypnea	tachypnea	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059390	skos:exactMatch	hp:HP:0032149	Breakthrough Pain	Breakthrough pain	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059630	skos:exactMatch	efo:0000586	Mesenchymal Stem Cells	mesenchymal stem cell	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D058924	skos:exactMatch	chebi:CHEBI:37942	Thienopyridines	thienopyridine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056892	skos:exactMatch	go:GO:0016592	Mediator Complex	mediator complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056850	skos:exactMatch	hgnc:1779	Cyclin-Dependent Kinase 8	CDK8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056743	skos:exactMatch	hgnc:1585	Cyclin D3	CCND3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056744	skos:exactMatch	hgnc:1579	Cyclin B1	CCNB1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056748	skos:exactMatch	hgnc:1594	Cyclin H	CCNH	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056750	skos:exactMatch	hgnc:1577	Cyclin A1	CCNA1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056751	skos:exactMatch	hgnc:1578	Cyclin A2	CCNA2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056765	skos:exactMatch	hgnc:1580	Cyclin B2	CCNB2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056807	skos:exactMatch	hp:HP:0025630	Argininosuccinic Aciduria	Argininosuccinic aciduria	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056833	skos:exactMatch	hp:HP:0025567	Central Serous Chorioretinopathy	Central serous chorioretinopathy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056849	skos:exactMatch	hgnc:1772	Cyclin-Dependent Kinase 3	CDK3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055531	skos:exactMatch	go:GO:0097504	Gemini of Coiled Bodies	Gemini of coiled bodies	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055495	skos:exactMatch	go:GO:0022008	Neurogenesis	neurogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055623	skos:exactMatch	hp:HP:0025127	Keratosis, Actinic	Actinic keratosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055417	skos:exactMatch	hgnc:1072	Bone Morphogenetic Protein 5	BMP5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055418	skos:exactMatch	hgnc:1073	Bone Morphogenetic Protein 6	BMP6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055419	skos:exactMatch	hgnc:1074	Bone Morphogenetic Protein 7	BMP7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055427	skos:exactMatch	hgnc:4217	Growth Differentiation Factor 2	GDF2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055428	skos:exactMatch	hgnc:4220	Growth Differentiation Factor 5	GDF5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055429	skos:exactMatch	hgnc:4224	Growth Differentiation Factor 9	GDF9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055423	skos:exactMatch	efo:0009371	Diet, Ketogenic	ketogenic diet	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055430	skos:exactMatch	hgnc:1068	Bone Morphogenetic Protein 15	BMP15	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055436	skos:exactMatch	hgnc:30142	Growth Differentiation Factor 15	GDF15	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055451	skos:exactMatch	hgnc:4218	Growth Differentiation Factor 3	GDF3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055415	skos:exactMatch	hgnc:1071	Bone Morphogenetic Protein 4	BMP4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055398	skos:exactMatch	hgnc:1070	Bone Morphogenetic Protein 3	BMP3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055413	skos:exactMatch	hgnc:4215	Growth Differentiation Factor 10	GDF10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054876	skos:exactMatch	go:GO:0097354	Prenylation	prenylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054816	skos:exactMatch	chebi:CHEBI:51174	Levopropoxyphene	levopropoxyphene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055257	skos:exactMatch	hgnc:7516	Mucin-5B	MUC5B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055262	skos:exactMatch	hgnc:7512	Mucin-2	MUC2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055272	skos:exactMatch	hgnc:7517	Mucin-6	MUC6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054638	skos:exactMatch	hgnc:3064	Dual Specificity Phosphatase 1	DUSP1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054640	skos:exactMatch	hgnc:3069	Dual Specificity Phosphatase 3	DUSP3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054642	skos:exactMatch	hgnc:3072	Dual Specificity Phosphatase 6	DUSP6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054414	skos:exactMatch	hgnc:10615	Chemokine CCL17	CCL17	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054415	skos:exactMatch	hgnc:10617	Chemokine CCL19	CCL19	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054418	skos:exactMatch	hgnc:10619	Chemokine CCL20	CCL20	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054422	skos:exactMatch	hgnc:10621	Chemokine CCL22	CCL22	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054423	skos:exactMatch	hgnc:10623	Chemokine CCL24	CCL24	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054425	skos:exactMatch	hgnc:10626	Chemokine CCL27	CCL27	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054426	skos:exactMatch	hgnc:4603	Chemokine CXCL2	CXCL2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054427	skos:exactMatch	hgnc:10643	Chemokine CXCL6	CXCL6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054447	skos:exactMatch	hgnc:4474	Receptors, CCR10	CCR10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054377	skos:exactMatch	hgnc:10672	Chemokine CXCL12	CXCL12	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054380	skos:exactMatch	hgnc:1060	Receptors, CXCR5	CXCR5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054390	skos:exactMatch	hgnc:1603	Receptors, CCR2	CCR2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054397	skos:exactMatch	hgnc:1604	Receptors, CCR3	CCR3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054405	skos:exactMatch	hgnc:10627	Chemokine CCL3	CCL3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054410	skos:exactMatch	hgnc:10634	Chemokine CCL7	CCL7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054412	skos:exactMatch	hgnc:10635	Chemokine CCL8	CCL8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054341	skos:exactMatch	hgnc:6338	Receptors, KIR3DL1	KIR3DL1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054342	skos:exactMatch	hgnc:6329	Receptors, KIR2DL1	KIR2DL1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054343	skos:exactMatch	hgnc:6330	Receptors, KIR2DL2	KIR2DL2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054344	skos:exactMatch	hgnc:6331	Receptors, KIR2DL3	KIR2DL3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054347	skos:exactMatch	hgnc:6339	Receptors, KIR3DL2	KIR3DL2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054360	skos:exactMatch	hgnc:4602	Chemokine CXCL1	CXCL1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053781	skos:exactMatch	hgnc:11768	Transforming Growth Factor beta2	TGFB2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053782	skos:exactMatch	hgnc:11769	Transforming Growth Factor beta3	TGFB3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054079	skos:exactMatch	efo:0006888	Vascular Malformations	vascular malformation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053613	skos:exactMatch	hgnc:6190	Janus Kinase 1	JAK1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053614	skos:exactMatch	hgnc:6192	Janus Kinase 2	JAK2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053616	skos:exactMatch	hgnc:6193	Janus Kinase 3	JAK3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053626	skos:exactMatch	chebi:CHEBI:575568	Atovaquone	atovaquone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053634	skos:exactMatch	hgnc:12440	TYK2 Kinase	TYK2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053533	skos:exactMatch	hgnc:6446	Keratin-8	KRT8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053535	skos:exactMatch	hgnc:6415	Keratin-13	KRT13	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053537	skos:exactMatch	hgnc:6427	Keratin-17	KRT17	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053538	skos:exactMatch	hgnc:6430	Keratin-18	KRT18	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053539	skos:exactMatch	hgnc:6436	Keratin-19	KRT19	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053179	skos:exactMatch	hgnc:1508	Caspase 7	CASP7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053181	skos:exactMatch	hgnc:1509	Caspase 8	CASP8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051526	skos:exactMatch	hgnc:3666	Fibroblast Growth Factor 10	FGF10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051538	skos:exactMatch	hgnc:11621	Hepatocyte Nuclear Factor 1-alpha	HNF1A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051539	skos:exactMatch	hgnc:11630	Hepatocyte Nuclear Factor 1-beta	HNF1B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051357	skos:exactMatch	hgnc:1771	Cyclin-Dependent Kinase 2	CDK2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051358	skos:exactMatch	hgnc:1773	Cyclin-Dependent Kinase 4	CDK4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051360	skos:exactMatch	hgnc:1774	Cyclin-Dependent Kinase 5	CDK5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051361	skos:exactMatch	hgnc:1777	Cyclin-Dependent Kinase 6	CDK6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051383	skos:exactMatch	hgnc:4564	GRB10 Adaptor Protein	GRB10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051523	skos:exactMatch	hgnc:3685	Fibroblast Growth Factor 7	FGF7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051524	skos:exactMatch	hgnc:3686	Fibroblast Growth Factor 8	FGF8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C486356	skos:exactMatch	uniprot:P61328	FGF12 protein, human	FGF12	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C484724	skos:exactMatch	uniprot:O60258	FGF17 protein, human	FGF17	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C117476	skos:exactMatch	uniprot:O95750	FGF19 protein, human	FGF19	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496444	skos:exactMatch	uniprot:P11487	FGF3 protein, human	FGF3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C512705	skos:exactMatch	uniprot:O43320	FGF16 protein, human	FGF16	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496445	skos:exactMatch	uniprot:P08620	FGF4 protein, human	FGF4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C417531	skos:exactMatch	uniprot:Q8N441	FGFRL1 protein, human	FGFRL1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C416003	skos:exactMatch	uniprot:Q9NP95	FGF20 protein, human	FGF20	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496463	skos:exactMatch	uniprot:O15520	FGF10 protein, human	FGF10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496449	skos:exactMatch	uniprot:P12034	FGF5 protein, human	FGF5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496452	skos:exactMatch	uniprot:P10767	FGF6 protein, human	FGF6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496456	skos:exactMatch	uniprot:P55075	FGF8 protein, human	FGF8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496459	skos:exactMatch	uniprot:P31371	FGF9 protein, human	FGF9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496453	skos:exactMatch	uniprot:P21781	FGF7 protein, human	FGF7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496353	skos:exactMatch	uniprot:P21802	FGFR2 protein, human	FGFR2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496365	skos:exactMatch	uniprot:P22607	FGFR3 protein, human	FGFR3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496371	skos:exactMatch	uniprot:P22455	FGFR4 protein, human	FGFR4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C496348	skos:exactMatch	uniprot:P11362	FGFR1 protein, human	FGFR1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000627735	skos:exactMatch	uniprot:Q9HCT0	FGF22 protein, human	FGF22	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000706947	skos:exactMatch	uniprot:Q9NSA1	FGF21 protein, human	FGF21	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016222	skos:exactMatch	hgnc:3676	Fibroblast Growth Factor 2	FGF2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016220	skos:exactMatch	hgnc:3665	Fibroblast Growth Factor 1	FGF1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D042863	skos:exactMatch	hgnc:1780	Cyclin-Dependent Kinase 9	CDK9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000598645	skos:exactMatch	doid:DOID:0080091	Spheroid body myopathy	spheroid body myopathy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000596385	skos:exactMatch	doid:DOID:0111404	Jalili syndrome	Jalili syndrome	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000626124	skos:exactMatch	doid:DOID:0060728	NGLY1 deficiency	NGLY1-deficiency	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000656784	skos:exactMatch	doid:DOID:0050072	adiaspiromycosis	adiaspiromycosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000656825	skos:exactMatch	doid:DOID:0050096	tinea barbae	tinea barbae	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C000656904	skos:exactMatch	doid:DOID:8912	tinea nigra	tinea nigra	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535334	skos:exactMatch	doid:DOID:0050600	ABCD syndrome	ABCD syndrome	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535358	skos:exactMatch	doid:DOID:980	Choroidal sclerosis	choroidal sclerosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535388	skos:exactMatch	doid:DOID:0050647	Arts syndrome	Arts syndrome	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535330	skos:exactMatch	doid:DOID:6691	Aagenaes syndrome	Aagenaes syndrome	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535328	skos:exactMatch	doid:DOID:0060177	Homocarnosinosis	homocarnosinosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535416	skos:exactMatch	doid:DOID:0110158	Charcot-Marie-Tooth disease, Type 2I	Charcot-Marie-Tooth disease type 2I	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535420	skos:exactMatch	doid:DOID:0110191	Charcot-Marie-Tooth disease, Type 4B1	Charcot-Marie-Tooth disease type 4B1	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535421	skos:exactMatch	doid:DOID:0110190	Charcot-Marie-Tooth disease, Type 4B2	Charcot-Marie-Tooth disease type 4B2	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535436	skos:exactMatch	doid:DOID:0050663	Bethlem myopathy	Bethlem myopathy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535440	skos:exactMatch	doid:DOID:0050664	Bietti Crystalline Dystrophy	Bietti crystalline corneoretinal dystrophy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C535549	skos:exactMatch	doid:DOID:3927	Pelvic lipomatosis	pelvic lipomatosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D066146	skos:exactMatch	go:GO:0044297	Cell Body	cell body	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C019919	skos:exactMatch	go:GO:1990143	CoA-synthesizing protein complex	CoA-synthesizing protein complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C035492	skos:exactMatch	go:GO:0031838	haptoglobin-hemoglobin complex	haptoglobin-hemoglobin complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C033727	skos:exactMatch	go:GO:0045283	fumarate reductase complex	fumarate reductase complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071218	skos:exactMatch	go:GO:0007624	Ultradian Rhythm	ultradian rhythm	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071437	skos:exactMatch	go:GO:0007411	Axon Guidance	axon guidance	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071444	skos:exactMatch	go:GO:0042331	Phototaxis	phototaxis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071448	skos:exactMatch	go:GO:0007413	Axon Fasciculation	axonal fasciculation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072159	skos:exactMatch	go:GO:0005869	Dynactin Complex	dynactin complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000072777	skos:exactMatch	go:GO:0032537	Host-Seeking Behavior	host-seeking behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000073398	skos:exactMatch	go:GO:0070988	Demethylation	demethylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000073399	skos:exactMatch	go:GO:0080111	DNA Demethylation	DNA demethylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000079403	skos:exactMatch	go:GO:0097707	Ferroptosis	ferroptosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078790	skos:exactMatch	go:GO:0030073	Insulin Secretion	insulin secretion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077320	skos:exactMatch	go:GO:0110148	Biomineralization	biomineralization	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000205	skos:exactMatch	go:GO:0042641	Actomyosin	actomyosin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000200	skos:exactMatch	go:GO:0001508	Action Potentials	action potential	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000566	skos:exactMatch	go:GO:0097186	Amelogenesis	amelogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077743	skos:exactMatch	chebi:CHEBI:23847	Diterpene Alkaloids	diterpene alkaloid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000738	skos:exactMatch	chebi:CHEBI:16032	Androsterone	androsterone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000688	skos:exactMatch	chebi:CHEBI:28102	Amylose	amylose	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000687	skos:exactMatch	chebi:CHEBI:28057	Amylopectin	amylopectin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000080549	skos:exactMatch	go:GO:0048102	Autophagic Cell Death	autophagic cell death	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000940	skos:exactMatch	go:GO:0020033	Antigenic Variation	antigenic variation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001370	skos:exactMatch	go:GO:0098930	Axonal Transport	axonal transport	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001777	skos:exactMatch	go:GO:0007596	Blood Coagulation	blood coagulation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002448	skos:exactMatch	go:GO:0007155	Cell Adhesion	cell adhesion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002449	skos:exactMatch	go:GO:0098743	Cell Aggregation	cell aggregation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002450	skos:exactMatch	go:GO:0007154	Cell Communication	cell communication	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002453	skos:exactMatch	go:GO:0007049	Cell Cycle	cell cycle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002455	skos:exactMatch	go:GO:0051301	Cell Division	cell division	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002473	skos:exactMatch	go:GO:0005618	Cell Wall	cell wall	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002634	skos:exactMatch	go:GO:0030595	Chemotaxis, Leukocyte	leukocyte chemotaxis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002837	skos:exactMatch	go:GO:0042583	Chromaffin Granules	chromaffin granule	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003216	skos:exactMatch	go:GO:0035106	Conditioning, Operant	operant conditioning	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003260	skos:exactMatch	go:GO:0060242	Contact Inhibition	contact inhibition	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003307	skos:exactMatch	go:GO:0007620	Copulation	copulation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003341	skos:exactMatch	go:GO:0001554	Luteolysis	luteolysis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003595	skos:exactMatch	go:GO:0099636	Cytoplasmic Streaming	cytoplasmic streaming	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003623	skos:exactMatch	go:GO:1990603	Dark Adaptation	dark adaptation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003810	skos:exactMatch	go:GO:0097187	Dentinogenesis	dentinogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004031	skos:exactMatch	go:GO:0060207	Diestrus	diestrus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004063	skos:exactMatch	go:GO:0007586	Digestion	digestion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004327	skos:exactMatch	go:GO:0042756	Drinking Behavior	drinking behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004455	skos:exactMatch	go:GO:0050959	Echolocation	echolocation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004705	skos:exactMatch	go:GO:0006897	Endocytosis	endocytosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004903	skos:exactMatch	go:GO:0034117	Erythrocyte Aggregation	erythrocyte aggregation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004956	skos:exactMatch	go:GO:0042751	Estivation	estivation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005247	skos:exactMatch	go:GO:0007631	Feeding Behavior	feeding behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005342	skos:exactMatch	go:GO:0042730	Fibrinolysis	fibrinolysis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005427	skos:exactMatch	go:GO:0000128	Flocculation	flocculation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005785	skos:exactMatch	go:GO:0035822	Gene Conversion	gene conversion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005786	skos:exactMatch	go:GO:0010468	Gene Expression Regulation	regulation of gene expression	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005790	skos:exactMatch	go:GO:0051866	General Adaptation Syndrome	general adaptation syndrome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D006031	skos:exactMatch	go:GO:0070085	Glycosylation	glycosylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D006605	skos:exactMatch	go:GO:0042750	Hibernation	hibernation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007314	skos:exactMatch	go:GO:0007320	Insemination	insemination	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007408	skos:exactMatch	go:GO:0050892	Intestinal Absorption	intestinal absorption	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007698	skos:exactMatch	go:GO:0042465	Kinesis	kinesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007774	skos:exactMatch	go:GO:0007595	Lactation	lactation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008115	skos:exactMatch	go:GO:0097421	Liver Regeneration	liver regeneration	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008247	skos:exactMatch	go:GO:0005764	Lysosomes	lysosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008262	skos:exactMatch	go:GO:0042116	Macrophage Activation	macrophage activation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008425	skos:exactMatch	go:GO:0042711	Maternal Behavior	maternal behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008561	skos:exactMatch	go:GO:0061025	Membrane Fusion	membrane fusion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008566	skos:exactMatch	go:GO:0016020	Membranes	membrane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008686	skos:exactMatch	go:GO:0060210	Metestrus	metestrus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008745	skos:exactMatch	go:GO:0032259	Methylation	methylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009043	skos:exactMatch	go:GO:0003774	Motor Activity	motor activity	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009079	skos:exactMatch	go:GO:0120197	Mucociliary Clearance	mucociliary clearance	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009210	skos:exactMatch	go:GO:0030016	Myofibrils	myofibril	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009469	skos:exactMatch	go:GO:0031594	Neuromuscular Junction	neuromuscular junction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009586	skos:exactMatch	go:GO:0009399	Nitrogen Fixation	nitrogen fixation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009697	skos:exactMatch	go:GO:0005731	Nucleolus Organizer Region	nucleolus organizer region	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010058	skos:exactMatch	go:GO:0018991	Oviposition	oviposition	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010064	skos:exactMatch	go:GO:0007566	Embryo Implantation	embryo implantation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010332	skos:exactMatch	go:GO:0042712	Paternal Behavior	paternal behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010410	skos:exactMatch	go:GO:0043084	Penile Erection	penile erection	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010452	skos:exactMatch	go:GO:0043043	Peptide Biosynthesis	peptide biosynthetic process	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010873	skos:exactMatch	go:GO:0006907	Pinocytosis	pinocytosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010974	skos:exactMatch	go:GO:0070527	Platelet Aggregation	platelet aggregation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010766	skos:exactMatch	go:GO:0016310	Phosphorylation	phosphorylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011359	skos:exactMatch	go:GO:0060208	Proestrus	proestrus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011434	skos:exactMatch	go:GO:0019230	Proprioception	proprioception	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011485	skos:exactMatch	go:GO:0005515	Protein Binding	protein binding	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011489	skos:exactMatch	go:GO:0030164	Protein Denaturation	protein denaturation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011554	skos:exactMatch	go:GO:0031143	Pseudopodia	pseudopodium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012270	skos:exactMatch	go:GO:0005840	Ribosomes	ribosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012472	skos:exactMatch	go:GO:0046541	Salivation	saliva secretion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012728	skos:exactMatch	go:GO:0001739	Sex Chromatin	sex chromatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012733	skos:exactMatch	go:GO:0007548	Sex Differentiation	sex differentiation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012919	skos:exactMatch	go:GO:0035176	Social Behavior	social behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013049	skos:exactMatch	go:GO:0008091	Spectrin	spectrin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013075	skos:exactMatch	go:GO:0048240	Sperm Capacitation	sperm capacitation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013077	skos:exactMatch	go:GO:0061827	Sperm Head	sperm head	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013394	skos:exactMatch	go:GO:0070014	Sucrase-Isomaltase Complex	sucrase-isomaltase complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013559	skos:exactMatch	go:GO:0044403	Symbiosis	symbiotic process	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013570	skos:exactMatch	go:GO:0097060	Synaptic Membranes	synaptic membrane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013572	skos:exactMatch	go:GO:0008021	Synaptic Vesicles	synaptic vesicle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013573	skos:exactMatch	go:GO:0000795	Synaptonemal Complex	synaptonemal complex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014661	skos:exactMatch	go:GO:0042310	Vasoconstriction	vasoconstriction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014818	skos:exactMatch	go:GO:0007296	Vitellogenesis	vitellogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016631	skos:exactMatch	go:GO:0097413	Lewy Bodies	Lewy body	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016874	skos:exactMatch	go:GO:0097418	Neurofibrillary Tangles	neurofibrillary tangle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017368	skos:exactMatch	go:GO:0018342	Protein Prenylation	protein prenylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015870	skos:exactMatch	go:GO:0010467	Gene Expression	gene expression	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018087	skos:exactMatch	go:GO:0009536	Plastids	plastid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018271	skos:exactMatch	go:GO:0048500	Signal Recognition Particle	signal recognition particle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018386	skos:exactMatch	go:GO:0000776	Kinetochores	kinetochore	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018522	skos:exactMatch	go:GO:0009630	Gravitropism	gravitropism	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018523	skos:exactMatch	go:GO:0009606	Tropism	tropism	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018524	skos:exactMatch	go:GO:0009638	Phototropism	phototropism	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019175	skos:exactMatch	go:GO:0006306	DNA Methylation	DNA methylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019599	skos:exactMatch	go:GO:0097457	Mossy Fibers, Hippocampal	hippocampal mossy fiber	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019706	skos:exactMatch	go:GO:0060079	Excitatory Postsynaptic Potentials	excitatory postsynaptic potential	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019898	skos:exactMatch	go:GO:0035425	Autocrine Communication	autocrine signaling	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019899	skos:exactMatch	go:GO:0038001	Paracrine Communication	paracrine signaling	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020101	skos:exactMatch	go:GO:0007340	Acrosome Reaction	acrosome reaction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020439	skos:exactMatch	go:GO:0030426	Growth Cones	growth cone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020460	skos:exactMatch	go:GO:0042470	Melanosomes	melanosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020524	skos:exactMatch	go:GO:0009579	Thylakoids	thylakoid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020675	skos:exactMatch	go:GO:0005777	Peroxisomes	peroxisome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020676	skos:exactMatch	go:GO:0009514	Glyoxysomes	glyoxysome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020868	skos:exactMatch	go:GO:0016458	Gene Silencing	gene silencing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D021381	skos:exactMatch	go:GO:0015031	Protein Transport	protein transport	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D021601	skos:exactMatch	go:GO:0005802	trans-Golgi Network	trans-Golgi network	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022162	skos:exactMatch	go:GO:0031410	Cytoplasmic Vesicles	cytoplasmic vesicle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022163	skos:exactMatch	go:GO:0030136	Clathrin-Coated Vesicles	clathrin-coated vesicle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022502	skos:exactMatch	go:GO:0001725	Stress Fibers	stress fiber	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D030762	skos:exactMatch	go:GO:0044849	Estrous Cycle	estrous cycle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D026721	skos:exactMatch	go:GO:0031123	RNA 3' End Processing	RNA 3'-end processing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D031425	skos:exactMatch	go:GO:0009506	Plasmodesmata	plasmodesma	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D032961	skos:exactMatch	go:GO:0097225	Sperm Midpiece	sperm midpiece	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D034461	skos:exactMatch	go:GO:0001553	Luteinization	luteinization	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D036881	skos:exactMatch	go:GO:0060292	Long-Term Synaptic Depression	long-term synaptic depression	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D042003	skos:exactMatch	go:GO:0006323	DNA Packaging	DNA packaging	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D021962	skos:exactMatch	go:GO:0098857	Membrane Microdomains	membrane microdomain	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D043762	skos:exactMatch	go:GO:0019098	Reproductive Behavior	reproductive behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D044603	skos:exactMatch	go:GO:0043263	Cellulosomes	cellulosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D045524	skos:exactMatch	go:GO:0030089	Phycobilisomes	phycobilisome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D046148	skos:exactMatch	go:GO:0007535	Donor Selection	donor selection	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D048648	skos:exactMatch	go:GO:0031039	Macronucleus	macronucleus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D049229	skos:exactMatch	go:GO:0043197	Dendritic Spines	dendritic spine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D049469	skos:exactMatch	go:GO:0007128	Meiotic Prophase I	meiotic prophase I	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D046249	skos:exactMatch	go:GO:0043039	Transfer RNA Aminoacylation	tRNA aminoacylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D050356	skos:exactMatch	go:GO:0006629	Lipid Metabolism	lipid metabolic process	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053478	skos:exactMatch	go:GO:0043293	Apoptosomes	apoptosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054262	skos:exactMatch	go:GO:0007369	Gastrulation	gastrulation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054337	skos:exactMatch	go:GO:0043697	Cell Dedifferentiation	cell dedifferentiation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054468	skos:exactMatch	go:GO:0005930	Axoneme	axoneme	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054657	skos:exactMatch	go:GO:0044391	Ribosome Subunits	ribosomal subunit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054658	skos:exactMatch	go:GO:0015934	Ribosome Subunits, Large	large ribosomal subunit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054679	skos:exactMatch	go:GO:0015935	Ribosome Subunits, Small	small ribosomal subunit	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054817	skos:exactMatch	go:GO:0009856	Pollination	pollination	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054974	skos:exactMatch	go:GO:0043034	Costameres	costamere	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054992	skos:exactMatch	go:GO:0001772	Immunological Synapses	immunological synapse	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D057897	skos:exactMatch	go:GO:0060013	Reflex, Righting	righting reflex	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D057900	skos:exactMatch	go:GO:0045056	Transcytosis	transcytosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D057907	skos:exactMatch	go:GO:0014069	Post-Synaptic Density	postsynaptic density	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D058767	skos:exactMatch	go:GO:0043335	Protein Unfolding	protein unfolding	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D058849	skos:exactMatch	go:GO:0042026	Protein Refolding	protein refolding	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D058894	skos:exactMatch	go:GO:0042151	Nematocyst	nematocyst	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059007	skos:exactMatch	go:GO:0005700	Polytene Chromosomes	polytene chromosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D060049	skos:exactMatch	go:GO:0008356	Asymmetric Cell Division	asymmetric cell division	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D060449	skos:exactMatch	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D065608	skos:exactMatch	go:GO:0070293	Renal Reabsorption	renal absorption	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000067128	skos:exactMatch	go:GO:1903561	Extracellular Vesicles	extracellular vesicle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069292	skos:exactMatch	go:GO:0070269	Pyroptosis	pyroptosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071182	skos:exactMatch	go:GO:0005776	Autophagosomes	autophagosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000705	skos:exactMatch	go:GO:0051322	Anaphase	anaphase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001329	skos:exactMatch	go:GO:0001896	Autolysis	autolysis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001343	skos:exactMatch	go:GO:0006914	Autophagy	autophagy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001485	skos:exactMatch	go:GO:0005604	Basement Membrane	basement membrane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001519	skos:exactMatch	go:GO:0007610	Behavior	behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001775	skos:exactMatch	go:GO:0008015	Blood Circulation	blood circulation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002454	skos:exactMatch	go:GO:0030154	Cell Differentiation	cell differentiation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002462	skos:exactMatch	go:GO:0005886	Cell Membrane	plasma membrane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002479	skos:exactMatch	go:GO:0016234	Inclusion Bodies	inclusion body	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002502	skos:exactMatch	go:GO:0005814	Centrioles	centriole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002633	skos:exactMatch	go:GO:0006935	Chemotaxis	chemotaxis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002736	skos:exactMatch	go:GO:0009507	Chloroplasts	chloroplast	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002823	skos:exactMatch	go:GO:0042600	Chorion	chorion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002843	skos:exactMatch	go:GO:0000785	Chromatin	chromatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002875	skos:exactMatch	go:GO:0005694	Chromosomes	chromosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002940	skos:exactMatch	go:GO:0007623	Circadian Rhythm	circadian rhythm	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003071	skos:exactMatch	go:GO:0050890	Cognition	cognition	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003167	skos:exactMatch	go:GO:0006956	Complement Activation	complement activation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003593	skos:exactMatch	go:GO:0005737	Cytoplasm	cytoplasm	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003599	skos:exactMatch	go:GO:0005856	Cytoskeleton	cytoskeleton	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003600	skos:exactMatch	go:GO:0005829	Cytosol	cytosol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003672	skos:exactMatch	go:GO:0030421	Defecation	defecation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003712	skos:exactMatch	go:GO:0030425	Dendrites	dendrite	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003896	skos:exactMatch	go:GO:0030057	Desmosomes	desmosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004260	skos:exactMatch	go:GO:0006281	DNA Repair	DNA repair	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004261	skos:exactMatch	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004721	skos:exactMatch	go:GO:0005783	Endoplasmic Reticulum	endoplasmic reticulum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005089	skos:exactMatch	go:GO:0006887	Exocytosis	exocytosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005109	skos:exactMatch	go:GO:0031012	Extracellular Matrix	extracellular matrix	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005110	skos:exactMatch	go:GO:0005615	Extracellular Space	extracellular space	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005285	skos:exactMatch	go:GO:0006113	Fermentation	fermentation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005306	skos:exactMatch	go:GO:0009566	Fertilization	fertilization	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005943	skos:exactMatch	go:GO:0006094	Gluconeogenesis	gluconeogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D006019	skos:exactMatch	go:GO:0006096	Glycolysis	glycolytic process	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D006056	skos:exactMatch	go:GO:0005794	Golgi Apparatus	Golgi apparatus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D006487	skos:exactMatch	go:GO:0007599	Hemostasis	hemostasis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D006570	skos:exactMatch	go:GO:0000792	Heterochromatin	heterochromatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D006967	skos:exactMatch	go:GO:0002524	Hypersensitivity	hypersensitivity	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007249	skos:exactMatch	go:GO:0006954	Inflammation	inflammatory response	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007399	skos:exactMatch	go:GO:0051325	Interphase	interphase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007858	skos:exactMatch	go:GO:0007612	Learning	learning	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008213	skos:exactMatch	go:GO:0046649	Lymphocyte Activation	lymphocyte activation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008409	skos:exactMatch	go:GO:0071626	Mastication	mastication	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008572	skos:exactMatch	go:GO:0042696	Menarche	menarche	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008593	skos:exactMatch	go:GO:0042697	Menopause	menopause	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008597	skos:exactMatch	go:GO:0044850	Menstrual Cycle	menstrual cycle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008598	skos:exactMatch	go:GO:0042703	Menstruation	menstruation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008660	skos:exactMatch	go:GO:0008152	Metabolism	metabolic process	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008677	skos:exactMatch	go:GO:0051323	Metaphase	metaphase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008830	skos:exactMatch	go:GO:0042579	Microbodies	microbody	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008841	skos:exactMatch	go:GO:0015629	Actin Cytoskeleton	actin cytoskeleton	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008870	skos:exactMatch	go:GO:0005874	Microtubules	microtubule	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008928	skos:exactMatch	go:GO:0005739	Mitochondria	mitochondrion	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009119	skos:exactMatch	go:GO:0006936	Muscle Contraction	muscle contraction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009186	skos:exactMatch	go:GO:0043209	Myelin Sheath	myelin sheath	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009336	skos:exactMatch	go:GO:0070265	Necrosis	necrotic cell death	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009685	skos:exactMatch	go:GO:0005635	Nuclear Envelope	nuclear envelope	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009707	skos:exactMatch	go:GO:0000786	Nucleosomes	nucleosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009805	skos:exactMatch	go:GO:0042476	Odontogenesis	odontogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009866	skos:exactMatch	go:GO:0048477	Oogenesis	oogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010060	skos:exactMatch	go:GO:0030728	Ovulation	ovulation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010085	skos:exactMatch	go:GO:0006119	Oxidative Phosphorylation	oxidative phosphorylation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010528	skos:exactMatch	go:GO:0030432	Peristalsis	peristalsis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010587	skos:exactMatch	go:GO:0006909	Phagocytosis	phagocytosis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010788	skos:exactMatch	go:GO:0015979	Photosynthesis	photosynthesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010858	skos:exactMatch	go:GO:0043473	Pigmentation	pigmentation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011235	skos:exactMatch	go:GO:0002120	Predatory Behavior	predatory behavior	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011418	skos:exactMatch	go:GO:0051324	Prophase	prophase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011992	skos:exactMatch	go:GO:0005768	Endosomes	endosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012038	skos:exactMatch	go:GO:0031099	Regeneration	regeneration	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012098	skos:exactMatch	go:GO:0000003	Reproduction	reproduction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012100	skos:exactMatch	go:GO:0019954	Reproduction, Asexual	asexual reproduction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012326	skos:exactMatch	go:GO:0008380	RNA Splicing	RNA splicing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012508	skos:exactMatch	go:GO:0042383	Sarcolemma	sarcolemma	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012518	skos:exactMatch	go:GO:0030017	Sarcomeres	sarcomere	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012519	skos:exactMatch	go:GO:0016529	Sarcoplasmic Reticulum	sarcoplasmic reticulum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D012730	skos:exactMatch	go:GO:0000803	Sex Chromosomes	sex chromosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013081	skos:exactMatch	go:GO:0097722	Sperm Motility	sperm motility	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013091	skos:exactMatch	go:GO:0007283	Spermatogenesis	spermatogenesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013550	skos:exactMatch	go:GO:0036268	Swimming	swimming	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013569	skos:exactMatch	go:GO:0045202	Synapses	synapse	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013692	skos:exactMatch	go:GO:0051326	Telophase	telophase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014078	skos:exactMatch	go:GO:0044691	Tooth Eruption	tooth eruption	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014617	skos:exactMatch	go:GO:0005773	Vacuoles	vacuole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014664	skos:exactMatch	go:GO:0042311	Vasodilation	vasodilation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014796	skos:exactMatch	go:GO:0007601	Visual Perception	visual perception	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014945	skos:exactMatch	go:GO:0042060	Wound Healing	wound healing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014960	skos:exactMatch	go:GO:0000805	X Chromosome	X chromosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014998	skos:exactMatch	go:GO:0000806	Y Chromosome	Y chromosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015388	skos:exactMatch	go:GO:0043226	Organelles	organelle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015398	skos:exactMatch	go:GO:0007165	Signal Transduction	signal transduction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015530	skos:exactMatch	go:GO:0016363	Nuclear Matrix	nuclear matrix	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015539	skos:exactMatch	go:GO:0030168	Platelet Activation	platelet activation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016193	skos:exactMatch	go:GO:0051318	G1 Phase	G1 phase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016196	skos:exactMatch	go:GO:0051320	S Phase	S phase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016723	skos:exactMatch	go:GO:0046849	Bone Remodeling	bone remodeling	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016897	skos:exactMatch	go:GO:0045730	Respiratory Burst	respiratory burst	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D016922	skos:exactMatch	go:GO:0090398	Cellular Senescence	cellular senescence	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017209	skos:exactMatch	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017510	skos:exactMatch	go:GO:0006457	Protein Folding	protein folding	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017629	skos:exactMatch	go:GO:0005921	Gap Junctions	gap junction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018375	skos:exactMatch	go:GO:0042119	Neutrophil Activation	neutrophil activation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018385	skos:exactMatch	go:GO:0005813	Centrosome	centrosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018392	skos:exactMatch	go:GO:0071514	Genomic Imprinting	genetic imprinting	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018699	skos:exactMatch	go:GO:0030135	Coated Vesicles	coated vesicle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018870	skos:exactMatch	go:GO:0005791	Endoplasmic Reticulum, Rough	rough endoplasmic reticulum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D018871	skos:exactMatch	go:GO:0005790	Endoplasmic Reticulum, Smooth	smooth endoplasmic reticulum	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019069	skos:exactMatch	go:GO:0045333	Cell Respiration	cellular respiration	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019108	skos:exactMatch	go:GO:0070160	Tight Junctions	tight junction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019154	skos:exactMatch	go:GO:0030908	Protein Splicing	protein splicing	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019276	skos:exactMatch	go:GO:0030112	Glycocalyx	glycocalyx	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019457	skos:exactMatch	go:GO:0031052	Chromosome Breakage	chromosome breakage	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020090	skos:exactMatch	go:GO:0007059	Chromosome Segregation	chromosome segregation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020894	skos:exactMatch	go:GO:0001527	Microfibrils	microfibril	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D021941	skos:exactMatch	go:GO:0005901	Caveolae	caveola	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022002	skos:exactMatch	go:GO:0030056	Hemidesmosomes	hemidesmosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022005	skos:exactMatch	go:GO:0005912	Adherens Junctions	adherens junction	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022022	skos:exactMatch	go:GO:0005643	Nuclear Pore	nuclear pore	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022041	skos:exactMatch	go:GO:0000791	Euchromatin	euchromatin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022161	skos:exactMatch	go:GO:0030133	Transport Vesicles	transport vesicle	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D023102	skos:exactMatch	go:GO:0043276	Anoikis	anoikis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D034443	skos:exactMatch	go:GO:0050658	RNA Transport	RNA transport	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D034622	skos:exactMatch	go:GO:0016246	RNA Interference	RNA interference	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D034881	skos:exactMatch	go:GO:0005652	Nuclear Lamina	nuclear lamina	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D036801	skos:exactMatch	go:GO:0007567	Parturition	parturition	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D048348	skos:exactMatch	go:GO:0001171	Reverse Transcription	reverse transcription	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D048749	skos:exactMatch	go:GO:0000910	Cytokinesis	cytokinesis	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D049109	skos:exactMatch	go:GO:0008283	Cell Proliferation	cell population proliferation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051336	skos:exactMatch	go:GO:0031966	Mitochondrial Membranes	mitochondrial membrane	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059447	skos:exactMatch	go:GO:0000075	Cell Cycle Checkpoints	cell cycle checkpoint	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059547	skos:exactMatch	go:GO:0032420	Stereocilia	stereocilium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D060152	skos:exactMatch	go:GO:0033151	V(D)J Recombination	V(D)J recombination	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007382	skos:exactMatch	go:GO:0005882	Intermediate Filaments	intermediate filament	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008871	skos:exactMatch	go:GO:0005902	Microvilli	microvillus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055944	skos:exactMatch	go:GO:0110143	Magnetosomes	magnetosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D057646	skos:exactMatch	go:GO:0019061	Virus Uncoating	uncoating of virus	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D057465	skos:exactMatch	go:GO:0061984	Catabolite Repression	catabolite repression	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055212	skos:exactMatch	go:GO:0032391	Photoreceptor Connecting Cilium	photoreceptor connecting cilium	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000069396	skos:exactMatch	go:GO:0005761	Mitochondrial Ribosomes	mitochondrial ribosome	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000071040	skos:exactMatch	go:GO:0043194	Axon Initial Segment	axon initial segment	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000080642	skos:exactMatch	go:GO:0061684	Chaperone-Mediated Autophagy	chaperone-mediated autophagy	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000081363	skos:exactMatch	go:GO:0039679	Occlusion Bodies, Viral	viral occlusion body	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001846	skos:exactMatch	go:GO:0060348	Bone Development	bone development	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001861	skos:exactMatch	go:GO:1990523	Bone Regeneration	bone regeneration	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001862	skos:exactMatch	go:GO:0045453	Bone Resorption	bone resorption	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000873	skos:exactMatch	chebi:CHEBI:46955	Anthracenes	anthracenes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001381	skos:exactMatch	chebi:CHEBI:48105	Azepines	azepine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001218	skos:exactMatch	chebi:CHEBI:2877	Aspartame	aspartame	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001507	skos:exactMatch	chebi:CHEBI:3001	Beclomethasone	beclomethasone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001539	skos:exactMatch	chebi:CHEBI:3013	Bendroflumethiazide	bendroflumethiazide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001542	skos:exactMatch	chebi:CHEBI:3015	Benomyl	benomyl	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001547	skos:exactMatch	chebi:CHEBI:22698	Benzaldehydes	benzaldehydes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001549	skos:exactMatch	chebi:CHEBI:22702	Benzamides	benzamides	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001552	skos:exactMatch	chebi:CHEBI:35676	Benzazepines	benzazepine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001553	skos:exactMatch	chebi:CHEBI:3023	Benzbromarone	benzbromarone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001557	skos:exactMatch	chebi:CHEBI:53348	Benzenesulfonates	benzenesulfonates	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001562	skos:exactMatch	chebi:CHEBI:22715	Benzimidazoles	benzimidazoles	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001564	skos:exactMatch	chebi:CHEBI:29865	Benzo(a)pyrene	benzo[a]pyrene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001569	skos:exactMatch	chebi:CHEBI:22720	Benzodiazepines	benzodiazepine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001581	skos:exactMatch	chebi:CHEBI:50265	Benzothiadiazines	benzothiadiazine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001590	skos:exactMatch	chebi:CHEBI:3048	Benztropine	benzatropine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001592	skos:exactMatch	chebi:CHEBI:22743	Benzyl Alcohols	benzyl alcohols	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001594	skos:exactMatch	chebi:CHEBI:3056	Benzyl Viologen	Benzyl viologen	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001599	skos:exactMatch	chebi:CHEBI:16118	Berberine	berberine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001600	skos:exactMatch	chebi:CHEBI:22754	Berberine Alkaloids	berberine alkaloid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001640	skos:exactMatch	chebi:CHEBI:3092	Bicuculline	bicuculline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001645	skos:exactMatch	chebi:CHEBI:53662	Biguanides	biguanides	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001708	skos:exactMatch	chebi:CHEBI:15373	Biopterin	biopterin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001710	skos:exactMatch	chebi:CHEBI:15956	Biotin	biotin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001726	skos:exactMatch	chebi:CHEBI:3125	Bisacodyl	Bisacodyl	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001735	skos:exactMatch	chebi:CHEBI:3131	Bithionol	bithionol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001737	skos:exactMatch	chebi:CHEBI:18138	Biuret	biuret	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001839	skos:exactMatch	chebi:CHEBI:80229	Bombesin	Bombesin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001865	skos:exactMatch	chebi:CHEBI:77742	Bongkrekic Acid	bongkrekic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001880	skos:exactMatch	chebi:CHEBI:33589	Boranes	boranes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001881	skos:exactMatch	chebi:CHEBI:22910	Borates	borates	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001888	skos:exactMatch	chebi:CHEBI:59765	Boric Acids	boric acids	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001889	skos:exactMatch	chebi:CHEBI:38270	Borinic Acids	borinic acids	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001897	skos:exactMatch	chebi:CHEBI:38269	Boronic Acids	boronic acids	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001960	skos:exactMatch	chebi:CHEBI:31302	Bromazepam	Bromazepam	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002027	skos:exactMatch	chebi:CHEBI:3210	Bufotenin	bufotenin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002040	skos:exactMatch	chebi:CHEBI:6438	Levobunolol	levobunolol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002045	skos:exactMatch	chebi:CHEBI:3215	Bupivacaine	bupivacaine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002047	skos:exactMatch	chebi:CHEBI:3216	Buprenorphine	buprenorphine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002049	skos:exactMatch	chebi:CHEBI:3221	Burimamide	Burimamide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002065	skos:exactMatch	chebi:CHEBI:3223	Buspirone	buspirone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002074	skos:exactMatch	chebi:CHEBI:22951	Butanones	butanone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002077	skos:exactMatch	chebi:CHEBI:3242	Butorphanol	butorphanol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002092	skos:exactMatch	chebi:CHEBI:41055	Butyrylthiocholine	butyrylthiocholine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002103	skos:exactMatch	chebi:CHEBI:18127	Cadaverine	cadaverine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002104	skos:exactMatch	chebi:CHEBI:22977	Cadmium	cadmium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002110	skos:exactMatch	chebi:CHEBI:27732	Caffeine	caffeine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002164	skos:exactMatch	chebi:CHEBI:36773	Camphor	camphor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002166	skos:exactMatch	chebi:CHEBI:27656	Camptothecin	camptothecin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002174	skos:exactMatch	chebi:CHEBI:354984	Candicidin	candicidin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002186	skos:exactMatch	chebi:CHEBI:67194	Cannabinoids	cannabinoid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002187	skos:exactMatch	chebi:CHEBI:3360	Cannabinol	Cannabinol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002193	skos:exactMatch	chebi:CHEBI:64213	Cantharidin	cantharidin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002211	skos:exactMatch	chebi:CHEBI:3374	Capsaicin	capsaicin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002220	skos:exactMatch	chebi:CHEBI:3387	Carbamazepine	carbamazepine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002129	skos:exactMatch	chebi:CHEBI:60579	Calcium Oxalate	calcium oxalate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002261	skos:exactMatch	chebi:CHEBI:3405	Carboxin	carboxin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002260	skos:exactMatch	chebi:CHEBI:3403	Carboprost	carboprost	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002323	skos:exactMatch	chebi:CHEBI:3414	Carfecillin	carfecillin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002328	skos:exactMatch	chebi:CHEBI:3419	Carisoprodol	carisoprodol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002330	skos:exactMatch	chebi:CHEBI:3423	Carmustine	carmustine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002336	skos:exactMatch	chebi:CHEBI:15727	Carnosine	carnosine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002351	skos:exactMatch	chebi:CHEBI:3435	Carrageenan	carrageenan	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002354	skos:exactMatch	chebi:CHEBI:3437	Carteolol	carteolol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002395	skos:exactMatch	chebi:CHEBI:33567	Catecholamines	catecholamine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002396	skos:exactMatch	chebi:CHEBI:33566	Catechols	catechols	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002412	skos:exactMatch	chebi:CHEBI:36916	Cations	cation	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002433	skos:exactMatch	chebi:CHEBI:3478	Cefaclor	cefaclor	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002438	skos:exactMatch	chebi:CHEBI:3493	Cefoperazone	cefoperazone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002440	skos:exactMatch	chebi:CHEBI:209807	Cefoxitin	cefoxitin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002441	skos:exactMatch	chebi:CHEBI:3507	Cefsulodin	cefsulodin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002444	skos:exactMatch	chebi:CHEBI:3515	Cefuroxime	cefuroxime	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002475	skos:exactMatch	chebi:CHEBI:17057	Cellobiose	cellobiose	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002492	skos:exactMatch	chebi:CHEBI:35488	Central Nervous System Depressants	central nervous system depressant	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002504	skos:exactMatch	chebi:CHEBI:6712	Meclofenoxate	Meclofenoxate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002506	skos:exactMatch	chebi:CHEBI:3534	Cephalexin	cephalexin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002509	skos:exactMatch	chebi:CHEBI:3537	Cephaloridine	cefaloridine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002513	skos:exactMatch	chebi:CHEBI:55429	Cephamycins	cephamycin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002515	skos:exactMatch	chebi:CHEBI:3547	Cephradine	cephradine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002518	skos:exactMatch	chebi:CHEBI:17761	Ceramides	ceramide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002554	skos:exactMatch	chebi:CHEBI:23079	Cerebrosides	cerebroside	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002569	skos:exactMatch	chebi:CHEBI:171741	Cerulenin	cerulenin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002599	skos:exactMatch	chebi:CHEBI:27618	Chalcone	chalcone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002606	skos:exactMatch	chebi:CHEBI:91090	Charcoal	charcoal	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002629	skos:exactMatch	chebi:CHEBI:23092	Chemosterilants	chemosterilant	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002635	skos:exactMatch	chebi:CHEBI:16755	Chenodeoxycholic Acid	chenodeoxycholic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002686	skos:exactMatch	chebi:CHEBI:17029	Chitin	chitin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002698	skos:exactMatch	chebi:CHEBI:81902	Chloralose	Chloralose	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002701	skos:exactMatch	chebi:CHEBI:17698	Chloramphenicol	chloramphenicol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002716	skos:exactMatch	chebi:CHEBI:81850	Chlormequat	chlormequat	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002722	skos:exactMatch	chebi:CHEBI:23132	Chlorobenzenes	chlorobenzenes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002723	skos:exactMatch	chebi:CHEBI:23133	Chlorobenzoates	chlorobenzoate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002733	skos:exactMatch	chebi:CHEBI:23150	Chlorophenols	chlorophenol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002735	skos:exactMatch	chebi:CHEBI:38206	Chlorophyllides	chlorophyllide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002738	skos:exactMatch	chebi:CHEBI:3638	Chloroquine	chloroquine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002743	skos:exactMatch	chebi:CHEBI:3642	Chlorphenesin	chlorphenesin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002746	skos:exactMatch	chebi:CHEBI:3647	Chlorpromazine	chlorpromazine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002748	skos:exactMatch	chebi:CHEBI:34630	Chlorpropham	chlorpropham	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002710	skos:exactMatch	chebi:CHEBI:3614	Chlorhexidine	chlorhexidine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009681	skos:exactMatch	go:GO:0000741	Nuclear Fusion	karyogamy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010588	skos:exactMatch	go:GO:0045335	Phagosomes	phagocytic vesicle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010863	skos:exactMatch	go:GO:0097195	Piloerection	pilomotor reflex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011132	skos:exactMatch	go:GO:0005844	Polyribosomes	polysome	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011768	skos:exactMatch	go:GO:0045254	Pyruvate Dehydrogenase Complex	pyruvate dehydrogenase complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010427	skos:exactMatch	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008893	skos:exactMatch	go:GO:0060156	Milk Ejection	milk ejection reflex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D009411	skos:exactMatch	go:GO:0043679	Nerve Endings	axon terminus	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D008066	skos:exactMatch	go:GO:0016042	Lipolysis	lipid catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D015922	skos:exactMatch	go:GO:0062167	Complement C1q	complement component C1q complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013082	skos:exactMatch	go:GO:0036126	Sperm Tail	sperm flagellum	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017735	skos:exactMatch	go:GO:0019042	Virus Latency	viral latency	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019065	skos:exactMatch	go:GO:0019068	Virus Assembly	virion assembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D019897	skos:exactMatch	go:GO:0042597	Periplasm	periplasmic space	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020219	skos:exactMatch	go:GO:0051216	Chondrogenesis	cartilage development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D020541	skos:exactMatch	go:GO:0015030	Coiled Bodies	Cajal body	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D042583	skos:exactMatch	go:GO:0001946	Lymphangiogenesis	lymphangiogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022001	skos:exactMatch	go:GO:0005925	Focal Adhesions	focal adhesion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D022101	skos:exactMatch	go:GO:0005815	Microtubule-Organizing Center	microtubule organizing center	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D023902	skos:exactMatch	go:GO:0007129	Chromosome Pairing	synapsis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D045346	skos:exactMatch	go:GO:0009512	Cytochrome b6f Complex	cytochrome b6f complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D021982	skos:exactMatch	go:GO:0030055	Cell-Matrix Junctions	cell-substrate junction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D050261	skos:exactMatch	go:GO:0005980	Glycogenolysis	glycogen catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D051738	skos:exactMatch	go:GO:0000808	Origin Recognition Complex	origin recognition complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053038	skos:exactMatch	go:GO:0009372	Quorum Sensing	quorum sensing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053205	skos:exactMatch	go:GO:0090406	Pollen Tube	pollen tube	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053298	skos:exactMatch	go:GO:0034360	Chylomicron Remnants	chylomicron remnant	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C081483	skos:exactMatch	go:GO:0070505	tryphine	pollen coat	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C118437	skos:exactMatch	go:GO:0032021	negative elongation factor	NELF complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000077279	skos:exactMatch	go:GO:0046944	Protein Carbamylation	protein carbamoylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000177	skos:exactMatch	go:GO:0001669	Acrosome	acrosomal vesicle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000917	skos:exactMatch	go:GO:0002377	Antibody Formation	immunoglobulin production	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003214	skos:exactMatch	go:GO:0008306	Conditioning, Classical	associative learning	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005106	skos:exactMatch	go:GO:0035640	Exploratory Behavior	exploration behavior	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005407	skos:exactMatch	go:GO:0005929	Flagella	cilium	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007401	skos:exactMatch	go:GO:0030325	Interrenal Gland	adrenal gland development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D005498	skos:exactMatch	go:GO:0001541	Follicular Phase	ovarian follicle development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000374	skos:exactMatch	go:GO:0002118	Aggression	aggressive behavior	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000920	skos:exactMatch	go:GO:0001788	Antibody-Dependent Cell Cytotoxicity	antibody-dependent cellular cytotoxicity	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D007113	skos:exactMatch	go:GO:0045087	Immunity, Innate	innate immune response	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014074	skos:exactMatch	go:GO:0034505	Tooth Calcification	tooth mineralization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D017201	skos:exactMatch	go:GO:0019076	Virus Shedding	viral release from host cell	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055697	skos:exactMatch	go:GO:0050909	Taste Perception	sensory perception of taste	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D054261	skos:exactMatch	go:GO:0001841	Neurulation	neural tube formation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053444	skos:exactMatch	go:GO:0060080	Inhibitory Postsynaptic Potentials	inhibitory postsynaptic potential	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056245	skos:exactMatch	go:GO:0016581	Mi-2 Nucleosome Remodeling and Deacetylase Complex	NuRD complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056827	skos:exactMatch	go:GO:0036452	Endosomal Sorting Complexes Required for Transport	ESCRT complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D058207	skos:exactMatch	go:GO:0016925	Sumoylation	protein sumoylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D057131	skos:exactMatch	go:GO:0042783	Immune Evasion	evasion of host immune response	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D060746	skos:exactMatch	go:GO:0036503	Endoplasmic Reticulum-Associated Degradation	ERAD pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D063326	skos:exactMatch	go:GO:0000178	Exosome Multienzyme Ribonuclease Complex	exosome (RNase complex)	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064113	skos:exactMatch	go:GO:0099048	CRISPR-Cas Systems	CRISPR-cas system	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064173	skos:exactMatch	go:GO:0005680	Anaphase-Promoting Complex-Cyclosome	anaphase-promoting complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064210	skos:exactMatch	go:GO:0019748	Secondary Metabolism	secondary metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D064527	skos:exactMatch	go:GO:0009647	Etiolation	skotomorphogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D013014	skos:exactMatch	go:GO:0009432	SOS Response (Genetics)	SOS response	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002952	skos:exactMatch	go:GO:0006099	Citric Acid Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D010012	skos:exactMatch	go:GO:0001503	Osteogenesis	ossification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D011499	skos:exactMatch	go:GO:0043687	Protein Processing, Post-Translational	post-translational protein modification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D014554	skos:exactMatch	go:GO:0060073	Urination	micturition	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D048750	skos:exactMatch	go:GO:0000280	Cell Nucleus Division	nuclear division	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D053843	skos:exactMatch	go:GO:0006298	DNA Mismatch Repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C498714	skos:exactMatch	go:GO:0005742	TOM translocase	mitochondrial outer membrane translocase complex	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C048844	skos:exactMatch	efo:0005030	anti-IgG	anti-IgG	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C056900	skos:exactMatch	efo:0003266	neuromedin U	neuromedin U	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D056655	skos:exactMatch	hgnc:2535	Cathepsin H	CTSH	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055312	skos:exactMatch	hgnc:2481	Cystatin A	CSTA	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055313	skos:exactMatch	hgnc:2482	Cystatin B	CSTB	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055316	skos:exactMatch	hgnc:2475	Cystatin C	CST3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D055332	skos:exactMatch	hgnc:2478	Cystatin M	CST6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00030	skos:exactMatch	go:GO:0006098	Pentose phosphate pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00052	skos:exactMatch	go:GO:0006012	Galactose metabolism	galactose metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00061	skos:exactMatch	go:GO:0006633	Fatty acid biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00062	skos:exactMatch	go:GO:0030497	Fatty acid elongation	fatty acid elongation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00071	skos:exactMatch	go:GO:0009062	Fatty acid degradation	fatty acid catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00100	skos:exactMatch	go:GO:0006694	Steroid biosynthesis	steroid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00190	skos:exactMatch	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00195	skos:exactMatch	go:GO:0015979	Photosynthesis	photosynthesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00220	skos:exactMatch	go:GO:0006526	Arginine biosynthesis	arginine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00240	skos:exactMatch	go:GO:0006206	Pyrimidine metabolism	pyrimidine nucleobase metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00254	skos:exactMatch	go:GO:0045122	Aflatoxin biosynthesis	aflatoxin biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00281	skos:exactMatch	go:GO:1903447	Geraniol degradation	geraniol catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00300	skos:exactMatch	go:GO:0009085	Lysine biosynthesis	lysine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00310	skos:exactMatch	go:GO:0006554	Lysine degradation	lysine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00331	skos:exactMatch	go:GO:0033050	Clavulanic acid biosynthesis	clavulanic acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00332	skos:exactMatch	go:GO:1901769	Carbapenem biosynthesis	carbapenem biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00340	skos:exactMatch	go:GO:0006547	Histidine metabolism	histidine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00350	skos:exactMatch	go:GO:0006570	Tyrosine metabolism	tyrosine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00362	skos:exactMatch	go:GO:0043639	Benzoate degradation	benzoate catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00380	skos:exactMatch	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00410	skos:exactMatch	go:GO:0019482	beta-Alanine metabolism	beta-alanine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00460	skos:exactMatch	go:GO:0033052	Cyanoamino acid metabolism	cyanoamino acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00473	skos:exactMatch	go:GO:0046436	D-Alanine metabolism	D-alanine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00480	skos:exactMatch	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00510	skos:exactMatch	go:GO:0006487	N-Glycan biosynthesis	protein N-linked glycosylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00521	skos:exactMatch	go:GO:0019872	Streptomycin biosynthesis	streptomycin biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00531	skos:exactMatch	go:GO:0006027	Glycosaminoglycan degradation	glycosaminoglycan catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00540	skos:exactMatch	go:GO:0009103	Lipopolysaccharide biosynthesis	lipopolysaccharide biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00550	skos:exactMatch	go:GO:0009252	Peptidoglycan biosynthesis	peptidoglycan biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04110	skos:exactMatch	go:GO:0007049	Cell cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04144	skos:exactMatch	go:GO:0006897	Endocytosis	endocytosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00561	skos:exactMatch	go:GO:0046486	Glycerolipid metabolism	glycerolipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00562	skos:exactMatch	go:GO:0043647	Inositol phosphate metabolism	inositol phosphate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00564	skos:exactMatch	go:GO:0006650	Glycerophospholipid metabolism	glycerophospholipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00565	skos:exactMatch	go:GO:0046485	Ether lipid metabolism	ether lipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00590	skos:exactMatch	go:GO:0019369	Arachidonic acid metabolism	arachidonic acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00591	skos:exactMatch	go:GO:0043651	Linoleic acid metabolism	linoleic acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00592	skos:exactMatch	go:GO:0036109	alpha-Linolenic acid metabolism	alpha-linolenic acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00600	skos:exactMatch	go:GO:0006665	Sphingolipid metabolism	sphingolipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00620	skos:exactMatch	go:GO:0006090	Pyruvate metabolism	pyruvate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00622	skos:exactMatch	go:GO:0042184	Xylene degradation	xylene catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00623	skos:exactMatch	go:GO:0042203	Toluene degradation	toluene catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00626	skos:exactMatch	go:GO:1901170	Naphthalene degradation	naphthalene catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00633	skos:exactMatch	go:GO:0046263	Nitrotoluene degradation	nitrotoluene catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00640	skos:exactMatch	go:GO:0019541	Propanoate metabolism	propionate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00643	skos:exactMatch	go:GO:0042207	Styrene degradation	styrene catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00680	skos:exactMatch	go:GO:0015947	Methane metabolism	methane metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00730	skos:exactMatch	go:GO:0006772	Thiamine metabolism	thiamine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00740	skos:exactMatch	go:GO:0006771	Riboflavin metabolism	riboflavin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00750	skos:exactMatch	go:GO:0042816	Vitamin B6 metabolism	vitamin B6 metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00780	skos:exactMatch	go:GO:0006768	Biotin metabolism	biotin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00785	skos:exactMatch	go:GO:0009106	Lipoic acid metabolism	lipoate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00790	skos:exactMatch	go:GO:0046656	Folate biosynthesis	folic acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00791	skos:exactMatch	go:GO:0019381	Atrazine degradation	atrazine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00830	skos:exactMatch	go:GO:0042572	Retinol metabolism	retinol metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00901	skos:exactMatch	go:GO:0035835	Indole alkaloid biosynthesis	indole alkaloid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00902	skos:exactMatch	go:GO:0016099	Monoterpenoid biosynthesis	monoterpenoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00904	skos:exactMatch	go:GO:0016102	Diterpenoid biosynthesis	diterpenoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00905	skos:exactMatch	go:GO:0016132	Brassinosteroid biosynthesis	brassinosteroid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00906	skos:exactMatch	go:GO:0016117	Carotenoid biosynthesis	carotenoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00908	skos:exactMatch	go:GO:0033398	Zeatin biosynthesis	zeatin biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00920	skos:exactMatch	go:GO:0006790	Sulfur metabolism	sulfur compound metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00930	skos:exactMatch	go:GO:0019384	Caprolactam degradation	caprolactam catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00940	skos:exactMatch	go:GO:0009699	Phenylpropanoid biosynthesis	phenylpropanoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00941	skos:exactMatch	go:GO:0009813	Flavonoid biosynthesis	flavonoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00942	skos:exactMatch	go:GO:0009718	Anthocyanin biosynthesis	anthocyanin-containing compound biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00943	skos:exactMatch	go:GO:0009717	Isoflavonoid biosynthesis	isoflavonoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00950	skos:exactMatch	go:GO:0033075	Isoquinoline alkaloid biosynthesis	isoquinoline alkaloid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00966	skos:exactMatch	go:GO:0019761	Glucosinolate biosynthesis	glucosinolate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00984	skos:exactMatch	go:GO:0006706	Steroid degradation	steroid catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map01212	skos:exactMatch	go:GO:0006631	Fatty acid metabolism	fatty acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04920	skos:exactMatch	go:GO:0033210	Adipocytokine signaling pathway	leptin-mediated signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map02024	skos:exactMatch	go:GO:0009372	Quorum sensing	quorum sensing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03030	skos:exactMatch	go:GO:0006260	DNA replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03320	skos:exactMatch	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04071	skos:exactMatch	go:GO:0090520	Sphingolipid signaling pathway	sphingolipid mediated signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04012	skos:exactMatch	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04218	skos:exactMatch	go:GO:0090398	Cellular senescence	cellular senescence	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04917	skos:exactMatch	go:GO:0038161	Prolactin signaling pathway	prolactin signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04310	skos:exactMatch	go:GO:0016055	Wnt signaling pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03440	skos:exactMatch	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04390	skos:exactMatch	go:GO:0035329	Hippo signaling pathway	hippo signaling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04210	skos:exactMatch	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04217	skos:exactMatch	go:GO:0070266	Necroptosis	necroptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04217	skos:exactMatch	mesh:D000079302	Necroptosis	Necroptosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04216	skos:exactMatch	mesh:D000079403	Ferroptosis	Ferroptosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04216	skos:exactMatch	go:GO:0097707	Ferroptosis	ferroptosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00970	skos:exactMatch	go:GO:0043039	Aminoacyl-tRNA biosynthesis	tRNA aminoacylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03013	skos:exactMatch	go:GO:0050658	RNA transport	RNA transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03018	skos:exactMatch	go:GO:0006401	RNA degradation	RNA catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04115	skos:exactMatch	go:GO:0030330	p53 signaling pathway	DNA damage response, signal transduction by p53 class mediator	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04260	skos:exactMatch	go:GO:0060048	Cardiac muscle contraction	cardiac muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04270	skos:exactMatch	go:GO:0014829	Vascular smooth muscle contraction	vascular smooth muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04330	skos:exactMatch	go:GO:0007219	Notch signaling pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04340	skos:exactMatch	go:GO:0007224	Hedgehog signaling pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04360	skos:exactMatch	go:GO:0007411	Axon guidance	axon guidance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04361	skos:exactMatch	go:GO:0031103	Axon regeneration	axon regeneration	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04380	skos:exactMatch	go:GO:0030316	Osteoclast differentiation	osteoclast differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04611	skos:exactMatch	go:GO:0030168	Platelet activation	platelet activation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04612	skos:exactMatch	go:GO:0019882	Antigen processing and presentation	antigen processing and presentation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03430	skos:exactMatch	go:GO:0006298	Mismatch repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04620	skos:exactMatch	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04621	skos:exactMatch	go:GO:0035872	NOD-like receptor signaling pathway	nucleotide-binding domain, leucine rich repeat containing receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04650	skos:exactMatch	go:GO:0042267	Natural killer cell mediated cytotoxicity	natural killer cell mediated cytotoxicity	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04660	skos:exactMatch	go:GO:0050852	T cell receptor signaling pathway	T cell receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04662	skos:exactMatch	go:GO:0050853	B cell receptor signaling pathway	B cell receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04710	skos:exactMatch	go:GO:0007623	Circadian rhythm	circadian rhythm	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04721	skos:exactMatch	go:GO:0099504	Synaptic vesicle cycle	synaptic vesicle cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04722	skos:exactMatch	go:GO:0038179	Neurotrophin signaling pathway	neurotrophin signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04744	skos:exactMatch	go:GO:0007602	Phototransduction	phototransduction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04911	skos:exactMatch	go:GO:0030073	Insulin secretion	insulin secretion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04920	skos:exactMatch	go:GO:0033209	Adipocytokine signaling pathway	tumor necrosis factor-mediated signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04920	skos:exactMatch	go:GO:0033211	Adipocytokine signaling pathway	adiponectin-activated signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04979	skos:exactMatch	go:GO:0008203	Cholesterol metabolism	cholesterol metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04971	skos:exactMatch	go:GO:0001696	Gastric acid secretion	gastric acid secretion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04714	skos:exactMatch	mesh:D022722	Thermogenesis	Thermogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04720	skos:exactMatch	mesh:D017774	Long-term potentiation	Long-Term Potentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP100	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1002	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1009	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1011	speciesSpecific	go:GO:0050852	TCR Signaling Pathway	T cell receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1014	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1016	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1018	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1020	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1023	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1024	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1025	speciesSpecific	go:GO:0050853	B Cell Receptor Signaling Pathway	B cell receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP103	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1032	speciesSpecific	mesh:D000070576	NLR Proteins	NLR Proteins	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1050	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1053	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP999	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP964	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1083	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1290	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1254	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1200	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1539	speciesSpecific	go:GO:0001525	Angiogenesis	angiogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1393	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1351	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP179	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP429	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2862	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4758	speciesSpecific	mesh:D009404	Nephrotic syndrome	Nephrotic Syndrome	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1022	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1026	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1028	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1029	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1034	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1035	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1036	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1044	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1064	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1065	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1067	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1070	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1073	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1075	speciesSpecific	go:GO:0046655	Folate Metabolism	folic acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1086	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1101	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1105	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1119	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1126	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1135	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1142	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1148	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1152	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1153	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1141	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP116	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1186	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1189	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1203	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1204	speciesSpecific	go:GO:0006298	Mismatch Repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1079	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP109	speciesSpecific	go:GO:0006258	UDP-Glucose Conversion	UDP-glucose catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1105	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1105	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1118	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1133	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1205	speciesSpecific	go:GO:0035825	Homologous Recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1217	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1221	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1233	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1240	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1248	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1257	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1258	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1227	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1261	speciesSpecific	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1262	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1263	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1259	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1264	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1270	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1282	speciesSpecific	go:GO:0032259	Methylation	methylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1283	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1292	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1295	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1296	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1297	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1299	speciesSpecific	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP13	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1300	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1301	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1302	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1308	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1309	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1314	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1223	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1229	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP123	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1230	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1231	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1232	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1247	speciesSpecific	go:GO:0032259	Methylation	methylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP125	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1316	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP132	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1331	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1331	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1331	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1335	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1339	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1343	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1345	speciesSpecific	go:GO:0050852	T Cell Receptor Signaling Pathway	T cell receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1348	speciesSpecific	go:GO:0030521	Androgen Receptor Signaling Pathway	androgen receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1349	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1352	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1355	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1366	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1372	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP138	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1383	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1384	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1387	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1388	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP14	speciesSpecific	go:GO:0005986	Sucrose Biosynthesis	sucrose biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP142	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1449	speciesSpecific	go:GO:0034121	Regulation of toll-like receptor signaling pathway	regulation of toll-like receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1453	speciesSpecific	go:GO:0040025	Vulval development	vulval development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP146	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1489	speciesSpecific	go:GO:0031929	TOR signaling	TOR signaling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1495	speciesSpecific	go:GO:0006544	Glycine Metabolism	glycine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP150	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1518	speciesSpecific	go:GO:0006532	Aspartate Biosynthesis	aspartate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1531	speciesSpecific	go:GO:0042359	Vitamin D Metabolism	vitamin D metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1533	speciesSpecific	go:GO:0009235	Vitamin B12 Metabolism	cobalamin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1538	speciesSpecific	go:GO:0009813	Flavonoid Biosynthesis	flavonoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP154	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1541	speciesSpecific	mesh:D004734	Energy Metabolism	Energy Metabolism	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP155	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP155	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP155	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP156	speciesSpecific	go:GO:0006094	Gluconeogenesis	gluconeogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP158	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP160	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1600	speciesSpecific	go:GO:0018933	Nicotine Metabolism	nicotine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP164	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP165	speciesSpecific	go:GO:0000162	Tryptophan Biosynthesis	tryptophan biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP171	speciesSpecific	go:GO:0034355	NAD Salvage Pathway	NAD salvage	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP172	speciesSpecific	go:GO:0042213	m-cresol degradation	m-cresol catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP173	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP175	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP176	speciesSpecific	go:GO:0046655	Folate Metabolism	folic acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1771	speciesSpecific	go:GO:0006657	Kennedy pathway	CDP-choline pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP178	speciesSpecific	go:GO:0006550	Isoleucine Degradation	isoleucine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP18	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP180	speciesSpecific	go:GO:0009098	Leucine Biosynthesis	leucine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP181	speciesSpecific	go:GO:0019334	P-cymene Degradation	p-cymene catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP183	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP186	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP188	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP19	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP192	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP196	speciesSpecific	go:GO:0006750	Glutathione Biosynthesis	glutathione biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2	speciesSpecific	go:GO:0009099	Valine Biosynthesis	valine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP200	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2037	speciesSpecific	go:GO:0038161	Prolactin Signaling Pathway	prolactin signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP159	speciesSpecific	go:GO:0019277	UDP-N-Acetylgalactosamine Biosynthesis	UDP-N-acetylgalactosamine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1591	speciesSpecific	go:GO:0007507	Heart Development	heart development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP1596	speciesSpecific	efo:0005882	Iron Homeostasis	iron ion homeostasis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2067	speciesSpecific	go:GO:0007507	Heart Development	heart development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP208	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP211	speciesSpecific	go:GO:0030509	BMP signaling pathway	BMP signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP214	speciesSpecific	go:GO:0006086	Pyruvate Dehydrogenase Pathway	acetyl-CoA biosynthetic process from pyruvate	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP216	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2224	speciesSpecific	go:GO:1904070	Ascaroside Biosynthesis	ascaroside biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2276	speciesSpecific	go:GO:0010001	Glial Cell Differentiation	glial cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2279	speciesSpecific	go:GO:0048316	Seed Development	seed development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2316	speciesSpecific	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2318	speciesSpecific	go:GO:0019395	Fatty acid oxidation	fatty acid oxidation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP236	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP236	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP236	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP241	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2313	speciesSpecific	mesh:D000375	Aging	Aging	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2313	speciesSpecific	go:GO:0007568	Aging	aging	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP23	speciesSpecific	go:GO:0050853	B Cell Receptor Signaling Pathway	B cell receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP228	speciesSpecific	go:GO:0019692	Deoxyribose phosphate metabolism	deoxyribose phosphate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2436	speciesSpecific	go:GO:0042417	Dopamine metabolism	dopamine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP250	speciesSpecific	go:GO:0009097	Isoleucine Biosynthesis	isoleucine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP251	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP253	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP254	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP261	speciesSpecific	go:GO:0006545	Glycine biosynthesis	glycine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2621	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP844	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP96	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4787	speciesSpecific	go:GO:0001649	Osteoblast differentiation	osteoblast differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2863	speciesSpecific	go:GO:0006099	Krebs cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3184	speciesSpecific	go:GO:0001525	Angiogenesis	angiogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP282	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP295	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2622	speciesSpecific	go:GO:0005982	Starch Metabolism	starch metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP269	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP270	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP275	speciesSpecific	go:GO:0006526	Arginine Biosynthesis	arginine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP281	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2826	speciesSpecific	go:GO:0050783	Cocaine metabolism	cocaine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP266	speciesSpecific	go:GO:0019432	Triglyceride Biosynthesis	triglyceride biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP264	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2623	speciesSpecific	go:GO:0005985	Sucrose Metabolism	sucrose metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP224	speciesSpecific	go:GO:0019564	Aerobic Glycerol Catabolism	aerobic glycerol catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2849	speciesSpecific	go:GO:0060218	Hematopoietic Stem Cell Differentiation	hematopoietic stem cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2872	speciesSpecific	go:GO:0050872	White fat cell differentiation	white fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP29	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP301	speciesSpecific	go:GO:0006569	Tryptophan Degradation	tryptophan catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP302	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP305	speciesSpecific	go:GO:0008211	Glucocorticoid Metabolism	glucocorticoid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP291	speciesSpecific	go:GO:0007530	Sex determination	sex determination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2912	speciesSpecific	go:GO:0014829	Vascular smooth muscle contraction	vascular smooth muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP290	speciesSpecific	go:GO:0006596	Polyamine Biosynthesis	polyamine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP2851	speciesSpecific	go:GO:0009873	Ethylene signaling pathway	ethylene-activated signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP280	speciesSpecific	go:GO:0019415	Carbon monoxide dehydrogenase pathway	acetate biosynthetic process from carbon monoxide	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3256	speciesSpecific	go:GO:0031929	TOR Signaling	TOR signaling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP306	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP310	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3118	speciesSpecific	go:GO:0015844	Monoamine Transport	monoamine transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3119	speciesSpecific	go:GO:0006974	DNA Damage Response	cellular response to DNA damage stimulus	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP312	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3132	speciesSpecific	go:GO:0034121	Regulation of toll-like receptor signaling pathway	regulation of toll-like receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3134	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3142	speciesSpecific	go:GO:0006544	Glycine Metabolism	glycine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3155	speciesSpecific	go:GO:0042417	Dopamine metabolism	dopamine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3162	speciesSpecific	go:GO:0042359	Vitamin D Metabolism	vitamin D metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3168	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3203	speciesSpecific	go:GO:0010001	Glial Cell Differentiation	glial cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3185	speciesSpecific	go:GO:0018933	Nicotine Metabolism	nicotine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP316	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3193	speciesSpecific	go:GO:0009235	Vitamin B12 Metabolism	cobalamin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3194	speciesSpecific	go:GO:0032933	SREBP signalling	SREBP signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP987	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP994	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP987	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP987	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP983	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP977	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3197	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3211	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP323	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3232	speciesSpecific	go:GO:0006665	Sphingolipid Metabolism	sphingolipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3247	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3248	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP328	speciesSpecific	go:GO:0000256	Allantoin Degradation	allantoin catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3280	speciesSpecific	go:GO:0007507	Heart Development	heart development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP331	speciesSpecific	go:GO:0009088	Threonine Biosynthesis	threonine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP336	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP341	speciesSpecific	go:GO:0038092	Nodal Signaling Pathway	nodal signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP345	speciesSpecific	go:GO:0006546	Glycine Degradation	glycine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP367	speciesSpecific	go:GO:0012501	Programmed Cell Death	programmed cell death	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP347	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP354	speciesSpecific	go:GO:0006552	Leucine Degradation	leucine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP357	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP360	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP369	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP370	speciesSpecific	go:GO:0006665	Sphingolipid Metabolism	sphingolipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP376	speciesSpecific	mesh:D012084	Renin - Angiotensin System	Renin-Angiotensin System	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP38	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3891	speciesSpecific	go:GO:0018910	Benzene metabolism	benzene metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP390	speciesSpecific	go:GO:0019496	Serine-isocitrate lyase pathway	serine-isocitrate lyase pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP3942	speciesSpecific	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP398	speciesSpecific	go:GO:0005992	Trehalose Anabolism	trehalose biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4020	speciesSpecific	go:GO:0035357	PPAR Signaling Pathway	peroxisome proliferator activated receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4022	speciesSpecific	go:GO:0006206	Pyrimidine metabolism	pyrimidine nucleobase metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP403	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP404	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP408	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP411	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP412	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4149	speciesSpecific	go:GO:0050872	White fat cell differentiation	white fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP421	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP422	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4249	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4313	speciesSpecific	mesh:D000079403	Ferroptosis	Ferroptosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4313	speciesSpecific	go:GO:0097707	Ferroptosis	ferroptosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP432	speciesSpecific	go:GO:0006530	Asparagine degradation	asparagine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4321	speciesSpecific	mesh:D022722	Thermogenesis	Thermogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP434	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP435	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP436	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP446	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4506	speciesSpecific	go:GO:0006570	Tyrosine Metabolism	tyrosine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP451	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP46	speciesSpecific	go:GO:0009087	Methionine Degradation	methionine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP461	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP463	speciesSpecific	go:GO:0019653	Purine Fermentation	anaerobic purine nucleobase catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP465	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP466	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP467	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP469	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP470	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP474	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP476	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP478	speciesSpecific	go:GO:0005980	Glycogen Catabolism	glycogen catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP4784	speciesSpecific	go:GO:0030166	Proteoglycan biosynthesis	proteoglycan biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP484	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP490	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP492	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP496	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP504	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP513	speciesSpecific	go:GO:0042423	Catecholamine synthesis	catecholamine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP514	speciesSpecific	go:GO:0000105	Histidine Biosynthesis	histidine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP517	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP519	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP522	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP528	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP529	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP533	speciesSpecific	go:GO:0009085	Lysine Biosynthesis	lysine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP538	speciesSpecific	go:GO:0006571	Tyrosine Biosynthesis	tyrosine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP54	speciesSpecific	go:GO:0006527	Arginine degradation	arginine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP542	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP545	speciesSpecific	go:GO:0006956	Complement Activation	complement activation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP55	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP550	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP551	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP561	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP564	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP565	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP568	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP574	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP575	speciesSpecific	go:GO:0009061	Anaerobic respiration	anaerobic respiration	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP59	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP60	speciesSpecific	go:GO:0042203	Toluene degradation	toluene catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP618	speciesSpecific	go:GO:0009908	Flower Development	flower development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP623	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP626	speciesSpecific	go:GO:0009688	Abscisic Acid Biosynthesis	abscisic acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP627	speciesSpecific	go:GO:0019432	Triacylglycerol Biosynthesis	triglyceride biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP63	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP632	speciesSpecific	go:GO:0008203	Cholesterol metabolism	cholesterol metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP66	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP661	speciesSpecific	go:GO:0042593	Glucose Homeostasis	glucose homeostasis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP67	speciesSpecific	go:GO:0006529	Asparagine Biosynthesis	asparagine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP673	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP697	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP699	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP7	speciesSpecific	go:GO:0000097	Sulfur Amino Acid biosynthesis	sulfur amino acid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP707	speciesSpecific	go:GO:0006974	DNA Damage Response	cellular response to DNA damage stimulus	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP727	speciesSpecific	go:GO:0015844	Monoamine Transport	monoamine transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP75	speciesSpecific	go:GO:0002224	Toll-like Receptor Signaling Pathway	toll-like receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP757	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP76	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP77	speciesSpecific	go:GO:0006537	Glutamate biosynthesis	glutamate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP785	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP787	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP79	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP790	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP793	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP796	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP798	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP802	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP804	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP805	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP81	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP833	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP835	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP84	speciesSpecific	go:GO:0009435	NAD Biosynthesis	NAD biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP848	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP85	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP86	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP865	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP869	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP869	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP869	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP87	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP897	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP899	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP9	speciesSpecific	go:GO:0008654	Phospholipid Biosynthesis	phospholipid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP905	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP906	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP909	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP91	speciesSpecific	go:GO:0019395	Fatty acid oxidation	fatty acid oxidation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP912	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP917	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP925	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP952	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP955	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP967	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP969	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP97	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+wikipathways:WP391	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-109581	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-109582	speciesSpecific	go:GO:0007599	Hemostasis	hemostasis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-109704	speciesSpecific	go:GO:0014065	PI3K Cascade	phosphatidylinositol 3-kinase signaling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-114608	speciesSpecific	go:GO:0002576	Platelet degranulation	platelet degranulation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-1187000	speciesSpecific	go:GO:0009566	Fertilization	fertilization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-1234174	speciesSpecific	go:GO:0071456	Cellular response to hypoxia	cellular response to hypoxia	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-189451	speciesSpecific	go:GO:0006783	Heme biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-157579	speciesSpecific	go:GO:0000723	Telomere Maintenance	telomere maintenance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-196807	speciesSpecific	go:GO:1901847	Nicotinate metabolism	nicotinate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-196783	speciesSpecific	go:GO:0015937	Coenzyme A biosynthesis	coenzyme A biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-BTA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-CEL-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-CFA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-DDI-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-DME-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-DRE-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-GGA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-MMU-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-PFA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-RNO-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-SCE-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-SPO-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-SSC-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-XTR-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9646399	speciesSpecific	go:GO:0035973	Aggrephagy	aggrephagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-109581	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-351143	speciesSpecific	go:GO:0097055	Agmatine biosynthesis	agmatine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8964540	speciesSpecific	go:GO:0006522	Alanine metabolism	alanine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-193048	speciesSpecific	go:GO:0006702	Androgen biosynthesis	androgen biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9612973	speciesSpecific	go:GO:0006914	Autophagy	autophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-422475	speciesSpecific	go:GO:0007411	Axon guidance	axon guidance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73929	speciesSpecific	go:GO:0006285	Base-Excision Repair, AP Site Formation	base-excision repair, AP site formation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5576891	speciesSpecific	go:GO:0061337	Cardiac conduction	cardiac conduction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-200425	speciesSpecific	go:GO:0009437	Carnitine metabolism	carnitine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-71262	speciesSpecific	go:GO:0045329	Carnitine synthesis	carnitine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-209905	speciesSpecific	go:GO:0042423	Catecholamine biosynthesis	catecholamine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1640170	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-69620	speciesSpecific	go:GO:0000075	Cell Cycle Checkpoints	cell cycle checkpoint	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-446728	speciesSpecific	go:GO:0034330	Cell junction organization	cell junction organization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1222541	speciesSpecific	go:GO:0045454	Cell redox homeostasis	cell redox homeostasis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-421270	speciesSpecific	go:GO:0045216	Cell-cell junction organization	cell-cell junction organization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2559583	speciesSpecific	go:GO:0090398	Cellular Senescence	cellular senescence	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-3371556	speciesSpecific	go:GO:0034605	Cellular response to heat stress	cellular response to heat	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1234174	speciesSpecific	go:GO:0071456	Cellular response to hypoxia	cellular response to hypoxia	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9613829	speciesSpecific	mesh:D000080642	Chaperone Mediated Autophagy	Chaperone-Mediated Autophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-191273	speciesSpecific	go:GO:0006695	Cholesterol biosynthesis	cholesterol biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-6807047	speciesSpecific	go:GO:0033489	Cholesterol biosynthesis via desmosterol	cholesterol biosynthetic process via desmosterol	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-6798163	speciesSpecific	go:GO:0042426	Choline catabolism	choline catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2142753	speciesSpecific	go:GO:0019369	Arachidonic acid metabolism	arachidonic acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5620912	speciesSpecific	go:GO:0097711	Anchoring of the basal body to the plasma membrane	ciliary basal body-plasma membrane docking	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5617833	speciesSpecific	go:GO:0060271	Cilium Assembly	cilium assembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8963901	speciesSpecific	go:GO:0034371	Chylomicron remodeling	chylomicron remodeling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8963888	speciesSpecific	go:GO:0034378	Chylomicron assembly	chylomicron assembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-156582	speciesSpecific	mesh:D000107	Acetylation	Acetylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-6807062	speciesSpecific	go:GO:0033490	Cholesterol biosynthesis via lathosterol	cholesterol biosynthetic process via lathosterol	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2022870	speciesSpecific	go:GO:0030206	Chondroitin sulfate biosynthesis	chondroitin sulfate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-4839726	speciesSpecific	go:GO:0006325	Chromatin organization	chromatin organization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-400253	speciesSpecific	mesh:D057906	Circadian Clock	Circadian Clocks	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8856828	speciesSpecific	go:GO:0072583	Clathrin-mediated endocytosis	clathrin-dependent endocytosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-196783	speciesSpecific	go:GO:0015937	Coenzyme A biosynthesis	coenzyme A biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1442490	speciesSpecific	go:GO:0030574	Collagen degradation	collagen catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1474290	speciesSpecific	go:GO:0032964	Collagen formation	collagen biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-166658	speciesSpecific	go:GO:0006956	Complement cascade	complement activation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-71288	speciesSpecific	go:GO:0006600	Creatine metabolism	creatine metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8949613	speciesSpecific	go:GO:0042407	Cristae formation	cristae formation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73894	speciesSpecific	go:GO:0006281	DNA Repair	DNA repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-69306	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5334118	speciesSpecific	go:GO:0006306	DNA methylation	DNA methylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-68952	speciesSpecific	go:GO:0006270	DNA replication initiation	DNA replication initiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-69190	speciesSpecific	go:GO:0022616	DNA strand elongation	DNA strand elongation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-429914	speciesSpecific	go:GO:0000288	Deadenylation-dependent mRNA decay	nuclear-transcribed mRNA catabolic process, deadenylation-dependent decay	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73927	speciesSpecific	go:GO:0045007	Depurination	depurination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73928	speciesSpecific	go:GO:0045008	Depyrimidination	depyrimidination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2022923	speciesSpecific	go:GO:0030208	Dermatan sulfate biosynthesis	dermatan sulfate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5688426	speciesSpecific	go:GO:0016579	Deubiquitination	protein deubiquitination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8935690	speciesSpecific	go:GO:0007586	Digestion	digestion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2468052	speciesSpecific	go:GO:0034085	Establishment of Sister Chromatid Cohesion	establishment of sister chromatid cohesion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-193144	speciesSpecific	go:GO:0006703	Estrogen biosynthesis	estrogen biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-71384	speciesSpecific	go:GO:0006069	Ethanol oxidation	ethanol oxidation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1474244	speciesSpecific	go:GO:0030198	Extracellular matrix organization	extracellular matrix organization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8978868	speciesSpecific	go:GO:0006631	Fatty acid metabolism	fatty acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1187000	speciesSpecific	go:GO:0009566	Fertilization	fertilization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5652227	speciesSpecific	go:GO:0046370	Fructose biosynthesis	fructose biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70350	speciesSpecific	go:GO:0006001	Fructose catabolism	fructose catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5652084	speciesSpecific	go:GO:0006000	Fructose metabolism	fructose metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-69236	speciesSpecific	go:GO:0051318	G1 Phase	G1 phase	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-69615	speciesSpecific	go:GO:0044783	G1/S DNA Damage Checkpoints	G1 DNA damage checkpoint	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-68911	speciesSpecific	go:GO:0051319	G2 Phase	G2 phase	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70370	speciesSpecific	go:GO:0019388	Galactose catabolism	galactose catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-190861	speciesSpecific	go:GO:0016264	Gap junction assembly	gap junction assembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-211000	speciesSpecific	go:GO:0031047	Gene Silencing by RNA	gene silencing by RNA	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70171	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-189483	speciesSpecific	go:GO:0042167	Heme degradation	heme catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-3322077	speciesSpecific	go:GO:0005978	Glycogen synthesis	glycogen biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-194002	speciesSpecific	go:GO:0006704	Glucocorticoid biosynthesis	glucocorticoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70263	speciesSpecific	go:GO:0006094	Gluconeogenesis	gluconeogenesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70326	speciesSpecific	go:GO:0006006	Glucose metabolism	glucose metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1483206	speciesSpecific	go:GO:0046474	Glycerophospholipid biosynthesis	glycerophospholipid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-6814848	speciesSpecific	go:GO:0046475	Glycerophospholipid catabolism	glycerophospholipid catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-6783984	speciesSpecific	go:GO:0006546	Glycine degradation	glycine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8982491	speciesSpecific	go:GO:0005977	Glycogen metabolism	glycogen metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1630316	speciesSpecific	go:GO:0030203	Glycosaminoglycan metabolism	glycosaminoglycan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1660662	speciesSpecific	go:GO:0006687	Glycosphingolipid metabolism	glycosphingolipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8963896	speciesSpecific	go:GO:0034380	HDL assembly	high-density lipoprotein particle assembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8964011	speciesSpecific	go:GO:0034384	HDL clearance	high-density lipoprotein particle clearance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8964058	speciesSpecific	go:GO:0034375	HDL remodeling	high-density lipoprotein particle remodeling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-189451	speciesSpecific	go:GO:0006783	Heme biosynthesis	heme biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-109582	speciesSpecific	go:GO:0007599	Hemostasis	hemostasis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70921	speciesSpecific	go:GO:0006548	Histidine catabolism	histidine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2142845	speciesSpecific	go:GO:0030212	Hyaluronan metabolism	hyaluronan metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-168256	speciesSpecific	mesh:D007107	Immune System	Immune System	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1483249	speciesSpecific	go:GO:0043647	Inositol phosphate metabolism	inositol phosphate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-264876	speciesSpecific	go:GO:0030070	Insulin processing	insulin processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-77387	speciesSpecific	go:GO:0038020	Insulin receptor recycling	insulin receptor recycling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8963676	speciesSpecific	go:GO:0050892	Intestinal absorption	intestinal absorption	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8981373	speciesSpecific	go:GO:0106001	Intestinal hexose absorption	intestinal hexose absorption	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8963678	speciesSpecific	go:GO:0098856	Intestinal lipid absorption	intestinal lipid absorption	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5620924	speciesSpecific	go:GO:0042073	Intraflagellar transport	intraciliary transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5578775	speciesSpecific	go:GO:0050801	Ion homeostasis	ion homeostasis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2022854	speciesSpecific	go:GO:0018146	Keratan sulfate biosynthesis	keratan sulfate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2022857	speciesSpecific	go:GO:0042340	Keratan sulfate degradation	keratan sulfate catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-6805567	speciesSpecific	go:GO:0031424	Keratinization	keratinization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-74182	speciesSpecific	go:GO:1902224	Ketone body metabolism	ketone body metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8964038	speciesSpecific	go:GO:0034383	LDL clearance	low-density lipoprotein particle clearance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8964041	speciesSpecific	go:GO:0034374	LDL remodeling	low-density lipoprotein particle remodeling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5653890	speciesSpecific	go:GO:0005989	Lactose synthesis	lactose biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9615710	speciesSpecific	go:GO:0061738	Late endosomal microautophagy	late endosomal microautophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8964572	speciesSpecific	go:GO:0034389	Lipid particle organization	lipid droplet organization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9613354	speciesSpecific	go:GO:0061724	Lipophagy	lipophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9620244	speciesSpecific	mesh:D017774	Long-term potentiation	Long-Term Potentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-71064	speciesSpecific	go:GO:0006554	Lysine catabolism	lysine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-68886	speciesSpecific	go:GO:0000279	M Phase	M phase	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1632852	speciesSpecific	mesh:D000080550	Macroautophagy	Macroautophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1632852	speciesSpecific	go:GO:0016236	Macroautophagy	macroautophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1500620	speciesSpecific	mesh:D008540	Meiosis	Meiosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1500620	speciesSpecific	go:GO:0051321	Meiosis	meiotic cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1430728	speciesSpecific	go:GO:0008152	Metabolism	metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-156581	speciesSpecific	go:GO:0032259	Methylation	methylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-193993	speciesSpecific	go:GO:0006705	Mineralocorticoid biosynthesis	mineralocorticoid biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5358508	speciesSpecific	go:GO:0006298	Mismatch Repair	mismatch repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1268020	speciesSpecific	go:GO:0006626	Mitochondrial protein import	protein targeting to mitochondrion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-163316	speciesSpecific	go:GO:0006393	Mitochondrial transcription termination	termination of mitochondrial transcription	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5368287	speciesSpecific	go:GO:0032543	Mitochondrial translation	mitochondrial translation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5389840	speciesSpecific	go:GO:0070125	Mitochondrial translation elongation	mitochondrial translational elongation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5662702	speciesSpecific	go:GO:0042438	Melanin biosynthesis	melanin biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1237112	speciesSpecific	go:GO:0019509	Methionine salvage pathway	L-methionine salvage from methylthioadenosine	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5368286	speciesSpecific	go:GO:0070124	Mitochondrial translation initiation	mitochondrial translational initiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5419276	speciesSpecific	go:GO:0070126	Mitochondrial translation termination	mitochondrial translational termination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5205647	speciesSpecific	go:GO:0000423	Mitophagy	mitophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5205647	speciesSpecific	go:GO:0000422	Mitophagy	autophagy of mitochondrion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-68882	speciesSpecific	go:GO:0000090	Mitotic Anaphase	mitotic anaphase	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-68881	speciesSpecific	go:GO:0007091	Mitotic Metaphase/Anaphase Transition	metaphase/anaphase transition of mitotic cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-68877	speciesSpecific	go:GO:0000236	Mitotic Prometaphase	mitotic prometaphase	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-68875	speciesSpecific	go:GO:0000088	Mitotic Prophase	mitotic prophase	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-69618	speciesSpecific	go:GO:0071174	Mitotic Spindle Checkpoint	mitotic spindle checkpoint	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-397014	speciesSpecific	go:GO:0006936	Muscle contraction	muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-525793	speciesSpecific	go:GO:0007519	Myogenesis	skeletal muscle tissue development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-525793	speciesSpecific	go:GO:0042692	Myogenesis	muscle cell differentiation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-389542	speciesSpecific	go:GO:0006740	NADPH regeneration	NADPH regeneration	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-167060	speciesSpecific	go:GO:0032455	NGF processing	nerve growth factor processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9675108	speciesSpecific	go:GO:0007399	Nervous system development	nervous system development	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-6798695	speciesSpecific	go:GO:0043312	Neutrophil degranulation	neutrophil degranulation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-196807	speciesSpecific	go:GO:1901847	Nicotinate metabolism	nicotinate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2980766	speciesSpecific	go:GO:0051081	Nuclear Envelope Breakdown	nuclear envelope disassembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-72766	speciesSpecific	go:GO:0006412	Translation	translation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8956320	speciesSpecific	go:GO:0046112	Nucleobase biosynthesis	nucleobase biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8956319	speciesSpecific	go:GO:0046113	Nucleobase catabolism	nucleobase catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-774815	speciesSpecific	go:GO:0006334	Nucleosome assembly	nucleosome assembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8956321	speciesSpecific	go:GO:0043173	Nucleotide salvage	nucleotide salvage	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9664873	speciesSpecific	go:GO:0000425	Pexophagy	pexophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-561048	speciesSpecific	go:GO:0015711	Organic anion transport	organic anion transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-549127	speciesSpecific	go:GO:0015695	Organic cation transport	organic cation transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-109704	speciesSpecific	go:GO:0014065	PI3K Cascade	phosphatidylinositol 3-kinase signaling	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-71336	speciesSpecific	go:GO:0006098	Pentose phosphate pathway	pentose-phosphate shunt	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1483257	speciesSpecific	go:GO:0006644	Phospholipid metabolism	phospholipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-114608	speciesSpecific	go:GO:0002576	Platelet degranulation	platelet degranulation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-389977	speciesSpecific	go:GO:0007023	Post-chaperonin tubulin folding pathway	post-chaperonin tubulin folding pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-597592	speciesSpecific	go:GO:0043687	Post-translational protein modification	post-translational protein modification	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5357801	speciesSpecific	go:GO:0012501	Programmed Cell Death	programmed cell death	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70688	speciesSpecific	go:GO:0006562	Proline catabolism	proline catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-71032	speciesSpecific	go:GO:1902859	Propionyl-CoA catabolism	propionyl-CoA catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-391251	speciesSpecific	go:GO:0006457	Protein folding	protein folding	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9609507	speciesSpecific	go:GO:0008104	Protein localization	protein localization	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8876725	speciesSpecific	go:GO:0006479	Protein methylation	protein methylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5676934	speciesSpecific	go:GO:0030091	Protein repair	protein repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8852135	speciesSpecific	go:GO:0016567	Protein ubiquitination	protein ubiquitination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73817	speciesSpecific	go:GO:0009168	Purine ribonucleoside monophosphate biosynthesis	purine ribonucleoside monophosphate biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-74217	speciesSpecific	go:GO:0043101	Purine salvage	purine-containing compound salvage	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73614	speciesSpecific	go:GO:0008655	Pyrimidine salvage	pyrimidine-containing compound salvage	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70268	speciesSpecific	go:GO:0006090	Pyruvate metabolism	pyruvate metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5213460	speciesSpecific	go:GO:0070266	RIPK1-mediated regulated necrosis	necroptotic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73863	speciesSpecific	go:GO:0006363	RNA Polymerase I Transcription Termination	termination of RNA polymerase I transcription	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73856	speciesSpecific	go:GO:0006369	RNA Polymerase II Transcription Termination	termination of RNA polymerase II transcription	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-73980	speciesSpecific	go:GO:0006386	RNA Polymerase III Transcription Termination	termination of RNA polymerase III transcription	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-977606	speciesSpecific	go:GO:0030449	Regulation of Complement cascade	regulation of complement activation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-422356	speciesSpecific	go:GO:0050796	Regulation of insulin secretion	regulation of insulin secretion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-453276	speciesSpecific	go:GO:0007346	Regulation of mitotic cell cycle	regulation of mitotic cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1474165	speciesSpecific	go:GO:0000003	Reproduction	reproduction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5660526	speciesSpecific	go:GO:0010038	Response to metal ions	response to metal ion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-69242	speciesSpecific	go:GO:0051320	S Phase	S phase	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2990846	speciesSpecific	mesh:D058207	SUMOylation	Sumoylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2990846	speciesSpecific	go:GO:0016925	SUMOylation	protein sumoylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9663891	speciesSpecific	go:GO:0061912	Selective autophagy	selective autophagy	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1799339	speciesSpecific	go:GO:0006614	SRP-dependent cotranslational protein targeting to membrane	SRP-dependent cotranslational protein targeting to membrane	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-2408557	speciesSpecific	go:GO:0016260	Selenocysteine synthesis	selenocysteine biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-162582	speciesSpecific	go:GO:0007165	Signal Transduction	signal transduction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-445355	speciesSpecific	go:GO:0006939	Smooth Muscle Contraction	smooth muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-428157	speciesSpecific	go:GO:0006665	Sphingolipid metabolism	sphingolipid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-390522	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-1614635	speciesSpecific	go:GO:0000096	Sulfur amino acid metabolism	sulfur amino acid metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-157579	speciesSpecific	go:GO:0000723	Telomere Maintenance	telomere maintenance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8849175	speciesSpecific	go:GO:0006567	Threonine catabolism	threonine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-75944	speciesSpecific	go:GO:0006390	Transcription from mitochondrial promoters	mitochondrial transcription	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-75109	speciesSpecific	go:GO:0019432	Triglyceride biosynthesis	triglyceride biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-163560	speciesSpecific	go:GO:0019433	Triglyceride catabolism	triglyceride catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8979227	speciesSpecific	go:GO:0006641	Triglyceride metabolism	triglyceride metabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-71240	speciesSpecific	go:GO:0006569	Tryptophan catabolism	tryptophan catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8963684	speciesSpecific	go:GO:0006572	Tyrosine catabolism	tyrosine catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-70635	speciesSpecific	go:GO:0000050	Urea cycle	urea cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-77108	speciesSpecific	go:GO:0046952	Utilization of Ketone Bodies	ketone body catabolic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8866423	speciesSpecific	go:GO:0034379	VLDL assembly	very-low-density lipoprotein particle assembly	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-8964046	speciesSpecific	go:GO:0034447	VLDL clearance	very-low-density lipoprotein particle clearance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-5653656	speciesSpecific	go:GO:0016192	Vesicle-mediated transport	vesicle-mediated transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-9640463	speciesSpecific	go:GO:0010025	Wax biosynthesis	wax biosynthetic process	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-72187	speciesSpecific	go:GO:0031124	mRNA 3'-end processing	mRNA 3'-end processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-72086	speciesSpecific	go:GO:0006370	mRNA Capping	7-methylguanosine mRNA capping	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-72312	speciesSpecific	go:GO:0006364	rRNA processing	rRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-379724	speciesSpecific	go:GO:0043039	tRNA Aminoacylation	tRNA aminoacylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+reactome:R-HSA-72306	speciesSpecific	go:GO:0008033	tRNA processing	tRNA processing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000080242	skos:exactMatch	chebi:CHEBI:40304	8-Hydroxy-2'-Deoxyguanosine	8-hydroxy-2'-deoxyguanosine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000317	skos:exactMatch	chebi:CHEBI:37890	Adrenergic alpha-Antagonists	alpha-adrenergic antagonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000316	skos:exactMatch	chebi:CHEBI:35569	Adrenergic alpha-Agonists	alpha-adrenergic agonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000318	skos:exactMatch	chebi:CHEBI:35522	Adrenergic beta-Agonists	beta-adrenergic agonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000319	skos:exactMatch	chebi:CHEBI:35530	Adrenergic beta-Antagonists	beta-adrenergic antagonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000433	skos:exactMatch	chebi:CHEBI:28831	1-Propanol	propan-1-ol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000803	skos:exactMatch	chebi:CHEBI:2718	Angiotensin I	Angiotensin I	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000805	skos:exactMatch	chebi:CHEBI:89666	Angiotensin III	Angiotensin III	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000779	skos:exactMatch	chebi:CHEBI:36333	Anesthetics, Local	local anaesthetic	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000894	skos:exactMatch	chebi:CHEBI:35475	Anti-Inflammatory Agents, Non-Steroidal	non-steroidal anti-inflammatory drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000988	skos:exactMatch	chebi:CHEBI:145047	Antispermatogenic Agents	antispermatogenic agent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000993	skos:exactMatch	chebi:CHEBI:36050	Antitreponemal Agents	antitreponemal drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001378	skos:exactMatch	chebi:CHEBI:35726	Azasteroids	aza-steroid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001455	skos:exactMatch	chebi:CHEBI:28908	Bambermycins	bambermycin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001603	skos:exactMatch	chebi:CHEBI:33391	Berkelium	berkelium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001608	skos:exactMatch	chebi:CHEBI:30501	Beryllium	beryllium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001615	skos:exactMatch	chebi:CHEBI:10415	beta-Endorphin	beta-endorphin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001895	skos:exactMatch	chebi:CHEBI:27560	Boron	boron atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001969	skos:exactMatch	chebi:CHEBI:37149	Bromobenzenes	bromobenzenes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001971	skos:exactMatch	chebi:CHEBI:3181	Bromocriptine	bromocriptine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001977	skos:exactMatch	chebi:CHEBI:3183	Brompheniramine	brompheniramine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001978	skos:exactMatch	chebi:CHEBI:59424	Bromphenol Blue	bromophenol blue	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D001993	skos:exactMatch	chebi:CHEBI:35523	Bronchodilator Agents	bronchodilator agent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002118	skos:exactMatch	chebi:CHEBI:22984	Calcium	calcium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002120	skos:exactMatch	chebi:CHEBI:38807	Calcium Channel Agonists	calcium channel agonist	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002125	skos:exactMatch	chebi:CHEBI:3309	Calcium Gluconate	Calcium Gluconate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002142	skos:exactMatch	chebi:CHEBI:33392	Californium	californium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002227	skos:exactMatch	chebi:CHEBI:48513	Carbazoles	carbazoles	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002235	skos:exactMatch	chebi:CHEBI:34611	Carbofuran	carbofuran	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002244	skos:exactMatch	chebi:CHEBI:27594	Carbon	carbon atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002245	skos:exactMatch	chebi:CHEBI:16526	Carbon Dioxide	carbon dioxide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002254	skos:exactMatch	chebi:CHEBI:23016	Carbonates	carbonates	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002308	skos:exactMatch	chebi:CHEBI:28494	Cardiolipins	cardiolipin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002301	skos:exactMatch	chebi:CHEBI:83970	Cardiac Glycosides	cardiac glycoside	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002298	skos:exactMatch	chebi:CHEBI:74634	Cardenolides	cardenolides	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002273	skos:exactMatch	chebi:CHEBI:50903	Carcinogens	carcinogenic agent	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002740	skos:exactMatch	chebi:CHEBI:3640	Chlorothiazide	chlorothiazide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002745	skos:exactMatch	chebi:CHEBI:3646	Chlorphentermine	Chlorphentermine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002491	skos:exactMatch	chebi:CHEBI:35470	Central Nervous System Agents	central nervous system drug	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002784	skos:exactMatch	chebi:CHEBI:16113	Cholesterol	cholesterol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002794	skos:exactMatch	chebi:CHEBI:15354	Choline	choline	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002857	skos:exactMatch	chebi:CHEBI:28073	Chromium	chromium atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002867	skos:exactMatch	chebi:CHEBI:23238	Chromones	chromones	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002863	skos:exactMatch	chebi:CHEBI:75050	Chromogenic Compounds	chromogenic compound	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002801	skos:exactMatch	chebi:CHEBI:50241	Cholinesterase Reactivators	cholinesterase reactivator	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002939	skos:exactMatch	chebi:CHEBI:100241	Ciprofloxacin	ciprofloxacin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002934	skos:exactMatch	chebi:CHEBI:36091	Cinnamates	cinnamates	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002930	skos:exactMatch	chebi:CHEBI:51323	Cinchona Alkaloids	cinchona alkaloid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003006	skos:exactMatch	chebi:CHEBI:59115	Clopenthixol	clopenthixol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002997	skos:exactMatch	chebi:CHEBI:47780	Clomipramine	clomipramine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002996	skos:exactMatch	chebi:CHEBI:3752	Clomiphene	clomiphene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002994	skos:exactMatch	chebi:CHEBI:3750	Clofibrate	clofibrate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003022	skos:exactMatch	chebi:CHEBI:3764	Clotrimazole	clotrimazole	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003023	skos:exactMatch	chebi:CHEBI:49566	Cloxacillin	cloxacillin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003024	skos:exactMatch	chebi:CHEBI:3766	Clozapine	clozapine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003038	skos:exactMatch	chebi:CHEBI:23341	Cobamides	cobamides	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003042	skos:exactMatch	chebi:CHEBI:27958	Cocaine	cocaine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003049	skos:exactMatch	chebi:CHEBI:35818	Coccidiostats	coccidiostat	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003061	skos:exactMatch	chebi:CHEBI:16714	Codeine	codeine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003065	skos:exactMatch	chebi:CHEBI:15346	Coenzyme A	coenzyme A	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003067	skos:exactMatch	chebi:CHEBI:23354	Coenzymes	coenzyme	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003070	skos:exactMatch	chebi:CHEBI:16213	Coformycin	coformycin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003084	skos:exactMatch	chebi:CHEBI:3814	Colestipol	colestipol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003094	skos:exactMatch	chebi:CHEBI:3815	Collagen	Collagen	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003224	skos:exactMatch	chebi:CHEBI:34653	Congo Red	Congo Red	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003300	skos:exactMatch	chebi:CHEBI:28694	Copper	copper atom	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003345	skos:exactMatch	chebi:CHEBI:16827	Corticosterone	corticosterone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003348	skos:exactMatch	chebi:CHEBI:16962	Cortisone	cortisone	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003358	skos:exactMatch	chebi:CHEBI:64857	Cosmetics	cosmetic	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003366	skos:exactMatch	chebi:CHEBI:3901	Cosyntropin	cosyntropin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003372	skos:exactMatch	chebi:CHEBI:3903	Coumaphos	coumaphos	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003374	skos:exactMatch	chebi:CHEBI:23403	Coumarins	coumarins	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003375	skos:exactMatch	chebi:CHEBI:3908	Coumestrol	coumestrol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003401	skos:exactMatch	chebi:CHEBI:16919	Creatine	creatine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003404	skos:exactMatch	chebi:CHEBI:16737	Creatinine	creatinine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003408	skos:exactMatch	chebi:CHEBI:25399	Cresols	cresol	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003484	skos:exactMatch	chebi:CHEBI:16698	Cyanamide	cyanamide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003485	skos:exactMatch	chebi:CHEBI:23420	Cyanates	cyanates	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003486	skos:exactMatch	chebi:CHEBI:23424	Cyanides	cyanides	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003492	skos:exactMatch	chebi:CHEBI:17074	Cycasin	cycasin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003494	skos:exactMatch	chebi:CHEBI:82431	Cyclamates	Cyclamate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003501	skos:exactMatch	chebi:CHEBI:3994	Cyclizine	cyclizine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003505	skos:exactMatch	chebi:CHEBI:23456	Cyclodextrins	cyclodextrin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003506	skos:exactMatch	chebi:CHEBI:31446	Cyclofenil	Cyclofenil	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003511	skos:exactMatch	chebi:CHEBI:23480	Cyclohexanols	cyclohexanols	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003512	skos:exactMatch	chebi:CHEBI:23482	Cyclohexanones	cyclohexanones	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003513	skos:exactMatch	chebi:CHEBI:27641	Cycloheximide	cycloheximide	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003517	skos:exactMatch	chebi:CHEBI:23493	Cyclopentanes	cyclopentanes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003519	skos:exactMatch	chebi:CHEBI:4024	Cyclopentolate	cyclopentolate	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003521	skos:exactMatch	chebi:CHEBI:51454	Cyclopropanes	cyclopropanes	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003533	skos:exactMatch	chebi:CHEBI:4046	Cyproheptadine	cyproheptadine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003540	skos:exactMatch	chebi:CHEBI:17755	Cystathionine	cystathionine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003544	skos:exactMatch	chebi:CHEBI:21260	Cysteic Acid	cysteic acid	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003545	skos:exactMatch	chebi:CHEBI:15356	Cysteine	cysteine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003548	skos:exactMatch	chebi:CHEBI:81392	Cysteinyldopa	Cysteinyldopa	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003553	skos:exactMatch	chebi:CHEBI:17376	Cystine	cystine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003562	skos:exactMatch	chebi:CHEBI:17562	Cytidine	cytidine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003571	skos:exactMatch	chebi:CHEBI:23527	Cytochalasin B	cytochalasin B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003596	skos:exactMatch	chebi:CHEBI:16040	Cytosine	cytosine	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D003620	skos:exactMatch	chebi:CHEBI:4317	Dantrolene	dantrolene	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+ncit:C1707	skos:exactMatch	chebi:CHEBI:10023	Voriconazole	voriconazole	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+chebi:CHEBI:135931	skos:exactMatch	ncit:C73192	dexlansoprazole	Dexlansoprazole	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+chebi:CHEBI:6375	skos:exactMatch	ncit:C29150	lansoprazole	Lansoprazole	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+chebi:CHEBI:63598	skos:exactMatch	ncit:C1586	levofloxacin	Levofloxacin	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+ncit:C65538	skos:exactMatch	chebi:CHEBI:50275	Esomeprazole	esomeprazole	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+ncit:C2160	skos:exactMatch	chebi:CHEBI:52726	Proteasome Inhibitor	proteasome inhibitor	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D059765	skos:exactMatch	kegg.pathway:map03440	Homologous Recombination	Homologous recombination	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04360	skos:exactMatch	mesh:D000071437	Axon guidance	Axon Guidance	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000078790	skos:exactMatch	kegg.pathway:map04911	Insulin Secretion	Insulin secretion	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D002453	skos:exactMatch	kegg.pathway:map04110	Cell Cycle	Cell cycle	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D004705	skos:exactMatch	kegg.pathway:map04144	Endocytosis	Endocytosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D060449	skos:exactMatch	kegg.pathway:map04310	Wnt Signaling Pathway	Wnt signaling pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+go:GO:0005816	skos:exactMatch	ncit:C13365	spindle pole body	Spindle Pole Body	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04710	skos:exactMatch	mesh:D002940	Circadian rhythm	Circadian Rhythm	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03030	skos:exactMatch	mesh:D004261	DNA replication	DNA Replication	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00190	skos:exactMatch	mesh:D010085	Oxidative phosphorylation	Oxidative Phosphorylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00195	skos:exactMatch	mesh:D010788	Photosynthesis	Photosynthesis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04611	skos:exactMatch	mesh:D015539	Platelet activation	Platelet Activation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04218	skos:exactMatch	mesh:D016922	Cellular senescence	Cellular Senescence	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map04210	skos:exactMatch	mesh:D017209	Apoptosis	Apoptosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03013	skos:exactMatch	mesh:D034443	RNA transport	RNA Transport	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00030	skos:exactMatch	mesh:D010427	Pentose phosphate pathway	Pentose Phosphate Pathway	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map02024	skos:exactMatch	mesh:D053038	Quorum sensing	Quorum Sensing	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map03430	skos:exactMatch	mesh:D053843	Mismatch repair	DNA Mismatch Repair	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+go:GO:0070266	skos:exactMatch	mesh:D000079302	necroptotic process	Necroptosis	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+kegg.pathway:map00970	skos:exactMatch	mesh:D046249	Aminoacyl-tRNA biosynthesis	Transfer RNA Aminoacylation	sssom:HumanCurated	orcid:0000-0003-4423-4370	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:D000086382	skos:exactMatch	doid:DOID:0080600	COVID-19	COVID-19	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C437905	skos:exactMatch	uniprot:Q96PH6	DEFB118 protein, human	DEFB118	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C112641	skos:exactMatch	uniprot:O43583	DENR protein, human	DENR	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C494208	skos:exactMatch	uniprot:P60880	SNAP25 protein, human	SNAP25	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C494482	skos:exactMatch	uniprot:Q8NER1	TRPV1 protein, human	TRPV1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C495270	skos:exactMatch	uniprot:P35222	CTNNB1 protein, human	CTNNB1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C578038	skos:exactMatch	uniprot:Q02080	MEF2B protein, human	MEF2B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C077171	skos:exactMatch	uniprot:P31629	HIVEP2 protein, human	HIVEP2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C414177	skos:exactMatch	uniprot:P52569	SLC7A2 protein, human	SLC7A2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497937	skos:exactMatch	uniprot:P61764	STXBP1 protein, human	STXBP1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C494841	skos:exactMatch	uniprot:Q12791	KCNMA1 protein, human	KCNMA1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C108096	skos:exactMatch	uniprot:Q99643	SDHC protein, human	SDHC	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C511268	skos:exactMatch	uniprot:P31040	SDHA protein, human	SDHA	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C102467	skos:exactMatch	uniprot:Q99470	SDF2 protein, human	SDF2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C494881	skos:exactMatch	uniprot:O75907	DGAT1 protein, human	DGAT1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C580923	skos:exactMatch	uniprot:O95294	RASAL1 protein, human	RASAL1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C580922	skos:exactMatch	uniprot:Q9NTJ3	SMC4 protein, human	SMC4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C500151	skos:exactMatch	uniprot:Q9NX95	SYBU protein, human	SYBU	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C456359	skos:exactMatch	uniprot:Q969U7	PSMG2 protein, human	PSMG2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C513866	skos:exactMatch	uniprot:Q8NE35	CPEB3 protein, human	CPEB3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C489108	skos:exactMatch	uniprot:P05813	CRYBA1 protein, human	CRYBA1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C490613	skos:exactMatch	uniprot:Q12955	ANK3 protein, human	ANK3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C491904	skos:exactMatch	uniprot:O14617	AP3D1 protein, human	AP3D1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C510070	skos:exactMatch	uniprot:P53677	AP3M2 protein, human	AP3M2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C497872	skos:exactMatch	uniprot:P15408	FOSL2 protein, human	FOSL2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C498630	skos:exactMatch	uniprot:Q9Y6V0	PCLO protein, human	PCLO	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C512817	skos:exactMatch	uniprot:O75493	CA11 protein, human	CA11	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C407644	skos:exactMatch	uniprot:Q9NP60	IL1RAPL2 protein, human	IL1RAPL2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C403492	skos:exactMatch	uniprot:Q9UK73	FEM1B protein, human	FEM1B	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C485764	skos:exactMatch	uniprot:P35372	OPRM1 protein, human	OPRM1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C109742	skos:exactMatch	uniprot:Q14BN4	SLMAP protein, human	SLMAP	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C402222	skos:exactMatch	uniprot:Q9NZJ7	MTCH1 protein, human	MTCH1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C488761	skos:exactMatch	uniprot:Q6H3X3	RAET1G protein, human	RAET1G	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C488760	skos:exactMatch	uniprot:Q8TD07	RAET1E protein, human	RAET1E	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C490522	skos:exactMatch	uniprot:P78406	RAE1 protein, human	RAE1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C419389	skos:exactMatch	uniprot:Q12797	ASPH protein, human	ASPH	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C508131	skos:exactMatch	uniprot:Q8WYH8	ING5 protein, human	ING5	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C504404	skos:exactMatch	uniprot:Q92563	SPOCK2 protein, human	SPOCK2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C578040	skos:exactMatch	uniprot:Q06413	MEF2C protein, human	MEF2C	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C502025	skos:exactMatch	uniprot:Q9BZE1	MRPL37 protein, human	MRPL37	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C556354	skos:exactMatch	uniprot:P02765	AHSG protein, human	AHSG	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C519072	skos:exactMatch	uniprot:P11230	CHRNB1 protein, human	CHRNB1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C519156	skos:exactMatch	uniprot:Q9H2K0	MTIF3 protein, human	MTIF3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C518505	skos:exactMatch	uniprot:O96006	ZBED1 protein, human	ZBED1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C578043	skos:exactMatch	uniprot:Q14814	MEF2D protein, human	MEF2D	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C463459	skos:exactMatch	uniprot:Q5JY77	GPRASP1 protein, human	GPRASP1	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+mesh:C417919	skos:exactMatch	uniprot:Q9NQ84	GPRC5C protein, human	GPRC5C	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449619	skos:exactMatch	ncbiprotein:YP_009725297	Host translation inhibitor nsp1	leader protein	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449620	skos:exactMatch	ncbiprotein:YP_009725298	Non-structural protein 2	nsp2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449621	skos:exactMatch	ncbiprotein:YP_009725299	Non-structural protein 3	nsp3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449622	skos:exactMatch	ncbiprotein:YP_009725300	Non-structural protein 4	nsp4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449623	skos:exactMatch	ncbiprotein:YP_009725301	3C-like proteinase	3C-like proteinase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449624	skos:exactMatch	ncbiprotein:YP_009725302	Non-structural protein 6	nsp6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449625	skos:exactMatch	ncbiprotein:YP_009725303	Non-structural protein 7	nsp7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449626	skos:exactMatch	ncbiprotein:YP_009725304	Non-structural protein 8	nsp8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449627	skos:exactMatch	ncbiprotein:YP_009725305	Non-structural protein 9	nsp9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449628	skos:exactMatch	ncbiprotein:YP_009725306	Non-structural protein 10	nsp10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449629	skos:exactMatch	ncbiprotein:YP_009725307	RNA-directed RNA polymerase	RNA-dependent RNA polymerase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449630	skos:exactMatch	ncbiprotein:YP_009725308	Helicase	helicase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449631	skos:exactMatch	ncbiprotein:YP_009725309	Proofreading exoribonuclease	3'-to-5' exonuclease	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449632	skos:exactMatch	ncbiprotein:YP_009725310	Uridylate-specific endoribonuclease	endoRNAse	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449633	skos:exactMatch	ncbiprotein:YP_009725311	2'-O-methyltransferase	2'-O-ribose methyltransferase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+pr:PR:000035726	skos:exactMatch	uniprot.chain:PRO_0000396174	ubiquitin (UBB)	Ubiquitin	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449635	skos:exactMatch	ncbiprotein:YP_009742608	Host translation inhibitor nsp1	leader protein	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449636	skos:exactMatch	ncbiprotein:YP_009742609	Non-structural protein 2	nsp2	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449637	skos:exactMatch	ncbiprotein:YP_009742610	Non-structural protein 3	nsp3	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449638	skos:exactMatch	ncbiprotein:YP_009742611	Non-structural protein 4	nsp4	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449639	skos:exactMatch	ncbiprotein:YP_009742612	3C-like proteinase	3C-like proteinase	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449640	skos:exactMatch	ncbiprotein:YP_009742613	Non-structural protein 6	nsp6	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449641	skos:exactMatch	ncbiprotein:YP_009742614	Non-structural protein 7	nsp7	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449642	skos:exactMatch	ncbiprotein:YP_009742615	Non-structural protein 8	nsp8	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449643	skos:exactMatch	ncbiprotein:YP_009742616	Non-structural protein 9	nsp9	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449644	skos:exactMatch	ncbiprotein:YP_009742617	Non-structural protein 10	nsp10	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/
+uniprot.chain:PRO_0000449645	skos:exactMatch	ncbiprotein:YP_009725312	Non-structural protein 11	nsp11	sssom:HumanCurated	orcid:0000-0001-9439-5346	https://creativecommons.org/publicdomain/zero/1.0/

--- a/docs/_data/biomappings.sssom.tsv
+++ b/docs/_data/biomappings.sssom.tsv
@@ -1,0 +1,2299 @@
+subject_id	predicate_id	object_id	subject_label	object_label	creator_id	license
+umls:C0001973	skos:narrower	mesh:D000435	Alcoholic Intoxication, Chronic	Alcoholic Intoxication	orcid:0000-0003-4423-4370	CC0
+umls:C0004352	skos:exactMatch	mesh:D001321	Autistic Disorder	Autistic Disorder	orcid:0000-0003-4423-4370	CC0
+umls:C0006118	skos:exactMatch	mesh:D001932	Brain Neoplasms	Brain Neoplasms	orcid:0000-0003-4423-4370	CC0
+umls:C0006142	skos:exactMatch	mesh:D001943	Malignant neoplasm of breast	Breast Neoplasms	orcid:0000-0003-4423-4370	CC0
+mesh:C108192	skos:exactMatch	chebi:CHEBI:101381	aloxistatin	aloxistatin	orcid:0000-0001-9439-5346	CC0
+pfam:PF01391	skos:exactMatch	mesh:D003094	Collagen	Collagen	orcid:0000-0001-9439-5346	CC0
+mesh:D002465	skos:exactMatch	go:GO:0048870	Cell Movement	cell motility	orcid:0000-0001-9439-5346	CC0
+mesh:D002914	skos:exactMatch	go:GO:0042627	Chylomicrons	chylomicron	orcid:0000-0001-9439-5346	CC0
+mesh:D012374	skos:exactMatch	go:GO:0120200	Rod Cell Outer Segment	rod photoreceptor outer segment	orcid:0000-0001-9439-5346	CC0
+mesh:D014158	skos:exactMatch	go:GO:0006351	Transcription, Genetic	transcription, DNA-templated	orcid:0000-0001-9439-5346	CC0
+mesh:D014176	skos:exactMatch	go:GO:0006412	Protein Biosynthesis	translation	orcid:0000-0001-9439-5346	CC0
+mesh:D018919	skos:exactMatch	go:GO:0001525	Neovascularization, Physiologic	angiogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D048708	skos:exactMatch	go:GO:0016049	Cell Growth Processes	cell growth	orcid:0000-0001-9439-5346	CC0
+mesh:D058750	skos:exactMatch	go:GO:0001837	Epithelial-Mesenchymal Transition	epithelial to mesenchymal transition	orcid:0000-0001-9439-5346	CC0
+mesh:D059767	skos:exactMatch	go:GO:0000725	Recombinational DNA Repair	recombinational repair	orcid:0000-0001-9439-5346	CC0
+mesh:D016195	skos:exactMatch	go:GO:0051319	G2 Phase	G2 phase	orcid:0000-0001-9439-5346	CC0
+mesh:C497399	skos:exactMatch	uniprot:Q15797	SMAD1 protein, human	SMAD1	orcid:0000-0001-9439-5346	CC0
+mesh:C497782	skos:exactMatch	uniprot:Q15796	SMAD2 protein, human	SMAD2	orcid:0000-0001-9439-5346	CC0
+mesh:C497790	skos:exactMatch	uniprot:P84022	SMAD3 protein, human	SMAD3	orcid:0000-0001-9439-5346	CC0
+mesh:C497796	skos:exactMatch	uniprot:Q13485	SMAD4 protein, human	SMAD4	orcid:0000-0001-9439-5346	CC0
+mesh:C497797	skos:exactMatch	uniprot:Q99717	SMAD5 protein, human	SMAD5	orcid:0000-0001-9439-5346	CC0
+mesh:C497802	skos:exactMatch	uniprot:O43541	SMAD6 protein, human	SMAD6	orcid:0000-0001-9439-5346	CC0
+mesh:C497806	skos:exactMatch	uniprot:O15105	SMAD7 protein, human	SMAD7	orcid:0000-0001-9439-5346	CC0
+mesh:D005759	skos:exactMatch	ncit:C34632	Gastroenteritis	Gastroenteritis	orcid:0000-0001-9439-5346	CC0
+mesh:D005762	skos:exactMatch	ncit:C16603	Gastroenterology	Gastroenterology	orcid:0000-0001-9439-5346	CC0
+mesh:D005756	skos:exactMatch	ncit:C26780	Gastritis	Gastritis	orcid:0000-0001-9439-5346	CC0
+mesh:D005755	skos:exactMatch	chebi:CHEBI:75436	Gastrins	gastrin	orcid:0000-0001-9439-5346	CC0
+mesh:D005753	skos:exactMatch	ncit:C32656	Gastric Mucosa	Gastric Mucosa	orcid:0000-0001-9439-5346	CC0
+mesh:D005746	skos:exactMatch	go:GO:0035483	Gastric Emptying	gastric emptying	orcid:0000-0001-9439-5346	CC0
+mesh:D005744	skos:exactMatch	ncit:C94192	Gastric Acid	Gastric Acid	orcid:0000-0001-9439-5346	CC0
+mesh:D005743	skos:exactMatch	ncit:C15236	Gastrectomy	Gastrectomy	orcid:0000-0001-9439-5346	CC0
+mesh:D005735	skos:exactMatch	ncit:C122627	Garbage	Trash	orcid:0000-0001-9439-5346	CC0
+mesh:D005729	skos:exactMatch	ncit:C3049	Ganglioneuroma	Ganglioneuroma	orcid:0000-0001-9439-5346	CC0
+mesh:D005728	skos:exactMatch	ncit:C12467	Ganglia, Sympathetic	Sympathetic Ganglion	orcid:0000-0001-9439-5346	CC0
+mesh:D005708	skos:exactMatch	ncit:C66798	Gallium	Gallium	orcid:0000-0001-9439-5346	CC0
+mesh:D005707	skos:exactMatch	ncit:C63648	Gallic Acid	Gallic Acid	orcid:0000-0001-9439-5346	CC0
+mesh:D005693	skos:exactMatch	ncit:C84723	Galactosemias	Galactosemia	orcid:0000-0001-9439-5346	CC0
+mesh:D005690	skos:exactMatch	chebi:CHEBI:28260	Galactose	galactose	orcid:0000-0001-9439-5346	CC0
+mesh:D005697	skos:exactMatch	chebi:CHEBI:24163	Galactosides	galactoside	orcid:0000-0001-9439-5346	CC0
+mesh:D005687	skos:exactMatch	ncit:C113343	Galactorrhea	Galactorrhea	orcid:0000-0001-9439-5346	CC0
+mesh:D005685	skos:exactMatch	chebi:CHEBI:37165	Galactans	galactan	orcid:0000-0001-9439-5346	CC0
+mesh:D005684	skos:exactMatch	ncit:C75445	Gait	Gait	orcid:0000-0001-9439-5346	CC0
+mesh:D005661	skos:exactMatch	chebi:CHEBI:131714	Furagin	furagin	orcid:0000-0001-9439-5346	CC0
+mesh:D005664	skos:exactMatch	chebi:CHEBI:5195	Furazolidone	furazolidone	orcid:0000-0001-9439-5346	CC0
+mesh:D005665	skos:exactMatch	chebi:CHEBI:47426	Furosemide	furosemide	orcid:0000-0001-9439-5346	CC0
+mesh:D005667	skos:exactMatch	ncit:C34629	Furunculosis	Furunculosis	orcid:0000-0001-9439-5346	CC0
+mesh:D005669	skos:exactMatch	chebi:CHEBI:5199	Fusaric Acid	Fusaric acid	orcid:0000-0001-9439-5346	CC0
+mesh:D005670	skos:exactMatch	ncit:C77185	Fusarium	Fusarium	orcid:0000-0001-9439-5346	CC0
+mesh:D005672	skos:exactMatch	ncit:C65793	Fusidic Acid	Fusidic Acid	orcid:0000-0001-9439-5346	CC0
+mesh:D005673	skos:exactMatch	ncit:C76323	Fusobacterium	Fusobacterium	orcid:0000-0001-9439-5346	CC0
+mesh:D005674	skos:exactMatch	ncit:C84722	Fusobacterium Infections	Fusobacterium Infection	orcid:0000-0001-9439-5346	CC0
+mesh:D005675	skos:exactMatch	ncit:C86401	Fusobacterium necrophorum	Fusobacterium necrophorum	orcid:0000-0001-9439-5346	CC0
+mesh:D005677	skos:exactMatch	chebi:CHEBI:61048	G(M1) Ganglioside	ganglioside GM1	orcid:0000-0001-9439-5346	CC0
+mesh:D005678	skos:exactMatch	ncit:C516	G(M2) Ganglioside	Ganglioside GM2	orcid:0000-0001-9439-5346	CC0
+mesh:D005681	skos:exactMatch	ncit:C16596	Gabon	Gabon	orcid:0000-0001-9439-5346	CC0
+mesh:D005683	skos:exactMatch	ncit:C34630	Gagging	Gagging	orcid:0000-0001-9439-5346	CC0
+mesh:D005639	skos:exactMatch	ncit:C61483	Frustration	Frustration	orcid:0000-0001-9439-5346	CC0
+mesh:D005638	skos:exactMatch	ncit:C71972	Fruit	Fruit	orcid:0000-0001-9439-5346	CC0
+mesh:D005640	skos:exactMatch	chebi:CHEBI:81569	Follicle Stimulating Hormone	Follicle stimulating hormone	orcid:0000-0001-9439-5346	CC0
+mesh:D005641	skos:exactMatch	chebi:CHEBI:32188	Tegafur	Tegafur	orcid:0000-0001-9439-5346	CC0
+mesh:D005627	skos:exactMatch	ncit:C34627	Frostbite	Frostbite	orcid:0000-0001-9439-5346	CC0
+mesh:D005630	skos:exactMatch	chebi:CHEBI:28796	Fructans	fructan	orcid:0000-0001-9439-5346	CC0
+mesh:D005625	skos:exactMatch	ncit:C23287	Frontal Lobe	Frontal Lobe	orcid:0000-0001-9439-5346	CC0
+mesh:D005624	skos:exactMatch	ncit:C32635	Frontal Bone	Frontal Bone	orcid:0000-0001-9439-5346	CC0
+mesh:D005622	skos:exactMatch	ncit:C14362	Friend murine leukemia virus	Friend Murine Leukemia Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D005621	skos:exactMatch	ncit:C84718	Friedreich Ataxia	Friedreich Ataxia	orcid:0000-0001-9439-5346	CC0
+mesh:D005620	skos:exactMatch	ncit:C2347	Freund's Adjuvant	Freund's Adjuvant	orcid:0000-0001-9439-5346	CC0
+mesh:D005616	skos:exactMatch	ncit:C16593	French Guiana	French Guiana	orcid:0000-0001-9439-5346	CC0
+mesh:D005609	skos:exactMatch	ncit:C512	Free Radicals	Free Radical	orcid:0000-0001-9439-5346	CC0
+mesh:D005602	skos:exactMatch	ncit:C16592	France	France	orcid:0000-0001-9439-5346	CC0
+mesh:D005615	skos:exactMatch	ncit:C48160	Freezing	Freezing	orcid:0000-0001-9439-5346	CC0
+mesh:D005634	skos:exactMatch	ncit:C129394	Fructose-Bisphosphate Aldolase	Fructose-Bisphosphate Aldolase	orcid:0000-0001-9439-5346	CC0
+mesh:D005642	skos:exactMatch	ncit:C84721	Fuchs' Endothelial Dystrophy	Fuchs Endothelial Dystrophy	orcid:0000-0001-9439-5346	CC0
+mesh:C095085	skos:exactMatch	uniprot:P32302	CXCR5 protein, human	CXCR5	orcid:0000-0001-9439-5346	CC0
+mesh:C497894	skos:exactMatch	uniprot:Q08722	CD47 protein, human	CD47	orcid:0000-0001-9439-5346	CC0
+mesh:C497139	skos:exactMatch	uniprot:Q16760	DGKD protein, human	DGKD	orcid:0000-0001-9439-5346	CC0
+mesh:C537126	skos:exactMatch	doid:DOID:0111438	Optic atrophy 5	optic atrophy 5	orcid:0000-0001-9439-5346	CC0
+mesh:C537127	skos:exactMatch	doid:DOID:0111435	Optic atrophy 6	optic atrophy 6	orcid:0000-0001-9439-5346	CC0
+mesh:C537117	skos:exactMatch	doid:DOID:0080549	LEOPARD syndrome, 2	LEOPARD syndrome 2	orcid:0000-0001-9439-5346	CC0
+mesh:C537115	skos:exactMatch	doid:DOID:0111507	Lenz Majewski hyperostotic dwarfism	Lenz-Majewski hyperostotic dwarfism	orcid:0000-0001-9439-5346	CC0
+mesh:C537098	skos:exactMatch	doid:DOID:0050690	Brachyolmia	brachyolmia	orcid:0000-0001-9439-5346	CC0
+mesh:C537162	skos:exactMatch	doid:DOID:6823	Pancreatoblastoma	pancreatoblastoma	orcid:0000-0001-9439-5346	CC0
+mesh:C537202	skos:exactMatch	doid:DOID:0050974	Spinocerebellar ataxia 25	spinocerebellar ataxia type 25	orcid:0000-0001-9439-5346	CC0
+mesh:C537203	skos:exactMatch	doid:DOID:0050975	Spinocerebellar ataxia 26	spinocerebellar ataxia type 26	orcid:0000-0001-9439-5346	CC0
+mesh:C537199	skos:exactMatch	doid:DOID:0050971	Spinocerebellar ataxia 20	spinocerebellar ataxia type 20	orcid:0000-0001-9439-5346	CC0
+mesh:C537262	skos:exactMatch	ncit:C95436	Hereditary pancreatitis	Hereditary Pancreatitis	orcid:0000-0001-9439-5346	CC0
+mesh:C000622468	skos:exactMatch	uniprot:Q6PI78	TMEM65 protein, human	TMEM65	orcid:0000-0001-9439-5346	CC0
+mesh:C000626007	skos:exactMatch	uniprot:O15481	MAGEB4 protein, human	MAGEB4	orcid:0000-0001-9439-5346	CC0
+mesh:C493803	skos:exactMatch	uniprot:Q8WVX9	FAR1 protein, human	FAR1	orcid:0000-0001-9439-5346	CC0
+mesh:C000626466	skos:exactMatch	uniprot:O94919	ENDOD1 protein, human	ENDOD1	orcid:0000-0001-9439-5346	CC0
+mesh:D016985	skos:exactMatch	ncit:C86784	Streptococcus bovis	Streptococcus bovis	orcid:0000-0001-9439-5346	CC0
+mesh:D016990	skos:exactMatch	ncit:C86833	Ureaplasma urealyticum	Ureaplasma urealyticum	orcid:0000-0001-9439-5346	CC0
+mesh:D016993	skos:exactMatch	ncit:C76272	Chlamydophila pneumoniae	Chlamydophila pneumoniae	orcid:0000-0001-9439-5346	CC0
+mesh:D016997	skos:exactMatch	ncit:C86328	Coxiella burnetii	Coxiella burnetii	orcid:0000-0001-9439-5346	CC0
+mesh:D016998	skos:exactMatch	ncit:C14296	Helicobacter	Helicobacter	orcid:0000-0001-9439-5346	CC0
+mesh:D017000	skos:exactMatch	ncit:C86230	Campylobacter coli	Campylobacter coli	orcid:0000-0001-9439-5346	CC0
+mesh:D017006	skos:exactMatch	ncit:C33497	Rotator Cuff	Rotator Cuff	orcid:0000-0001-9439-5346	CC0
+mesh:D017011	skos:exactMatch	ncit:C86807	Streptococcus suis	Streptococcus suis	orcid:0000-0001-9439-5346	CC0
+mesh:D017023	skos:exactMatch	ncit:C100085	Coronary Angiography	Coronary Angiography	orcid:0000-0001-9439-5346	CC0
+mesh:D017024	skos:exactMatch	ncit:C15360	Chemotherapy, Adjuvant	Adjuvant Chemotherapy	orcid:0000-0001-9439-5346	CC0
+mesh:D017041	skos:exactMatch	ncit:C142541	Ethics Committees	Ethics Committee	orcid:0000-0001-9439-5346	CC0
+mesh:D017043	skos:exactMatch	ncit:C26717	Chalazion	Chalazion	orcid:0000-0001-9439-5346	CC0
+mesh:D017045	skos:exactMatch	ncit:C86483	Lactococcus	Lactococcus	orcid:0000-0001-9439-5346	CC0
+mesh:D017051	skos:exactMatch	ncit:C15252	Hospice Care	Hospice Care	orcid:0000-0001-9439-5346	CC0
+mesh:D017058	skos:exactMatch	ncit:C67114	Mexican Americans	Mexican American	orcid:0000-0001-9439-5346	CC0
+mesh:D017072	skos:exactMatch	ncit:C111122	Neostriatum	Neostriatum	orcid:0000-0001-9439-5346	CC0
+mesh:D017073	skos:exactMatch	ncit:C157793	Atherectomy	Atherectomy	orcid:0000-0001-9439-5346	CC0
+mesh:D017074	skos:exactMatch	ncit:C26725	Common Variable Immunodeficiency	Common Variable Immunodeficiency	orcid:0000-0001-9439-5346	CC0
+mesh:D017081	skos:exactMatch	ncit:C51681	Cholecystectomy, Laparoscopic	Laparoscopic Cholecystectomy	orcid:0000-0001-9439-5346	CC0
+mesh:D017089	skos:exactMatch	ncit:C14100	Ankyrin Repeat	Ankyrin Repeat	orcid:0000-0001-9439-5346	CC0
+mesh:D017092	skos:exactMatch	ncit:C84697	Porphyria, Erythropoietic	Erythropoietic Porphyria	orcid:0000-0001-9439-5346	CC0
+mesh:D017101	skos:exactMatch	ncit:C14301	Bacteriophage P1	Bacteriophage P1	orcid:0000-0001-9439-5346	CC0
+mesh:D017114	skos:exactMatch	ncit:C84396	Liver Failure, Acute	Acute Liver Failure	orcid:0000-0001-9439-5346	CC0
+mesh:D017026	skos:exactMatch	chebi:CHEBI:9367	Swainsonine	swainsonine	orcid:0000-0001-9439-5346	CC0
+mesh:D016966	skos:exactMatch	ncit:C86657	Porphyromonas gingivalis	Porphyromonas gingivalis	orcid:0000-0001-9439-5346	CC0
+mesh:D016967	skos:exactMatch	ncit:C86404	Fusobacterium nucleatum	Fusobacterium nucleatum	orcid:0000-0001-9439-5346	CC0
+mesh:D016960	skos:exactMatch	ncit:C86138	Agrobacterium tumefaciens	Agrobacterium tumefaciens	orcid:0000-0001-9439-5346	CC0
+mesh:D016958	skos:exactMatch	ncit:C86705	Pseudomonas putida	Pseudomonas putida	orcid:0000-0001-9439-5346	CC0
+mesh:D016957	skos:exactMatch	ncit:C86227	Burkholderia pseudomallei	Burkholderia pseudomallei	orcid:0000-0001-9439-5346	CC0
+mesh:D016955	skos:exactMatch	ncit:C86524	Moraxella bovis	Moraxella bovis	orcid:0000-0001-9439-5346	CC0
+mesh:D016979	skos:exactMatch	ncit:C76373	Pasteurella multocida	Pasteurella multocida	orcid:0000-0001-9439-5346	CC0
+mesh:D016980	skos:exactMatch	ncit:C86125	Aeromonas hydrophila	Aeromonas hydrophila	orcid:0000-0001-9439-5346	CC0
+mesh:D016978	skos:exactMatch	ncit:C86508	Mannheimia haemolytica	Mannheimia haemolytica	orcid:0000-0001-9439-5346	CC0
+mesh:D016981	skos:exactMatch	ncit:C86651	Plesiomonas	Plesiomonas	orcid:0000-0001-9439-5346	CC0
+mesh:D016982	skos:exactMatch	ncit:C86513	Micrococcus luteus	Micrococcus luteus	orcid:0000-0001-9439-5346	CC0
+mesh:D016983	skos:exactMatch	ncit:C76311	Enterococcus	Enterococcus	orcid:0000-0001-9439-5346	CC0
+mesh:D016984	skos:exactMatch	ncit:C86369	Enterococcus faecium	Enterococcus faecium	orcid:0000-0001-9439-5346	CC0
+mesh:D017027	skos:exactMatch	ncit:C17444	Protein Tyrosine Phosphatases	Protein Tyrosine Phosphatase	orcid:0000-0001-9439-5346	CC0
+mesh:D017028	skos:exactMatch	ncit:C17445	Caregivers	Caregiver	orcid:0000-0001-9439-5346	CC0
+mesh:D017035	skos:exactMatch	ncit:C62070	Pravastatin	Pravastatin	orcid:0000-0001-9439-5346	CC0
+mesh:D016975	skos:exactMatch	ncit:C86409	Gardnerella	Gardnerella	orcid:0000-0001-9439-5346	CC0
+mesh:D016970	skos:exactMatch	ncit:C86350	Eikenella	Eikenella	orcid:0000-0001-9439-5346	CC0
+mesh:D016968	skos:exactMatch	ncit:C86850	Wolinella	Wolinella	orcid:0000-0001-9439-5346	CC0
+mesh:D016919	skos:exactMatch	hp:HP:0032160	Meningitis, Cryptococcal	Cryptococcal meningitis	orcid:0000-0001-9439-5346	CC0
+mesh:D016918	skos:exactMatch	ncit:C128332	Arthritis, Reactive	Reactive Arthritis	orcid:0000-0001-9439-5346	CC0
+mesh:D016920	skos:exactMatch	ncit:C118297	Meningitis, Bacterial	Bacterial Meningitis	orcid:0000-0001-9439-5346	CC0
+mesh:D016923	skos:exactMatch	go:GO:0008219	Cell Death	cell death	orcid:0000-0001-9439-5346	CC0
+mesh:D016924	skos:exactMatch	ncit:C86115	Actinomyces viscosus	Actinomyces viscosus	orcid:0000-0001-9439-5346	CC0
+mesh:D016912	skos:exactMatch	chebi:CHEBI:6443	Levonorgestrel	levonorgestrel	orcid:0000-0001-9439-5346	CC0
+mesh:D016909	skos:exactMatch	ncit:C12824	Tibial Arteries	Tibial Artery	orcid:0000-0001-9439-5346	CC0
+mesh:D016906	skos:exactMatch	hgnc:6029	Interleukin-9	IL9	orcid:0000-0001-9439-5346	CC0
+mesh:D016856	skos:exactMatch	ncit:C112397	Phlebovirus	Phlebovirus	orcid:0000-0001-9439-5346	CC0
+mesh:D016859	skos:exactMatch	chebi:CHEBI:35856	Lipoxygenase Inhibitors	lipoxygenase inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D016878	skos:exactMatch	ncit:C80303	POEMS Syndrome	POEMS Syndrome	orcid:0000-0001-9439-5346	CC0
+mesh:D016879	skos:exactMatch	ncit:C15359	Salvage Therapy	Salvage Therapy	orcid:0000-0001-9439-5346	CC0
+mesh:D016880	skos:exactMatch	ncit:C17442	Anisotropy	Anisotropy	orcid:0000-0001-9439-5346	CC0
+mesh:D016881	skos:exactMatch	ncit:C84891	Microsporidiosis	Microsporidiosis	orcid:0000-0001-9439-5346	CC0
+mesh:D016883	skos:exactMatch	ncit:C50530	Diabetic Ketoacidosis	Diabetic Ketoacidosis	orcid:0000-0001-9439-5346	CC0
+mesh:D016885	skos:exactMatch	ncit:C68708	United States Department of Agriculture	United States Department of Agriculture	orcid:0000-0001-9439-5346	CC0
+mesh:D017122	skos:exactMatch	ncit:C14302	Bacteriophage T4	Bacteriophage T4	orcid:0000-0001-9439-5346	CC0
+mesh:D017127	skos:exactMatch	ncit:C106312	Glycation End Products, Advanced	Advanced Glycation End Product	orcid:0000-0001-9439-5346	CC0
+mesh:D017128	skos:exactMatch	ncit:C52001	Embolectomy	Embolectomy	orcid:0000-0001-9439-5346	CC0
+mesh:D017129	skos:exactMatch	ncit:C128393	Anisakiasis	Anisakiasis	orcid:0000-0001-9439-5346	CC0
+mesh:D017131	skos:exactMatch	ncit:C52003	Thrombectomy	Thrombectomy	orcid:0000-0001-9439-5346	CC0
+mesh:D017130	skos:exactMatch	ncit:C51999	Angioplasty	Angioplasty	orcid:0000-0001-9439-5346	CC0
+mesh:D017135	skos:exactMatch	ncit:C47476	Desogestrel	Desogestrel	orcid:0000-0001-9439-5346	CC0
+mesh:D017136	skos:exactMatch	go:GO:0006811	Ion Transport	ion transport	orcid:0000-0001-9439-5346	CC0
+mesh:D017144	skos:exactMatch	ncit:C154589	Focus Groups	Focus Group	orcid:0000-0001-9439-5346	CC0
+mesh:D017245	skos:exactMatch	ncit:C71630	Foscarnet	Foscarnet	orcid:0000-0001-9439-5346	CC0
+mesh:D017242	skos:exactMatch	ncit:C97211	Complement Factor H	Complement Factor H	orcid:0000-0001-9439-5346	CC0
+mesh:D017252	skos:exactMatch	ncit:C38897	CD3 Complex	CD3 Complex	orcid:0000-0001-9439-5346	CC0
+mesh:D017255	skos:exactMatch	ncit:C985	Acitretin	Acitretin	orcid:0000-0001-9439-5346	CC0
+mesh:D017257	skos:exactMatch	chebi:CHEBI:8774	Ramipril	ramipril	orcid:0000-0001-9439-5346	CC0
+mesh:D017259	skos:exactMatch	chebi:CHEBI:81389	Dimaprit	Dimaprit	orcid:0000-0001-9439-5346	CC0
+mesh:D017241	skos:exactMatch	ncit:C84885	MELAS Syndrome	MELAS Syndrome	orcid:0000-0001-9439-5346	CC0
+mesh:D017239	skos:exactMatch	chebi:CHEBI:45863	Paclitaxel	paclitaxel	orcid:0000-0001-9439-5346	CC0
+mesh:D017229	skos:exactMatch	ncit:C128396	Enterobiasis	Enterobiasis	orcid:0000-0001-9439-5346	CC0
+mesh:D017228	skos:exactMatch	ncit:C20428	Hepatocyte Growth Factor	Hepatocyte Growth Factor	orcid:0000-0001-9439-5346	CC0
+mesh:D017240	skos:exactMatch	ncit:C101328	Mitochondrial Myopathies	Mitochondrial Myopathy	orcid:0000-0001-9439-5346	CC0
+mesh:D017270	skos:exactMatch	hgnc:6667	Lipoprotein(a)	LPA	orcid:0000-0001-9439-5346	CC0
+mesh:D017271	skos:exactMatch	ncit:C84654	Craniomandibular Disorders	Craniomandibular Disorder	orcid:0000-0001-9439-5346	CC0
+mesh:D017273	skos:exactMatch	chebi:CHEBI:5523	Goserelin	Goserelin	orcid:0000-0001-9439-5346	CC0
+mesh:D017274	skos:exactMatch	chebi:CHEBI:7445	Nafarelin	Nafarelin	orcid:0000-0001-9439-5346	CC0
+mesh:D017275	skos:exactMatch	chebi:CHEBI:6073	Isradipine	Isradipine	orcid:0000-0001-9439-5346	CC0
+mesh:D017279	skos:exactMatch	ncit:C1223	Selenocysteine	Selenocysteine	orcid:0000-0001-9439-5346	CC0
+mesh:D017280	skos:exactMatch	ncit:C28258	Condoms	Condom	orcid:0000-0001-9439-5346	CC0
+pr:PR:000037273	skos:exactMatch	uniprot.chain:PRO_0000013209	sonic hedgehog protein N-product	Sonic hedgehog protein N-product	orcid:0000-0001-9439-5346	CC0
+pr:PR:000025578	skos:exactMatch	uniprot.chain:PRO_0000000090	soluble APP-beta	Soluble APP-beta	orcid:0000-0001-9439-5346	CC0
+pr:PR:000025577	skos:exactMatch	uniprot.chain:PRO_0000000089	soluble APP-alpha	Soluble APP-alpha	orcid:0000-0001-9439-5346	CC0
+pr:PR:000035908	skos:exactMatch	uniprot.chain:PRO_0000413735	serine/threonine-protein kinase 4 37kDa subunit	Serine/threonine-protein kinase 4 37kDa subunit	orcid:0000-0001-9439-5346	CC0
+pr:PR:000035906	skos:exactMatch	uniprot.chain:PRO_0000413713	serine/threonine-protein kinase 3 36kDa subunit	Serine/threonine-protein kinase 3 36kDa subunit	orcid:0000-0001-9439-5346	CC0
+pr:PR:000025588	skos:exactMatch	uniprot.chain:PRO_0000000096	P3(40)	P3(40)	orcid:0000-0001-9439-5346	CC0
+pr:PR:000025587	skos:exactMatch	uniprot.chain:PRO_0000000095	P3(42)	P3(42)	orcid:0000-0001-9439-5346	CC0
+pr:PR:000001757	skos:exactMatch	uniprot.chain:PRO_0000030311	nuclear factor NF-kappa-B p50 subunit	Nuclear factor NF-kappa-B p50 subunit	orcid:0000-0001-9439-5346	CC0
+pr:PR:000025586	skos:exactMatch	uniprot.chain:PRO_0000000097	gamma-secretase C-terminal fragment 59	Gamma-secretase C-terminal fragment 59	orcid:0000-0003-4423-4370	CC0
+pr:PR:000025589	skos:exactMatch	uniprot.chain:PRO_0000000099	gamma-secretase C-terminal fragment 50	Gamma-secretase C-terminal fragment 50	orcid:0000-0003-4423-4370	CC0
+pr:PR:000025585	skos:exactMatch	uniprot.chain:PRO_0000000098	gamma-secretase C-terminal fragment 57	Gamma-secretase C-terminal fragment 57	orcid:0000-0003-4423-4370	CC0
+pr:PR:000050115	skos:exactMatch	uniprot.chain:PRO_0000042262	heparanase 50 kDa subunit	Heparanase 50 kDa subunit	orcid:0000-0003-4423-4370	CC0
+pr:PR:000025582	skos:exactMatch	uniprot.chain:PRO_0000384574	C80	C80	orcid:0000-0003-4423-4370	CC0
+pr:PR:000025581	skos:exactMatch	uniprot.chain:PRO_0000000094	C83	C83	orcid:0000-0003-4423-4370	CC0
+pr:PR:000025580	skos:exactMatch	uniprot.chain:PRO_0000000091	C99	C99	orcid:0000-0003-4423-4370	CC0
+mesh:C514899	skos:exactMatch	uniprot:P48147	PREP protein, human	PREP	orcid:0000-0003-4423-4370	CC0
+mesh:C077914	skos:exactMatch	uniprot:Q01954	BNC1 protein, human	BNC1	orcid:0000-0003-4423-4370	CC0
+mesh:C497562	skos:exactMatch	uniprot:P40938	RFC3 protein, human	RFC3	orcid:0000-0003-4423-4370	CC0
+mesh:C456923	skos:exactMatch	uniprot:Q8N0V4	LGI2 protein, human	LGI2	orcid:0000-0003-4423-4370	CC0
+mesh:C480021	skos:exactMatch	uniprot:P30838	ALDH3A1 protein, human	ALDH3A1	orcid:0000-0003-4423-4370	CC0
+mesh:C581575	skos:exactMatch	uniprot:Q9BT17	MTG1 protein, human	MTG1	orcid:0000-0003-4423-4370	CC0
+mesh:C079091	skos:exactMatch	uniprot:Q02410	APBA1 protein, human	APBA1	orcid:0000-0003-4423-4370	CC0
+mesh:C493728	skos:exactMatch	uniprot:Q01196	RUNX1 protein, human	RUNX1	orcid:0000-0003-4423-4370	CC0
+mesh:C488098	skos:exactMatch	uniprot:Q96CM4	NXNL1 protein, human	NXNL1	orcid:0000-0003-4423-4370	CC0
+mesh:C492913	skos:exactMatch	uniprot:P38398	BRCA1 protein, human	BRCA1	orcid:0000-0003-4423-4370	CC0
+mesh:C000621508	skos:exactMatch	uniprot:P55085	F2RL1 protein, human	F2RL1	orcid:0000-0003-4423-4370	CC0
+mesh:C490780	skos:exactMatch	uniprot:Q9UNN5	FAF1 protein, human	FAF1	orcid:0000-0003-4423-4370	CC0
+mesh:C497563	skos:exactMatch	uniprot:P35249	RFC4 protein, human	RFC4	orcid:0000-0003-4423-4370	CC0
+mesh:C496061	skos:exactMatch	uniprot:P49023	PXN protein, human	PXN	orcid:0000-0003-4423-4370	CC0
+mesh:C497651	skos:exactMatch	uniprot:Q00597	FANCC protein, human	FANCC	orcid:0000-0003-4423-4370	CC0
+mesh:C489785	skos:exactMatch	uniprot:Q9NR77	PXMP2 protein, human	PXMP2	orcid:0000-0003-4423-4370	CC0
+mesh:C489803	skos:exactMatch	uniprot:Q9NP90	RAB9B protein, human	RAB9B	orcid:0000-0003-4423-4370	CC0
+mesh:C497564	skos:exactMatch	uniprot:P40937	RFC5 protein, human	RFC5	orcid:0000-0003-4423-4370	CC0
+mesh:C512648	skos:exactMatch	uniprot:Q9Y266	NUDC protein, human	NUDC	orcid:0000-0003-4423-4370	CC0
+mesh:C431383	skos:exactMatch	uniprot:Q96JC9	EAF1 protein, human	EAF1	orcid:0000-0003-4423-4370	CC0
+mesh:C070699	skos:exactMatch	uniprot:Q14512	FGFBP1 protein, human	FGFBP1	orcid:0000-0003-4423-4370	CC0
+mesh:C000592900	skos:exactMatch	uniprot:Q86VR8	FJX1 protein, human	FJX1	orcid:0000-0003-4423-4370	CC0
+mesh:C098179	skos:exactMatch	uniprot:Q13045	FLII protein, human	FLII	orcid:0000-0003-4423-4370	CC0
+mesh:C530652	skos:exactMatch	uniprot:Q9UIV8	SERPINB13 protein, human	SERPINB13	orcid:0000-0003-4423-4370	CC0
+mesh:C492570	skos:exactMatch	uniprot:P22674	CCNO protein, human	CCNO	orcid:0000-0003-4423-4370	CC0
+mesh:C094154	skos:exactMatch	uniprot:P55082	MFAP3 protein, human	MFAP3	orcid:0000-0003-4423-4370	CC0
+mesh:C578035	skos:exactMatch	uniprot:Q02078	MEF2A protein, human	MEF2A	orcid:0000-0003-4423-4370	CC0
+mesh:C496469	skos:exactMatch	uniprot:Q5TCQ9	MAGI3 protein, human	MAGI3	orcid:0000-0003-4423-4370	CC0
+pr:PR:000035910	skos:exactMatch	uniprot.chain:PRO_0000002981	coagulation factor V light chain	Coagulation factor V light chain	orcid:0000-0003-4423-4370	CC0
+uniprot.chain:PRO_0000005909	speciesSpecific	pr:PR:000050120	Complement C3 alpha chain	complement C3 alpha chain	orcid:0000-0003-4423-4370	CC0
+pr:PR:000050114	skos:exactMatch	uniprot.chain:PRO_0000042260	heparanase 8 kDa subunit	Heparanase 8 kDa subunit	orcid:0000-0003-4423-4370	CC0
+pr:PR:000050188	skos:exactMatch	uniprot.chain:PRO_0000014901	polymeric immunoglobulin receptor secretory component	Secretory component	orcid:0000-0003-4423-4370	CC0
+mesh:C495815	skos:exactMatch	uniprot:Q9Y281	CFL2 protein, human	CFL2	orcid:0000-0003-4423-4370	CC0
+mesh:C497121	skos:exactMatch	uniprot:Q02447	SP3 protein, human	SP3	orcid:0000-0003-4423-4370	CC0
+mesh:C091671	skos:exactMatch	uniprot:P46094	XCR1 protein, human	XCR1	orcid:0000-0003-4423-4370	CC0
+mesh:C099100	skos:exactMatch	uniprot:Q9BRK5	SDF4 protein, human	SDF4	orcid:0000-0003-4423-4370	CC0
+mesh:C000631507	skos:exactMatch	uniprot:Q9H8S5	CNTD2 protein, human	CNTD2	orcid:0000-0003-4423-4370	CC0
+mesh:C497453	skos:exactMatch	uniprot:P41134	ID1 protein, human	ID1	orcid:0000-0003-4423-4370	CC0
+mesh:C497442	skos:exactMatch	uniprot:Q16665	HIF1A protein, human	HIF1A	orcid:0000-0003-4423-4370	CC0
+mesh:C115114	skos:exactMatch	uniprot:Q9H2X6	HIPK2 protein, human	HIPK2	orcid:0000-0003-4423-4370	CC0
+mesh:C109102	skos:exactMatch	uniprot:Q9H422	HIPK3 protein, human	HIPK3	orcid:0000-0003-4423-4370	CC0
+mesh:C526744	skos:exactMatch	uniprot:Q9NR71	ASAH2 protein, human	ASAH2	orcid:0000-0003-4423-4370	CC0
+mesh:C000656407	skos:exactMatch	uniprot:Q96H12	MSANTD3 protein, human	MSANTD3	orcid:0000-0003-4423-4370	CC0
+mesh:C000656449	skos:exactMatch	uniprot:Q9NRY5	FAM114A2 protein, human	FAM114A2	orcid:0000-0003-4423-4370	CC0
+mesh:C496590	skos:exactMatch	uniprot:P49406	MRPL19 protein, human	MRPL19	orcid:0000-0003-4423-4370	CC0
+mesh:C519405	skos:exactMatch	uniprot:Q9Y5T4	DNAJC15 protein, human	DNAJC15	orcid:0000-0003-4423-4370	CC0
+mesh:C486655	skos:exactMatch	uniprot:Q96LC9	BMF protein, human	BMF	orcid:0000-0003-4423-4370	CC0
+mesh:C439386	skos:exactMatch	uniprot:Q9BYW1	SLC2A11 protein, human	SLC2A11	orcid:0000-0003-4423-4370	CC0
+mesh:C103258	skos:exactMatch	uniprot:Q14566	MCM6 protein, human	MCM6	orcid:0000-0003-4423-4370	CC0
+mesh:C502654	skos:exactMatch	uniprot:Q8IXM3	MRPL41 protein, human	MRPL41	orcid:0000-0003-4423-4370	CC0
+mesh:C100930	skos:exactMatch	uniprot:Q13405	MRPL49 protein, human	MRPL49	orcid:0000-0003-4423-4370	CC0
+mesh:C089821	skos:exactMatch	uniprot:Q96HJ5	MS4A3 protein, human	MS4A3	orcid:0000-0003-4423-4370	CC0
+mesh:C424714	skos:exactMatch	uniprot:Q96JQ5	MS4A4A protein, human	MS4A4A	orcid:0000-0003-4423-4370	CC0
+pr:PR:000050122	skos:exactMatch	uniprot.chain:PRO_0000005910	C3 anaphylatoxin	C3a anaphylatoxin	orcid:0000-0003-4423-4370	CC0
+mesh:C054369	skos:exactMatch	uniprot:P10636	MAPT protein, human	MAPT	orcid:0000-0003-4423-4370	CC0
+mesh:D001064	skos:exactMatch	ncit:C35145	Appendicitis	Appendicitis	orcid:0000-0003-4423-4370	CC0
+mesh:D000072000	skos:exactMatch	ncit:C17678	NF-KappaB Inhibitor alpha	NF-Kappa-B Inhibitor Alpha	orcid:0000-0003-4423-4370	CC0
+mesh:D001062	skos:exactMatch	ncit:C51687	Appendectomy	Appendectomy	orcid:0000-0003-4423-4370	CC0
+mesh:D003785	skos:exactMatch	ncit:C63715	Dental Pulp Capping	Dental Pulp Capping	orcid:0000-0003-4423-4370	CC0
+mesh:D001065	skos:exactMatch	ncit:C12380	Appendix	Appendix	orcid:0000-0003-4423-4370	CC0
+mesh:D000075927	skos:exactMatch	ncit:C25772	KRIT1 Protein	Krev Interaction Trapped Protein 1	orcid:0000-0003-4423-4370	CC0
+mesh:C012566	skos:exactMatch	ncit:C2639	taurolidine	Taurolidine	orcid:0000-0003-4423-4370	CC0
+mesh:D013654	skos:exactMatch	chebi:CHEBI:15891	Taurine	taurine	orcid:0000-0003-4423-4370	CC0
+mesh:D013656	skos:exactMatch	chebi:CHEBI:28865	Taurocholic Acid	taurocholic acid	orcid:0000-0003-4423-4370	CC0
+mesh:D013657	skos:exactMatch	chebi:CHEBI:9410	Taurodeoxycholic Acid	taurodeoxycholic acid	orcid:0000-0003-4423-4370	CC0
+mesh:D013658	skos:exactMatch	chebi:CHEBI:36259	Taurolithocholic Acid	taurolithocholic acid	orcid:0000-0003-4423-4370	CC0
+pr:PR:000050069	skos:exactMatch	uniprot.chain:PRO_0000005002	voltage-dependent calcium channel subunit delta-1	Voltage-dependent calcium channel subunit delta-1	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050130	skos:exactMatch	uniprot.chain:PRO_0000005914	complement C3g fragment	Complement C3g fragment	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050127	skos:exactMatch	uniprot.chain:PRO_0000005913	complement C3dg fragment	Complement C3dg fragment	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050131	skos:exactMatch	uniprot.chain:PRO_0000005915	complement C3d fragment	Complement C3d fragment	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050119	skos:exactMatch	uniprot.chain:PRO_0000005908	complement C3 beta chain	Complement C3 beta chain	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050124	skos:exactMatch	uniprot.chain:PRO_0000005911	complement C3b alpha' chain	Complement C3b alpha' chain	orcid:0000-0001-9439-5346	CC0
+pr:PR:000035934	skos:exactMatch	uniprot.chain:PRO_0000027759	coagulation factor IXa heavy chain	Coagulation factor IXa heavy chain	orcid:0000-0001-9439-5346	CC0
+pr:PR:000003367	skos:exactMatch	uniprot.chain:PRO_0000005731	chondrocalcin	Chondrocalcin	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050089	skos:exactMatch	uniprot.chain:PRO_0000004641	caspase-9 subunit p35	Caspase-9 subunit p35	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050090	skos:exactMatch	uniprot.chain:PRO_0000004643	caspase-9 subunit p10	Caspase-9 subunit p10	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002459	skos:exactMatch	uniprot.chain:PRO_0000004617	caspase-7 subunit p20	Caspase-7 subunit p20	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002458	skos:exactMatch	uniprot.chain:PRO_0000004619	caspase-7 subunit p11	Caspase-7 subunit p11	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002457	skos:exactMatch	uniprot.chain:PRO_0000004609	caspase-6 subunit p18	Caspase-6 subunit p18	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002456	skos:exactMatch	uniprot.chain:PRO_0000004611	caspase-6 subunit p11	Caspase-6 subunit p11	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002451	skos:exactMatch	uniprot.chain:PRO_0000004542	caspase-2 subunit p18	Caspase-2 subunit p18	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002452	skos:exactMatch	uniprot.chain:PRO_0000004544	caspase-2 subunit p13	Caspase-2 subunit p13	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036012	skos:exactMatch	uniprot.chain:PRO_0000420659	angiotensin 1-9	Angiotensin 1-9	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036013	skos:exactMatch	uniprot.chain:PRO_0000420660	angiotensin 1-7	Angiotensin 1-7	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050121	skos:exactMatch	uniprot.chain:PRO_0000430430	C3-beta-c	C3-beta-c	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002453	skos:exactMatch	uniprot.chain:PRO_0000004545	caspase-2 subunit p12	Caspase-2 subunit p12	orcid:0000-0001-9439-5346	CC0
+pr:PR:000035724	skos:exactMatch	uniprot.chain:PRO_0000396434	60S ribosomal protein L40	60S ribosomal protein L40	orcid:0000-0001-9439-5346	CC0
+pr:PR:000035936	skos:exactMatch	uniprot.chain:PRO_0000027791	activated factor Xa heavy chain	Activated factor Xa heavy chain	orcid:0000-0001-9439-5346	CC0
+mesh:D066293	skos:exactMatch	ncit:C33463	Renshaw Cells	Renshaw Cell	orcid:0000-0001-9439-5346	CC0
+mesh:D066292	skos:exactMatch	go:GO:0005811	Lipid Droplets	lipid droplet	orcid:0000-0001-9439-5346	CC0
+mesh:D066271	skos:exactMatch	ncit:C32550	External Capsule	External Capsule	orcid:0000-0001-9439-5346	CC0
+mesh:D066270	skos:exactMatch	ncit:C93209	Social Capital	Social Capital	orcid:0000-0001-9439-5346	CC0
+mesh:D066261	skos:exactMatch	ncit:C105920	Epigen	Epigen	orcid:0000-0001-9439-5346	CC0
+mesh:D066259	skos:exactMatch	ncit:C20432	Betacellulin	Betacellulin	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036062	skos:exactMatch	uniprot.chain:PRO_0000004629	caspase-8 isoform 1 cleaved 1	Caspase-8 subunit p18	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036064	skos:exactMatch	uniprot.chain:PRO_0000004631	caspase-8 isoform 1 cleaved 2	Caspase-8 subunit p10	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002449	skos:exactMatch	uniprot.chain:PRO_0000004522	caspase-1 isoform 1 cleaved 1	Caspase-1 subunit p20	orcid:0000-0001-9439-5346	CC0
+mesh:D066248	skos:exactMatch	ncit:C87668	High Fructose Corn Syrup	High Fructose Corn Syrup	orcid:0000-0001-9439-5346	CC0
+mesh:D066247	skos:exactMatch	hgnc:3432	Receptor, ErbB-4	ERBB4	orcid:0000-0001-9439-5346	CC0
+mesh:D066126	skos:exactMatch	ncit:C27994	Cardiotoxicity	Cardiotoxicity	orcid:0000-0001-9439-5346	CC0
+mesh:D066127	skos:exactMatch	ncit:C33892	White Matter	White Matter	orcid:0000-0001-9439-5346	CC0
+mesh:D066128	skos:exactMatch	ncit:C32695	Gray Matter	Gray Matter	orcid:0000-0001-9439-5346	CC0
+mesh:D066166	skos:exactMatch	ncit:C168385	Pectus Carinatum	Pectus Carinatum	orcid:0000-0001-9439-5346	CC0
+mesh:D066186	skos:exactMatch	ncit:C32391	Costal Cartilage	Costal Cartilage	orcid:0000-0001-9439-5346	CC0
+mesh:D066191	skos:exactMatch	ncit:C154777	Sensorimotor Cortex	Sensorimotor Cortex	orcid:0000-0001-9439-5346	CC0
+mesh:D066233	skos:exactMatch	ncit:C18740	Psychology, Developmental	Developmental Psychology	orcid:0000-0001-9439-5346	CC0
+mesh:D066235	skos:exactMatch	ncit:C146991	Fluorine-19 Magnetic Resonance Imaging	Fluorine-19 Magnetic Resonance Imaging	orcid:0000-0001-9439-5346	CC0
+mesh:D066066	skos:exactMatch	ncit:C49164	Response Evaluation Criteria in Solid Tumors	Response Evaluation Criteria in Solid Tumors	orcid:0000-0001-9439-5346	CC0
+mesh:D066027	skos:exactMatch	ncit:C159659	Transplant Recipients	Transplant Recipient	orcid:0000-0001-9439-5346	CC0
+mesh:D066007	skos:exactMatch	ncit:C90478	Toxicokinetics	Toxicokinetics	orcid:0000-0001-9439-5346	CC0
+mesh:D065927	skos:exactMatch	efo:0005191	Waist-Height Ratio	waist height ratio	orcid:0000-0001-9439-5346	CC0
+mesh:D065886	skos:exactMatch	efo:0010642	Neurodevelopmental Disorders	Neurodevelopmental disorder	orcid:0000-0001-9439-5346	CC0
+mesh:D065866	skos:exactMatch	ncit:C33218	Optic Tract	Optic Tract	orcid:0000-0001-9439-5346	CC0
+mesh:D065850	skos:exactMatch	ncit:C32291	Cerebral Peduncle	Cerebral Peduncle	orcid:0000-0001-9439-5346	CC0
+mesh:D065843	skos:exactMatch	ncit:C32409	Cerebral Crus	Crus Cerebri	orcid:0000-0001-9439-5346	CC0
+mesh:D065819	skos:exactMatch	ncit:C1707	Voriconazole	Voriconazole	orcid:0000-0001-9439-5346	CC0
+mesh:D065842	skos:exactMatch	ncit:C97341	Pars Compacta	Pars Compacta	orcid:0000-0001-9439-5346	CC0
+mesh:D065631	skos:exactMatch	doid:DOID:4481	Rhinitis, Allergic	allergic rhinitis	orcid:0000-0001-9439-5346	CC0
+mesh:D065707	skos:exactMatch	ncit:C99056	Schizencephaly	Schizencephaly	orcid:0000-0001-9439-5346	CC0
+mesh:D065527	skos:exactMatch	ncit:C157799	Brachial Plexus Block	Brachial Plexus Block	orcid:0000-0001-9439-5346	CC0
+mesh:D065108	skos:exactMatch	ncit:C2088	Ornithine Decarboxylase Inhibitors	Ornithine Decarboxylase Inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D065168	skos:exactMatch	chebi:CHEBI:68557	Bradykinin Receptor Antagonists	bradykinin receptor antagonist	orcid:0000-0001-9439-5346	CC0
+mesh:D065170	skos:exactMatch	ncit:C92730	Pregnancy, Angular	Angular Pregnancy	orcid:0000-0001-9439-5346	CC0
+mesh:D065171	skos:exactMatch	chebi:CHEBI:50792	Estrogen Receptor Antagonists	estrogen receptor antagonist	orcid:0000-0001-9439-5346	CC0
+mesh:D065173	skos:exactMatch	ncit:C92761	Pregnancy, Cornual	Cornual Pregnancy	orcid:0000-0001-9439-5346	CC0
+mesh:D065207	skos:exactMatch	ncit:C171516	Middle East Respiratory Syndrome Coronavirus	Middle East Respiratory Syndrome Coronavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D065290	skos:exactMatch	efo:0007949	Acute-On-Chronic Liver Failure	acute-on-chronic liver failure	orcid:0000-0001-9439-5346	CC0
+mesh:D065306	skos:exactMatch	ncit:C35392	Corneal Injuries	Corneal Injury	orcid:0000-0001-9439-5346	CC0
+mesh:D065326	skos:exactMatch	ncit:C157359	Children's Health Insurance Program	Children's Health Insurance Program	orcid:0000-0001-9439-5346	CC0
+mesh:D065426	skos:exactMatch	ncit:C132068	Cytoreduction Surgical Procedures	Cytoreductive Surgery	orcid:0000-0001-9439-5346	CC0
+mesh:D065102	skos:exactMatch	ncit:C20822	Licensed Practical Nurses	Licensed Practical Nurse	orcid:0000-0001-9439-5346	CC0
+mesh:D064966	skos:exactMatch	ncit:C17653	British Virgin Islands	Virgin Islands, British	orcid:0000-0001-9439-5346	CC0
+mesh:D064888	skos:exactMatch	ncit:C16084	Observational Study	Observational Study	orcid:0000-0001-9439-5346	CC0
+mesh:D064886	skos:exactMatch	ncit:C47824	Dataset	Data Set	orcid:0000-0001-9439-5346	CC0
+mesh:D064878	skos:exactMatch	ncit:C142748	Web Browser	Web Browser	orcid:0000-0001-9439-5346	CC0
+mesh:D064847	skos:exactMatch	ncit:C19341	Multimodal Imaging	Multimodal Imaging	orcid:0000-0001-9439-5346	CC0
+mesh:D064890	skos:exactMatch	ncit:C171586	Social Determinants of Health	Social Determinants of Health	orcid:0000-0001-9439-5346	CC0
+mesh:D064794	skos:exactMatch	chebi:CHEBI:135646	Lorajmine	lorajmine	orcid:0000-0001-9439-5346	CC0
+mesh:D064750	skos:exactMatch	chebi:CHEBI:8768	Rabeprazole	rabeprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D064748	skos:exactMatch	ncit:C73192	Dexlansoprazole	Dexlansoprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D064747	skos:exactMatch	ncit:C29150	Lansoprazole	Lansoprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D064751	skos:exactMatch	chebi:CHEBI:35276	Ammonium Compounds	ammonium compound	orcid:0000-0001-9439-5346	CC0
+mesh:D064791	skos:exactMatch	ncit:C65369	Desoxycorticosterone Acetate	Desoxycorticosterone Acetate	orcid:0000-0001-9439-5346	CC0
+mesh:D065026	skos:exactMatch	ncit:C77962	Hope	Hope	orcid:0000-0001-9439-5346	CC0
+mesh:D064696	skos:exactMatch	ncit:C66870	Zuclomiphene	Zuclomiphene	orcid:0000-0001-9439-5346	CC0
+mesh:D064695	skos:exactMatch	ncit:C28211	Enclomiphene	Enclomiphene	orcid:0000-0001-9439-5346	CC0
+mesh:D064692	skos:exactMatch	ncit:C29104	Hyoscyamine	Hyoscyamine	orcid:0000-0001-9439-5346	CC0
+mesh:D064704	skos:exactMatch	ncit:C1586	Levofloxacin	Levofloxacin	orcid:0000-0001-9439-5346	CC0
+mesh:D064705	skos:exactMatch	ncit:C76546	Racepinephrine	Racepinephrine	orcid:0000-0001-9439-5346	CC0
+mesh:D064730	skos:exactMatch	ncit:C1333	Dexrazoxane	Dexrazoxane	orcid:0000-0001-9439-5346	CC0
+mesh:D064906	skos:exactMatch	ncit:C93098	Qigong	Qigong	orcid:0000-0001-9439-5346	CC0
+mesh:D064591	skos:exactMatch	ncit:C60701	Allografts	Allograft	orcid:0000-0001-9439-5346	CC0
+mesh:D064652	skos:exactMatch	ncit:C32183	Basal Bodies	Basal Body	orcid:0000-0001-9439-5346	CC0
+mesh:D064650	skos:exactMatch	ncit:C20883	Home Health Nursing	Home Health Nursing	orcid:0000-0001-9439-5346	CC0
+mesh:D064648	skos:exactMatch	ncit:C17602	Critical Care Nursing	Critical Care Nursing	orcid:0000-0001-9439-5346	CC0
+mesh:D064706	skos:exactMatch	hp:HP:0031801	Vocal Cord Dysfunction	Vocal cord dysfunction	orcid:0000-0001-9439-5346	CC0
+mesh:D064386	skos:exactMatch	efo:0009615	Ankle Fractures	ankle fracture	orcid:0000-0001-9439-5346	CC0
+mesh:D064346	skos:exactMatch	ncit:C87054	Sagittal Abdominal Diameter	Sagittal Abdominal Diameter	orcid:0000-0001-9439-5346	CC0
+mesh:D064232	skos:exactMatch	ncit:C121547	Visual Analog Scale	Visual Analog Scale	orcid:0000-0001-9439-5346	CC0
+mesh:D064209	skos:exactMatch	ncit:C28269	Phytochemicals	Phytochemical	orcid:0000-0001-9439-5346	CC0
+mesh:D064208	skos:exactMatch	ncit:C86135	Aggregatibacter segnis	Aggregatibacter segnis	orcid:0000-0001-9439-5346	CC0
+mesh:D064206	skos:exactMatch	ncit:C86132	Aggregatibacter	Aggregatibacter	orcid:0000-0001-9439-5346	CC0
+mesh:D064207	skos:exactMatch	ncit:C86134	Aggregatibacter aphrophilus	Aggregatibacter aphrophilus	orcid:0000-0001-9439-5346	CC0
+mesh:D064166	skos:exactMatch	ncit:C69183	Vaccine Potency	Vaccine Potency	orcid:0000-0001-9439-5346	CC0
+mesh:D064048	skos:exactMatch	ncit:C13365	Spindle Pole Bodies	Spindle Pole Body	orcid:0000-0001-9439-5346	CC0
+mesh:D064047	skos:exactMatch	go:GO:0000922	Spindle Poles	spindle pole	orcid:0000-0001-9439-5346	CC0
+mesh:D064068	skos:exactMatch	ncit:C45426	Collagenous Sprue	Collagenous Sprue	orcid:0000-0001-9439-5346	CC0
+mesh:D064090	skos:exactMatch	ncit:C9184	Intraocular Lymphoma	Intraocular Lymphoma	orcid:0000-0001-9439-5346	CC0
+mesh:D064096	skos:exactMatch	ncit:C30006	Aurora Kinase A	Aurora Kinase A	orcid:0000-0001-9439-5346	CC0
+mesh:D064098	skos:exactMatch	ncit:C65538	Esomeprazole	Esomeprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D064107	skos:exactMatch	ncit:C68596	Aurora Kinase B	Aurora Kinase B	orcid:0000-0001-9439-5346	CC0
+mesh:D064108	skos:exactMatch	ncit:C95267	Aurora Kinase C	Aurora Kinase C	orcid:0000-0001-9439-5346	CC0
+mesh:D063990	skos:exactMatch	ncit:C43520	Gene Ontology	Gene Ontology	orcid:0000-0001-9439-5346	CC0
+mesh:D063826	skos:exactMatch	ncit:C123740	Kosovo	Kosovo	orcid:0000-0001-9439-5346	CC0
+mesh:D063806	skos:exactMatch	ncit:C27009	Myalgia	Myalgia	orcid:0000-0001-9439-5346	CC0
+mesh:D063766	skos:exactMatch	ncit:C84449	Pediatric Obesity	Childhood Obesity	orcid:0000-0001-9439-5346	CC0
+mesh:D063646	skos:exactMatch	ncit:C18078	Carcinogenesis	Carcinogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D063325	skos:exactMatch	chebi:CHEBI:32220	Tiapride Hydrochloride	Tiapride hydrochloride	orcid:0000-0001-9439-5346	CC0
+mesh:D063386	skos:exactMatch	chebi:CHEBI:67072	Cannabinoid Receptor Agonists	cannabinoid receptor agonist	orcid:0000-0001-9439-5346	CC0
+mesh:D063426	skos:exactMatch	ncit:C15422	Human Migration	Human Migration	orcid:0000-0001-9439-5346	CC0
+mesh:D063546	skos:exactMatch	go:GO:0020011	Apicoplasts	apicoplast	orcid:0000-0001-9439-5346	CC0
+mesh:D063388	skos:exactMatch	chebi:CHEBI:67197	Endocannabinoids	endocannabinoid	orcid:0000-0001-9439-5346	CC0
+mesh:D063088	skos:exactMatch	chebi:CHEBI:17102	Phosphoramides	phosphoramide	orcid:0000-0001-9439-5346	CC0
+mesh:D063005	skos:exactMatch	ncit:C18229	Health Information Systems	Health Information System	orcid:0000-0001-9439-5346	CC0
+mesh:D063126	skos:exactMatch	ncit:C157795	Balloon Valvuloplasty	Balloon Valvuloplasty	orcid:0000-0001-9439-5346	CC0
+mesh:D062907	skos:exactMatch	chebi:CHEBI:30744	Oxaloacetic Acid	oxaloacetic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D062745	skos:exactMatch	ncit:C118593	Junctional Adhesion Molecule A	Junctional Adhesion Molecule A	orcid:0000-0001-9439-5346	CC0
+mesh:D062689	skos:exactMatch	ncit:C27483	Lipoblastoma	Lipoblastoma	orcid:0000-0001-9439-5346	CC0
+mesh:D062559	skos:exactMatch	hgnc:10582	NAV1.8 Voltage-Gated Sodium Channel	SCN10A	orcid:0000-0001-9439-5346	CC0
+mesh:D062408	skos:exactMatch	ncit:C80249	Breakfast	Breakfast	orcid:0000-0001-9439-5346	CC0
+mesh:D062409	skos:exactMatch	ncit:C80250	Lunch	Lunch	orcid:0000-0001-9439-5346	CC0
+mesh:D062485	skos:exactMatch	ncit:C121558	Breath Holding	Breath Holding	orcid:0000-0001-9439-5346	CC0
+mesh:D062445	skos:exactMatch	hgnc:2032	Claudin-1	CLDN1	orcid:0000-0001-9439-5346	CC0
+mesh:D062446	skos:exactMatch	hgnc:2041	Claudin-2	CLDN2	orcid:0000-0001-9439-5346	CC0
+mesh:D062465	skos:exactMatch	hgnc:2045	Claudin-3	CLDN3	orcid:0000-0001-9439-5346	CC0
+mesh:D062506	skos:exactMatch	hgnc:2046	Claudin-4	CLDN4	orcid:0000-0001-9439-5346	CC0
+mesh:D062507	skos:exactMatch	hgnc:2047	Claudin-5	CLDN5	orcid:0000-0001-9439-5346	CC0
+mesh:D066249	skos:exactMatch	ncit:C41365	Craving	Craving	orcid:0000-0001-9439-5346	CC0
+mesh:D064703	skos:exactMatch	ncit:C71290	Family Nurse Practitioners	Family Nurse Practitioner	orcid:0000-0001-9439-5346	CC0
+mesh:D064690	skos:exactMatch	chebi:CHEBI:77567	Wakefulness-Promoting Agents	eugeroic	orcid:0000-0001-9439-5346	CC0
+mesh:D020169	skos:exactMatch	ncit:C18153	Caspases	Caspase	orcid:0000-0001-9439-5346	CC0
+mesh:D020170	skos:exactMatch	hgnc:1499	Caspase 1	CASP1	orcid:0000-0001-9439-5346	CC0
+mesh:D053148	skos:exactMatch	hgnc:1504	Caspase 3	CASP3	orcid:0000-0001-9439-5346	CC0
+mesh:D053178	skos:exactMatch	hgnc:1507	Caspase 6	CASP6	orcid:0000-0001-9439-5346	CC0
+mesh:D053455	skos:exactMatch	hgnc:1500	Caspase 10	CASP10	orcid:0000-0001-9439-5346	CC0
+mesh:D053456	skos:exactMatch	hgnc:1502	Caspase 14	CASP14	orcid:0000-0001-9439-5346	CC0
+mesh:C033246	skos:exactMatch	ncit:C121971	prostaglandin E3	Prostaglandin E3	orcid:0000-0001-9439-5346	CC0
+mesh:D011448	skos:exactMatch	chebi:CHEBI:49023	Prostaglandin Antagonists	prostaglandin antagonist	orcid:0000-0001-9439-5346	CC0
+mesh:D011453	skos:exactMatch	ncit:C782	Prostaglandins	Prostaglandin	orcid:0000-0001-9439-5346	CC0
+mesh:D011454	skos:exactMatch	chebi:CHEBI:26334	Prostaglandins A	prostaglandins A	orcid:0000-0001-9439-5346	CC0
+mesh:D011456	skos:exactMatch	chebi:CHEBI:26335	Prostaglandins B	prostaglandins B	orcid:0000-0001-9439-5346	CC0
+mesh:D011457	skos:exactMatch	chebi:CHEBI:26337	Prostaglandins D	prostaglandins D	orcid:0000-0001-9439-5346	CC0
+mesh:D011458	skos:exactMatch	chebi:CHEBI:26338	Prostaglandins E	prostaglandins E	orcid:0000-0001-9439-5346	CC0
+mesh:D011460	skos:exactMatch	chebi:CHEBI:26340	Prostaglandins F	prostaglandins F	orcid:0000-0001-9439-5346	CC0
+mesh:D011462	skos:exactMatch	chebi:CHEBI:26343	Prostaglandins G	prostaglandins G	orcid:0000-0001-9439-5346	CC0
+mesh:D011463	skos:exactMatch	chebi:CHEBI:26344	Prostaglandins H	prostaglandins H	orcid:0000-0001-9439-5346	CC0
+mesh:D015230	skos:exactMatch	chebi:CHEBI:15555	Prostaglandin D2	prostaglandin D2	orcid:0000-0001-9439-5346	CC0
+mesh:D044062	skos:exactMatch	chebi:CHEBI:26345	Prostaglandins I	prostaglandins I	orcid:0000-0001-9439-5346	CC0
+mesh:D044262	skos:exactMatch	chebi:CHEBI:15554	Prostaglandin H2	prostaglandin H2	orcid:0000-0001-9439-5346	CC0
+mesh:C000606551	skos:exactMatch	ncit:C152185	remdesivir	Remdesivir	orcid:0000-0001-9439-5346	CC0
+mesh:C000623728	skos:exactMatch	ncit:C112409	Rhinovirus C	Rhinovirus C	orcid:0000-0001-9439-5346	CC0
+mesh:C000623735	skos:exactMatch	ncit:C112408	Rhinovirus B	Rhinovirus B	orcid:0000-0001-9439-5346	CC0
+mesh:C000623787	skos:exactMatch	ncit:C112407	Rhinovirus A	Rhinovirus A	orcid:0000-0001-9439-5346	CC0
+mesh:C000592662	skos:exactMatch	ncit:C171848	DORAVIRINE	Doravirine	orcid:0000-0001-9439-5346	CC0
+mesh:C063638	skos:exactMatch	ncit:C82253	lobucavir	Lobucavir	orcid:0000-0001-9439-5346	CC0
+mesh:C066100	skos:exactMatch	ncit:C118556	poliovirus receptor	Poliovirus Receptor	orcid:0000-0001-9439-5346	CC0
+mesh:C053001	skos:exactMatch	ncit:C61526	adefovir	Adefovir	orcid:0000-0001-9439-5346	CC0
+mesh:C083858	skos:exactMatch	ncit:C73147	emivirine	Emivirine	orcid:0000-0001-9439-5346	CC0
+mesh:C087098	skos:exactMatch	ncit:C26677	virulizin	Virulizin	orcid:0000-0001-9439-5346	CC0
+mesh:C098320	skos:exactMatch	ncit:C29027	efavirenz	Efavirenz	orcid:0000-0001-9439-5346	CC0
+mesh:C107733	skos:exactMatch	ncit:C1786	cyanovirin N	Cyanovirin-N	orcid:0000-0001-9439-5346	CC0
+mesh:C414210	skos:exactMatch	ncit:C81611	peramivir	Peramivir	orcid:0000-0001-9439-5346	CC0
+mesh:C400401	skos:exactMatch	ncit:C82254	maribavir	Maribavir	orcid:0000-0001-9439-5346	CC0
+mesh:C118874	skos:exactMatch	ncit:C82255	rupintrivir	Rupintrivir	orcid:0000-0001-9439-5346	CC0
+mesh:C453221	skos:exactMatch	ncit:C136516	pritelivir	Pritelivir	orcid:0000-0001-9439-5346	CC0
+mesh:C462182	skos:exactMatch	ncit:C81605	favipiravir	Favipiravir	orcid:0000-0001-9439-5346	CC0
+mesh:C481671	skos:exactMatch	ncit:C73205	Dapivirine	Dapivirine	orcid:0000-0001-9439-5346	CC0
+mesh:C497721	skos:exactMatch	ncit:C66453	pradefovir	Pradefovir	orcid:0000-0001-9439-5346	CC0
+mesh:C505045	skos:exactMatch	ncit:C81606	Tecovirimat	Tecovirimat	orcid:0000-0001-9439-5346	CC0
+mesh:C549273	skos:exactMatch	ncit:C114981	daclatasvir	Daclatasvir	orcid:0000-0001-9439-5346	CC0
+mesh:C525733	skos:exactMatch	ncit:C90587	brincidofovir	Brincidofovir	orcid:0000-0001-9439-5346	CC0
+mesh:D000068696	skos:exactMatch	ncit:C76929	Rilpivirine	Rilpivirine	orcid:0000-0001-9439-5346	CC0
+mesh:D000068698	skos:exactMatch	ncit:C29490	Tenofovir	Tenofovir	orcid:0000-0001-9439-5346	CC0
+mesh:D000068898	skos:exactMatch	ncit:C73823	Raltegravir Potassium	Raltegravir Potassium	orcid:0000-0001-9439-5346	CC0
+mesh:D000069446	skos:exactMatch	ncit:C28835	Atazanavir Sulfate	Atazanavir Sulfate	orcid:0000-0001-9439-5346	CC0
+mesh:D000069454	skos:exactMatch	chebi:CHEBI:367163	Darunavir	darunavir	orcid:0000-0001-9439-5346	CC0
+mesh:D000069474	skos:exactMatch	ncit:C101263	Sofosbuvir	Sofosbuvir	orcid:0000-0001-9439-5346	CC0
+mesh:D000069616	skos:exactMatch	ncit:C129015	Simeprevir	Simeprevir	orcid:0000-0001-9439-5346	CC0
+mesh:D000071243	skos:exactMatch	ncit:C128423	Zika Virus Infection	Zika Virus Infection	orcid:0000-0001-9439-5346	CC0
+mesh:D000071244	skos:exactMatch	ncit:C128553	Zika Virus	Zika Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D000072230	skos:exactMatch	ncit:C120598	Sustained Virologic Response	Sustained Virologic Response	orcid:0000-0001-9439-5346	CC0
+mesh:D000072596	skos:exactMatch	ncit:C116608	Hepatitis A Virus Cellular Receptor 1	Hepatitis A Virus Cellular Receptor 1	orcid:0000-0001-9439-5346	CC0
+mesh:D000072597	skos:exactMatch	ncit:C104278	Hepatitis A Virus Cellular Receptor 2	Hepatitis A Virus Cellular Receptor 2	orcid:0000-0001-9439-5346	CC0
+mesh:D000073638	skos:exactMatch	ncit:C119319	Alphacoronavirus	Alphacoronavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D000073640	skos:exactMatch	ncit:C113207	Betacoronavirus	Betacoronavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D000073642	skos:exactMatch	ncit:C122313	Gammacoronavirus	Gammacoronavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D000077483	skos:exactMatch	ncit:C28235	Valacyclovir	Valacyclovir	orcid:0000-0001-9439-5346	CC0
+mesh:D000077560	skos:exactMatch	ncit:C2105	Enfuvirtide	Enfuvirtide	orcid:0000-0001-9439-5346	CC0
+mesh:D000077562	skos:exactMatch	ncit:C2629	Valganciclovir	Valganciclovir	orcid:0000-0001-9439-5346	CC0
+mesh:D000077592	skos:exactMatch	ncit:C73144	Maraviroc	Maraviroc	orcid:0000-0001-9439-5346	CC0
+mesh:D000077595	skos:exactMatch	ncit:C29044	Famciclovir	Famciclovir	orcid:0000-0001-9439-5346	CC0
+mesh:D000080309	skos:exactMatch	ncit:C169106	Environmental DNA	Environmental DNA	orcid:0000-0001-9439-5346	CC0
+mesh:D000077404	skos:exactMatch	ncit:C1600	Cidofovir	Cidofovir	orcid:0000-0001-9439-5346	CC0
+mesh:D000076142	skos:exactMatch	ncit:C18468	Virtual Reality	Virtual Reality	orcid:0000-0001-9439-5346	CC0
+mesh:D000212	skos:exactMatch	ncit:C205	Acyclovir	Acyclovir	orcid:0000-0001-9439-5346	CC0
+mesh:D000257	skos:exactMatch	ncit:C115149	Adenoviridae Infections	Adenovirus Infection	orcid:0000-0001-9439-5346	CC0
+mesh:D000524	skos:exactMatch	ncit:C112030	Alphavirus	Alphavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D000998	skos:exactMatch	ncit:C281	Antiviral Agents	Antiviral Agent	orcid:0000-0001-9439-5346	CC0
+mesh:D001103	skos:exactMatch	ncit:C112230	Arboviruses	Arbovirus	orcid:0000-0001-9439-5346	CC0
+mesh:D001739	skos:exactMatch	ncit:C89820	BK Virus	BK Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D001355	skos:exactMatch	ncit:C14186	Alpharetrovirus	Alpharetrovirus	orcid:0000-0001-9439-5346	CC0
+mesh:D002043	skos:exactMatch	ncit:C112028	Bunyaviridae	Bunyaviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D002139	skos:exactMatch	ncit:C14304	Caliciviridae	Caliciviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D003236	skos:exactMatch	ncit:C34509	Conjunctivitis, Viral	Viral Conjunctivitis	orcid:0000-0001-9439-5346	CC0
+mesh:D003716	skos:exactMatch	ncit:C112036	Dengue Virus	Dengue Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D004263	skos:exactMatch	ncit:C14199	DNA Tumor Viruses	DNA Tumor Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D004267	skos:exactMatch	ncit:C14200	DNA Viruses	DNA Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D004777	skos:exactMatch	ncit:C16551	Environment	Environment	orcid:0000-0001-9439-5346	CC0
+mesh:D004781	skos:exactMatch	ncit:C16552	Environmental Exposure	Environmental Exposure	orcid:0000-0001-9439-5346	CC0
+mesh:D004860	skos:exactMatch	ncit:C14205	Infectious Anemia Virus, Equine	Equine Infectious Anemia Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D005416	skos:exactMatch	ncit:C14208	Flavivirus	Flavivirus	orcid:0000-0001-9439-5346	CC0
+mesh:D019213	skos:exactMatch	ncit:C14326	Rubulavirus	Rubulavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D012229	skos:exactMatch	ncit:C77200	Rhinovirus	Rhinovirus	orcid:0000-0001-9439-5346	CC0
+mesh:D012209	skos:exactMatch	ncit:C112027	Rhabdoviridae	Rhabdoviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D012254	skos:exactMatch	ncit:C807	Ribavirin	Ribavirin	orcid:0000-0001-9439-5346	CC0
+mesh:D012328	skos:exactMatch	ncit:C14269	RNA Viruses	RNA Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D012412	skos:exactMatch	ncit:C77198	Rubella virus	Rubella Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D012901	skos:exactMatch	ncit:C96527	Variola virus	Variola Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D013155	skos:exactMatch	ncit:C14276	Spleen Focus-Forming Viruses	Spleen Focus-Forming Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D014035	skos:exactMatch	ncit:C77197	Togaviridae	Togaviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D012190	skos:exactMatch	ncit:C14268	Retroviridae	Retroviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D012087	skos:exactMatch	ncit:C112026	Reoviridae	Reoviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D011212	skos:exactMatch	ncit:C14261	Poxviridae	Poxvirus	orcid:0000-0001-9439-5346	CC0
+mesh:D011120	skos:exactMatch	ncit:C14260	Polyomavirus	Polyomavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D010942	skos:exactMatch	ncit:C14257	Plant Viruses	Plant Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D009975	skos:exactMatch	ncit:C53453	Orthomyxoviridae	Orthomyxoviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D010252	skos:exactMatch	ncit:C14255	Paramyxoviridae	Paramyxoviridae	orcid:0000-0001-9439-5346	CC0
+mesh:D010285	skos:exactMatch	ncit:C112401	Pseudocowpox Virus	Pseudocowpox Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D010849	skos:exactMatch	ncit:C14256	Picornaviridae	Picornavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D011054	skos:exactMatch	ncit:C91715	Poliovirus Vaccine, Inactivated	Inactivated Poliovirus Vaccine	orcid:0000-0001-9439-5346	CC0
+mesh:D014036	skos:exactMatch	ncit:C85192	Togaviridae Infections	Togaviridae Infection	orcid:0000-0001-9439-5346	CC0
+mesh:D014484	skos:exactMatch	ncit:C17236	United States Environmental Protection Agency	Environmental Protection Agency	orcid:0000-0001-9439-5346	CC0
+mesh:D045403	skos:exactMatch	ncit:C112290	Henipavirus	Henipavirus	orcid:0000-0001-9439-5346	CC0
+mesh:D029322	skos:exactMatch	ncit:C112362	Norovirus	Norovirus	orcid:0000-0001-9439-5346	CC0
+mesh:D014772	skos:exactMatch	ncit:C95945	Viroids	Viroid	orcid:0000-0001-9439-5346	CC0
+mesh:D014773	skos:exactMatch	ncit:C17256	Virology	Virology	orcid:0000-0001-9439-5346	CC0
+mesh:D014774	skos:exactMatch	ncit:C28198	Virulence	Virulence	orcid:0000-0001-9439-5346	CC0
+mesh:D014780	skos:exactMatch	ncit:C14283	Viruses	Virus	orcid:0000-0001-9439-5346	CC0
+mesh:D014903	skos:exactMatch	ncit:C43473	West Virginia	West Virginia	orcid:0000-0001-9439-5346	CC0
+mesh:D014768	skos:exactMatch	ncit:C43472	Virginia	Virginia	orcid:0000-0001-9439-5346	CC0
+mesh:D014767	skos:exactMatch	ncit:C17255	United States Virgin Islands	Virgin Islands, U.S.	orcid:0000-0001-9439-5346	CC0
+mesh:D015774	skos:exactMatch	chebi:CHEBI:465284	Ganciclovir	ganciclovir	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050268	skos:exactMatch	uniprot.chain:PRO_0000449648	spike protein S2 (SARS-CoV-2)	Spike protein S2	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050267	skos:exactMatch	uniprot.chain:PRO_0000449647	spike protein S1 (SARS-CoV-2)	Spike protein S1	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050278	skos:exactMatch	uniprot.chain:PRO_0000449627	non-structural protein 9 (SARS-CoV-2)	Non-structural protein 9	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050277	skos:exactMatch	uniprot.chain:PRO_0000449626	non-structural protein 8 (SARS-CoV-2)	Non-structural protein 8	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050276	skos:exactMatch	uniprot.chain:PRO_0000449625	non-structural protein 7 (SARS-CoV-2)	Non-structural protein 7	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050275	skos:exactMatch	uniprot.chain:PRO_0000449624	non-structural protein 6 (SARS-CoV-2)	Non-structural protein 6	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050273	skos:exactMatch	uniprot.chain:PRO_0000449622	non-structural protein 4 (SARS-CoV-2)	Non-structural protein 4	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050272	skos:exactMatch	uniprot.chain:PRO_0000449621	non-structural protein 3 (SARS-CoV-2)	Non-structural protein 3	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050271	skos:exactMatch	uniprot.chain:PRO_0000449620	non-structural protein 2 (SARS-CoV-2)	Non-structural protein 2	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050280	skos:exactMatch	uniprot.chain:PRO_0000449645	non-structural protein 11 (SARS-CoV-2)	Non-structural protein 11	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050279	skos:exactMatch	uniprot.chain:PRO_0000449628	non-structural protein 10 (SARS-CoV-2)	Non-structural protein 10	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050270	skos:exactMatch	uniprot.chain:PRO_0000449619	host translation inhibitor nsp1 (SARS-CoV-2)	Host translation inhibitor nsp1	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050285	skos:exactMatch	uniprot.chain:PRO_0000449630	helicase (SARS-CoV-2)	Helicase	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050274	skos:exactMatch	uniprot.chain:PRO_0000449623	3C-like proteinase (SARS-CoV-2)	3C-like proteinase	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050288	skos:exactMatch	uniprot.chain:PRO_0000449633	2'-O-methyltransferase (SARS-CoV-2)	2'-O-methyltransferase	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036008	skos:exactMatch	uniprot.chain:PRO_0000032457	angiotensin I	Angiotensin-1	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036009	skos:exactMatch	uniprot.chain:PRO_0000032458	angiotensin II	Angiotensin-2	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036010	skos:exactMatch	uniprot.chain:PRO_0000032459	angiotensin III	Angiotensin-3	orcid:0000-0001-9439-5346	CC0
+pr:PR:000036011	skos:exactMatch	uniprot.chain:PRO_0000420663	angiotensin IV	Angiotensin-4	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050135	skos:exactMatch	uniprot.chain:PRO_0000005909	complement C3 alpha chain (human)	Complement C3 alpha chain	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002450	skos:exactMatch	uniprot.chain:PRO_0000004524	caspase-1 isoform 1 cleaved 2	Caspase-1 subunit p10	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002454	skos:exactMatch	uniprot.chain:PRO_0000004572	caspase-3 isoform 1 cleaved 1	Caspase-3 subunit p12	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002455	skos:exactMatch	uniprot.chain:PRO_0000004571	caspase-3 isoform 1 cleaved 2	Caspase-3 subunit p17	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050084	skos:exactMatch	uniprot.chain:PRO_0000367048	155 kDa platelet multimerin (human)	155 kDa platelet multimerin	orcid:0000-0001-9439-5346	CC0
+pr:PR:000035718	skos:exactMatch	uniprot.chain:PRO_0000396478	40S ribosomal protein S27a	40S ribosomal protein S27a	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050083	skos:exactMatch	uniprot.chain:PRO_0000367047	platelet glycoprotein Ia* (human)	Platelet glycoprotein Ia*	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050284	skos:exactMatch	uniprot.chain:PRO_0000449629	RNA-directed RNA polymerase (SARS-CoV-2)	RNA-directed RNA polymerase	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002439	skos:exactMatch	uniprot.chain:PRO_0000223233	BH3-interacting domain death agonist isoform 1 cleaved 1	BH3-interacting domain death agonist p15	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002440	skos:exactMatch	uniprot.chain:PRO_0000223232	BH3-interacting domain death agonist isoform 1 cleaved 2	BH3-interacting domain death agonist p13	orcid:0000-0001-9439-5346	CC0
+pr:PR:000002441	skos:exactMatch	uniprot.chain:PRO_0000223231	BH3-interacting domain death agonist isoform 1 cleaved 3	BH3-interacting domain death agonist p11	orcid:0000-0001-9439-5346	CC0
+mesh:D066258	skos:exactMatch	hgnc:651	Amphiregulin	AREG	orcid:0000-0001-9439-5346	CC0
+mesh:D066260	skos:exactMatch	hgnc:3443	Epiregulin	EREG	orcid:0000-0001-9439-5346	CC0
+mesh:D066257	skos:exactMatch	hgnc:3059	Heparin-binding EGF-like Growth Factor	HBEGF	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050287	skos:exactMatch	uniprot.chain:PRO_0000449632	uridylate-specific endoribonuclease (SARS-CoV-2)	Uridylate-specific endoribonuclease	orcid:0000-0001-9439-5346	CC0
+mesh:D045473	skos:exactMatch	ncit:C112432	SARS Virus	SARS Coronavirus	orcid:0000-0001-9439-5346	CC0
+mesh:C000656484	skos:exactMatch	ncit:C169076	severe acute respiratory syndrome coronavirus 2	SARS Coronavirus 2	orcid:0000-0001-9439-5346	CC0
+mesh:C000657245	skos:exactMatch	doid:DOID:0080600	COVID-19	COVID-19	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050269	skos:exactMatch	uniprot.chain:PRO_0000449649	spike protein S2' (SARS-CoV-2)	Spike protein S2'	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050266	skos:exactMatch	uniprot.chain:PRO_0000449646	spike glycoprotein, signal peptide removed form (SARS-CoV-2)	Spike glycoprotein	orcid:0000-0001-9439-5346	CC0
+pr:PR:000050265	skos:exactMatch	uniprot.chain:PRO_0000449654	ORF7a protein, signal peptide removed form (SARS-CoV-2)	ORF7a protein	orcid:0000-0001-9439-5346	CC0
+mesh:D065098	skos:exactMatch	chebi:CHEBI:48406	Catechol O-Methyltransferase Inhibitors	EC 2.1.1.6 (catechol O-methyltransferase) inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D065093	skos:exactMatch	chebi:CHEBI:35625	beta-Lactamase Inhibitors	EC 3.5.2.6 (beta-lactamase) inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D064801	skos:exactMatch	chebi:CHEBI:50469	Phospholipase A2 Inhibitors	EC 3.1.1.4 (phospholipase A2) inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D064546	skos:exactMatch	hgnc:9395	Protein Kinase C beta	PRKCB	orcid:0000-0001-9439-5346	CC0
+mesh:D064424	skos:exactMatch	ncit:C18059	Tobacco Use	Tobacco Use	orcid:0000-0001-9439-5346	CC0
+mesh:D063926	skos:exactMatch	ncit:C112208	Drug Hypersensitivity Syndrome	Drug Hypersensitivity Syndrome	orcid:0000-0001-9439-5346	CC0
+mesh:D062385	skos:exactMatch	chebi:CHEBI:24675	Hydroxybenzoates	hydroxybenzoate	orcid:0000-0001-9439-5346	CC0
+mesh:D062405	skos:exactMatch	ncit:C157765	Motivational Interviewing	Motivational Interviewing	orcid:0000-0001-9439-5346	CC0
+mesh:D062407	skos:exactMatch	ncit:C80248	Meals	Meal	orcid:0000-0001-9439-5346	CC0
+mesh:D062625	skos:exactMatch	ncit:C8985	Cystadenofibroma	Cystadenofibroma	orcid:0000-0001-9439-5346	CC0
+mesh:D062645	skos:exactMatch	ncit:C99521	Percutaneous Coronary Intervention	Percutaneous Coronary Intervention	orcid:0000-0001-9439-5346	CC0
+mesh:D062685	skos:exactMatch	doid:DOID:0111556	Steatocystoma Multiplex	steatocystoma multiplex	orcid:0000-0001-9439-5346	CC0
+mesh:D062765	skos:exactMatch	hgnc:14686	Junctional Adhesion Molecule B	JAM2	orcid:0000-0001-9439-5346	CC0
+mesh:D062786	skos:exactMatch	hgnc:15532	Junctional Adhesion Molecule C	JAM3	orcid:0000-0001-9439-5346	CC0
+mesh:D061988	skos:exactMatch	ncit:C2160	Proteasome Inhibitors	Proteasome Inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D061986	skos:exactMatch	ncit:C18096	MCF-7 Cells	MCF7	orcid:0000-0001-9439-5346	CC0
+mesh:D061965	skos:exactMatch	chebi:CHEBI:50664	Matrix Metalloproteinase Inhibitors	matrix metalloproteinase inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D062245	skos:exactMatch	ncit:C127112	RxNorm	RxNorm	orcid:0000-0001-9439-5346	CC0
+mesh:D062187	skos:exactMatch	ncit:C21023	Spinal Cord Stimulation	Spinal Cord Stimulation	orcid:0000-0001-9439-5346	CC0
+mesh:D062085	skos:exactMatch	ncit:C88924	RNA, Long Noncoding	LincRNA	orcid:0000-0001-9439-5346	CC0
+mesh:D062071	skos:exactMatch	ncit:C114939	Infant, Extremely Premature	Extremely Preterm Infant	orcid:0000-0001-9439-5346	CC0
+mesh:D062048	skos:exactMatch	ncit:C116496	Narrow Band Imaging	Narrow Band Imaging	orcid:0000-0001-9439-5346	CC0
+mesh:D062365	skos:exactMatch	chebi:CHEBI:22494	Aminobenzoates	aminobenzoate	orcid:0000-0001-9439-5346	CC0
+mesh:D062346	skos:exactMatch	ncit:C18885	Molecular Medicine	Molecular Medicine	orcid:0000-0001-9439-5346	CC0
+mesh:D061466	skos:exactMatch	chebi:CHEBI:31781	Lopinavir	lopinavir	orcid:0000-0001-9439-5346	CC0
+mesh:D000001	skos:exactMatch	chebi:CHEBI:3305	Calcimycin	Calcimycin	orcid:0000-0001-9439-5346	CC0
+mesh:D000019	skos:exactMatch	chebi:CHEBI:50691	Abortifacient Agents	abortifacient	orcid:0000-0001-9439-5346	CC0
+mesh:D000068180	skos:exactMatch	chebi:CHEBI:31236	Aripiprazole	aripiprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D000068338	skos:exactMatch	chebi:CHEBI:68478	Everolimus	everolimus	orcid:0000-0001-9439-5346	CC0
+mesh:D000068576	skos:exactMatch	chebi:CHEBI:5938	Interferon beta-1b	Interferon beta-1b	orcid:0000-0001-9439-5346	CC0
+mesh:D000068679	skos:exactMatch	chebi:CHEBI:31536	Emtricitabine	emtricitabine	orcid:0000-0001-9439-5346	CC0
+mesh:D000068796	skos:exactMatch	chebi:CHEBI:83296	Orexin Receptor Antagonists	orexin receptor antagonist	orcid:0000-0001-9439-5346	CC0
+mesh:D000069059	skos:exactMatch	chebi:CHEBI:39548	Atorvastatin	atorvastatin	orcid:0000-0001-9439-5346	CC0
+mesh:D000069349	skos:exactMatch	chebi:CHEBI:63607	Linezolid	linezolid	orcid:0000-0001-9439-5346	CC0
+mesh:D000069557	skos:exactMatch	chebi:CHEBI:746859	Travoprost	travoprost	orcid:0000-0001-9439-5346	CC0
+mesh:D000070	skos:exactMatch	chebi:CHEBI:2379	Acebutolol	acebutolol	orcid:0000-0001-9439-5346	CC0
+mesh:D000072318	skos:exactMatch	chebi:CHEBI:38922	Dibenzofurans	dibenzofurans	orcid:0000-0001-9439-5346	CC0
+mesh:D000072376	skos:exactMatch	chebi:CHEBI:53030	Oxysterols	oxysterol	orcid:0000-0001-9439-5346	CC0
+mesh:D000072664	skos:exactMatch	chebi:CHEBI:50188	Provitamins	provitamin	orcid:0000-0001-9439-5346	CC0
+mesh:D000073	skos:exactMatch	chebi:CHEBI:22156	Acenaphthenes	acenaphthenes	orcid:0000-0001-9439-5346	CC0
+mesh:D000074382	skos:exactMatch	chebi:CHEBI:76413	Greenhouse Gases	greenhouse gas	orcid:0000-0001-9439-5346	CC0
+mesh:D000075163	skos:exactMatch	chebi:CHEBI:33963	Metallocenes	metallocene	orcid:0000-0001-9439-5346	CC0
+mesh:D000077145	skos:exactMatch	chebi:CHEBI:45373	Sulfanilamide	sulfanilamide	orcid:0000-0001-9439-5346	CC0
+mesh:D000077149	skos:exactMatch	chebi:CHEBI:9130	Sevoflurane	sevoflurane	orcid:0000-0001-9439-5346	CC0
+mesh:D000077150	skos:exactMatch	chebi:CHEBI:31941	Oxaliplatin	oxaliplatin	orcid:0000-0001-9439-5346	CC0
+mesh:D000077157	skos:exactMatch	chebi:CHEBI:50924	Sorafenib	sorafenib	orcid:0000-0001-9439-5346	CC0
+mesh:D000077205	skos:exactMatch	chebi:CHEBI:8228	Pioglitazone	pioglitazone	orcid:0000-0001-9439-5346	CC0
+mesh:D000077208	skos:exactMatch	chebi:CHEBI:8802	Remifentanil	remifentanil	orcid:0000-0001-9439-5346	CC0
+mesh:D000077210	skos:exactMatch	chebi:CHEBI:38940	Sunitinib	sunitinib	orcid:0000-0001-9439-5346	CC0
+mesh:D000077222	skos:exactMatch	chebi:CHEBI:15384	Limonene	limonene	orcid:0000-0001-9439-5346	CC0
+mesh:D000077236	skos:exactMatch	chebi:CHEBI:63631	Topiramate	topiramate	orcid:0000-0001-9439-5346	CC0
+mesh:D000077261	skos:exactMatch	chebi:CHEBI:3441	Carvedilol	carvedilol	orcid:0000-0001-9439-5346	CC0
+mesh:D000077266	skos:exactMatch	chebi:CHEBI:63611	Moxifloxacin	moxifloxacin	orcid:0000-0001-9439-5346	CC0
+mesh:D000077271	skos:exactMatch	chebi:CHEBI:36704	Imiquimod	imiquimod	orcid:0000-0001-9439-5346	CC0
+mesh:D000077276	skos:exactMatch	chebi:CHEBI:15948	Lycopene	lycopene	orcid:0000-0001-9439-5346	CC0
+mesh:D000077287	skos:exactMatch	chebi:CHEBI:6437	Levetiracetam	levetiracetam	orcid:0000-0001-9439-5346	CC0
+mesh:D000072338	skos:exactMatch	chebi:CHEBI:134046	Dibenzofurans, Polychlorinated	polychlorinated dibenzofuran	orcid:0000-0001-9439-5346	CC0
+mesh:D000072317	skos:exactMatch	chebi:CHEBI:36682	Polychlorinated Dibenzodioxins	polychlorinated dibenzodioxine	orcid:0000-0001-9439-5346	CC0
+mesh:D000077290	skos:exactMatch	chebi:CHEBI:61379	Harmala Alkaloids	harmala alkaloid	orcid:0000-0001-9439-5346	CC0
+mesh:D000077289	skos:exactMatch	chebi:CHEBI:6413	Letrozole	letrozole	orcid:0000-0001-9439-5346	CC0
+mesh:D000077288	skos:exactMatch	chebi:CHEBI:9753	Troglitazone	troglitazone	orcid:0000-0001-9439-5346	CC0
+mesh:D000077335	skos:exactMatch	chebi:CHEBI:4445	Desflurane	desflurane	orcid:0000-0001-9439-5346	CC0
+mesh:D000077336	skos:exactMatch	chebi:CHEBI:474180	Caspofungin	caspofungin	orcid:0000-0001-9439-5346	CC0
+mesh:D000077339	skos:exactMatch	chebi:CHEBI:6402	Leflunomide	leflunomide	orcid:0000-0001-9439-5346	CC0
+mesh:D000077405	skos:exactMatch	chebi:CHEBI:5959	Irbesartan	irbesartan	orcid:0000-0001-9439-5346	CC0
+mesh:D000077409	skos:exactMatch	chebi:CHEBI:9398	Tamsulosin	tamsulosin	orcid:0000-0001-9439-5346	CC0
+mesh:D000077333	skos:exactMatch	chebi:CHEBI:9434	Telmisartan	telmisartan	orcid:0000-0001-9439-5346	CC0
+mesh:D000077422	skos:exactMatch	chebi:CHEBI:35720	Enrofloxacin	enrofloxacin	orcid:0000-0001-9439-5346	CC0
+mesh:D000077465	skos:exactMatch	chebi:CHEBI:3286	Cabergoline	cabergoline	orcid:0000-0001-9439-5346	CC0
+mesh:D000077466	skos:exactMatch	chebi:CHEBI:9605	Tirofiban	tirofiban	orcid:0000-0001-9439-5346	CC0
+mesh:D000077484	skos:exactMatch	chebi:CHEBI:63637	Vemurafenib	vemurafenib	orcid:0000-0001-9439-5346	CC0
+mesh:D000077545	skos:exactMatch	chebi:CHEBI:31547	Eplerenone	eplerenone	orcid:0000-0001-9439-5346	CC0
+mesh:D000077553	skos:exactMatch	chebi:CHEBI:31530	Edaravone	edaravone	orcid:0000-0001-9439-5346	CC0
+mesh:D000077554	skos:exactMatch	chebi:CHEBI:6149	Levobupivacaine	levobupivacaine	orcid:0000-0001-9439-5346	CC0
+mesh:D000077583	skos:exactMatch	chebi:CHEBI:8713	Quinapril	quinapril	orcid:0000-0001-9439-5346	CC0
+mesh:D000077590	skos:exactMatch	chebi:CHEBI:6958	Mivacurium	Mivacurium	orcid:0000-0001-9439-5346	CC0
+mesh:D000077609	skos:exactMatch	chebi:CHEBI:90748	O-(Chloroacetylcarbamoyl)fumagillol	O-(chloroacetylcarbamoyl)fumagillol	orcid:0000-0001-9439-5346	CC0
+mesh:D000077613	skos:exactMatch	chebi:CHEBI:6339	Etoricoxib	etoricoxib	orcid:0000-0001-9439-5346	CC0
+mesh:D000077723	skos:exactMatch	chebi:CHEBI:478164	Cefepime	cefepime	orcid:0000-0001-9439-5346	CC0
+mesh:D000077731	skos:exactMatch	chebi:CHEBI:43968	Meropenem	meropenem	orcid:0000-0001-9439-5346	CC0
+mesh:D000078183	skos:exactMatch	chebi:CHEBI:38459	Oxindoles	oxindoles	orcid:0000-0001-9439-5346	CC0
+mesh:D000078102	skos:exactMatch	chebi:CHEBI:156095	Lumefantrine	lumefantrine	orcid:0000-0001-9439-5346	CC0
+mesh:D000077922	skos:exactMatch	chebi:CHEBI:39185	Thiamethoxam	thiamethoxam	orcid:0000-0001-9439-5346	CC0
+mesh:D000077771	skos:exactMatch	chebi:CHEBI:6817	Methantheline	Methantheline	orcid:0000-0001-9439-5346	CC0
+mesh:D000077770	skos:exactMatch	chebi:CHEBI:135948	Amifampridine	amifampridine	orcid:0000-0001-9439-5346	CC0
+mesh:D000077769	skos:exactMatch	chebi:CHEBI:8862	Rilmenidine	Rilmenidine	orcid:0000-0001-9439-5346	CC0
+mesh:D000078223	skos:exactMatch	chebi:CHEBI:18293	5-Methoxypsoralen	5-methoxypsoralen	orcid:0000-0001-9439-5346	CC0
+mesh:D000078328	skos:exactMatch	chebi:CHEBI:4995	Felbamate	felbamate	orcid:0000-0001-9439-5346	CC0
+mesh:D000078330	skos:exactMatch	chebi:CHEBI:7824	Oxcarbazepine	oxcarbazepine	orcid:0000-0001-9439-5346	CC0
+mesh:D000078604	skos:exactMatch	chebi:CHEBI:90414	Secretagogues	secretagogue	orcid:0000-0001-9439-5346	CC0
+mesh:D000078785	skos:exactMatch	chebi:CHEBI:6950	Mirtazapine	mirtazapine	orcid:0000-0001-9439-5346	CC0
+mesh:D000078789	skos:exactMatch	chebi:CHEBI:60552	Polyacetylene Polymer	polyacetylene polymer	orcid:0000-0001-9439-5346	CC0
+mesh:D000079	skos:exactMatch	chebi:CHEBI:15343	Acetaldehyde	acetaldehyde	orcid:0000-0001-9439-5346	CC0
+mesh:D000080	skos:exactMatch	chebi:CHEBI:59769	Acetals	acetal	orcid:0000-0001-9439-5346	CC0
+mesh:D000080084	skos:exactMatch	chebi:CHEBI:64068	Calicheamicins	calicheamicin	orcid:0000-0001-9439-5346	CC0
+mesh:D000081	skos:exactMatch	chebi:CHEBI:22160	Acetamides	acetamides	orcid:0000-0001-9439-5346	CC0
+mesh:D000081026	skos:exactMatch	chebi:CHEBI:26199	Polyprenols	polyprenol	orcid:0000-0001-9439-5346	CC0
+mesh:D000081503	skos:exactMatch	chebi:CHEBI:51185	Organoiron Compounds	organoiron compound	orcid:0000-0001-9439-5346	CC0
+mesh:D000086	skos:exactMatch	chebi:CHEBI:27690	Acetazolamide	acetazolamide	orcid:0000-0001-9439-5346	CC0
+mesh:D000093	skos:exactMatch	chebi:CHEBI:15688	Acetoin	acetoin	orcid:0000-0001-9439-5346	CC0
+mesh:D000096	skos:exactMatch	chebi:CHEBI:15347	Acetone	acetone	orcid:0000-0001-9439-5346	CC0
+mesh:D000098	skos:exactMatch	chebi:CHEBI:22187	Acetophenones	acetophenones	orcid:0000-0001-9439-5346	CC0
+mesh:D000109	skos:exactMatch	chebi:CHEBI:15355	Acetylcholine	acetylcholine	orcid:0000-0001-9439-5346	CC0
+mesh:D000114	skos:exactMatch	chebi:CHEBI:27518	Acetylene	acetylene	orcid:0000-0001-9439-5346	CC0
+mesh:D000156	skos:exactMatch	chebi:CHEBI:22211	Aconitic Acid	aconitic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D000157	skos:exactMatch	chebi:CHEBI:2430	Aconitine	aconitine	orcid:0000-0001-9439-5346	CC0
+mesh:D000165	skos:exactMatch	chebi:CHEBI:51739	Acridine Orange	acridine orange	orcid:0000-0001-9439-5346	CC0
+mesh:D000166	skos:exactMatch	chebi:CHEBI:22213	Acridines	acridines	orcid:0000-0001-9439-5346	CC0
+mesh:D000171	skos:exactMatch	chebi:CHEBI:15368	Acrolein	acrolein	orcid:0000-0001-9439-5346	CC0
+mesh:D000145	skos:exactMatch	chebi:CHEBI:26643	Acids, Aldehydic	aldehydic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D000178	skos:exactMatch	chebi:CHEBI:22216	Acrylamides	acrylamides	orcid:0000-0001-9439-5346	CC0
+mesh:D000181	skos:exactMatch	chebi:CHEBI:28217	Acrylonitrile	acrylonitrile	orcid:0000-0001-9439-5346	CC0
+mesh:D000186	skos:exactMatch	chebi:CHEBI:33337	Actinium	actinium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D000225	skos:exactMatch	chebi:CHEBI:16708	Adenine	adenine	orcid:0000-0001-9439-5346	CC0
+mesh:D000241	skos:exactMatch	chebi:CHEBI:16335	Adenosine	adenosine	orcid:0000-0001-9439-5346	CC0
+mesh:D000255	skos:exactMatch	chebi:CHEBI:15422	Adenosine Triphosphate	ATP	orcid:0000-0001-9439-5346	CC0
+mesh:D000325	skos:exactMatch	chebi:CHEBI:48962	Adrenodoxin	adrenodoxin	orcid:0000-0001-9439-5346	CC0
+mesh:D000345	skos:exactMatch	chebi:CHEBI:60788	Affinity Labels	affinity label	orcid:0000-0001-9439-5346	CC0
+mesh:D000376	skos:exactMatch	chebi:CHEBI:17431	Agmatine	agmatine	orcid:0000-0001-9439-5346	CC0
+mesh:D000404	skos:exactMatch	chebi:CHEBI:28462	Ajmaline	ajmaline	orcid:0000-0001-9439-5346	CC0
+mesh:D000409	skos:exactMatch	chebi:CHEBI:16449	Alanine	alanine	orcid:0000-0001-9439-5346	CC0
+mesh:D000420	skos:exactMatch	chebi:CHEBI:2549	Albuterol	albuterol	orcid:0000-0001-9439-5346	CC0
+mesh:D000431	skos:exactMatch	chebi:CHEBI:16236	Ethanol	ethanol	orcid:0000-0001-9439-5346	CC0
+mesh:D000432	skos:exactMatch	chebi:CHEBI:17790	Methanol	methanol	orcid:0000-0001-9439-5346	CC0
+mesh:D000443	skos:exactMatch	chebi:CHEBI:55313	Alcuronium	alcuronium	orcid:0000-0001-9439-5346	CC0
+mesh:D000447	skos:exactMatch	chebi:CHEBI:17478	Aldehydes	aldehyde	orcid:0000-0001-9439-5346	CC0
+mesh:D000448	skos:exactMatch	chebi:CHEBI:2555	Aldicarb	aldicarb	orcid:0000-0001-9439-5346	CC0
+mesh:D000450	skos:exactMatch	chebi:CHEBI:27584	Aldosterone	aldosterone	orcid:0000-0001-9439-5346	CC0
+mesh:D000466	skos:exactMatch	chebi:CHEBI:33646	Alkadienes	alkadiene	orcid:0000-0001-9439-5346	CC0
+mesh:D000473	skos:exactMatch	chebi:CHEBI:18310	Alkanes	alkane	orcid:0000-0001-9439-5346	CC0
+mesh:D000479	skos:exactMatch	chebi:CHEBI:33255	Alkylmercury Compounds	alkylmercury compound	orcid:0000-0001-9439-5346	CC0
+mesh:D000481	skos:exactMatch	chebi:CHEBI:15676	Allantoin	allantoin	orcid:0000-0001-9439-5346	CC0
+mesh:D000485	skos:exactMatch	chebi:CHEBI:50904	Allergens	allergen	orcid:0000-0001-9439-5346	CC0
+mesh:D000493	skos:exactMatch	chebi:CHEBI:40279	Allopurinol	allopurinol	orcid:0000-0001-9439-5346	CC0
+mesh:D000500	skos:exactMatch	chebi:CHEBI:31189	Allylestrenol	Allylestrenol	orcid:0000-0001-9439-5346	CC0
+mesh:D000523	skos:exactMatch	chebi:CHEBI:763	Algestone	algestone	orcid:0000-0001-9439-5346	CC0
+mesh:D000525	skos:exactMatch	chebi:CHEBI:2611	Alprazolam	alprazolam	orcid:0000-0001-9439-5346	CC0
+mesh:D000547	skos:exactMatch	chebi:CHEBI:2618	Amantadine	amantadine	orcid:0000-0001-9439-5346	CC0
+mesh:D000576	skos:exactMatch	chebi:CHEBI:33389	Americium	americium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D000583	skos:exactMatch	chebi:CHEBI:2637	Amikacin	amikacin	orcid:0000-0001-9439-5346	CC0
+mesh:D000584	skos:exactMatch	chebi:CHEBI:2639	Amiloride	amiloride	orcid:0000-0001-9439-5346	CC0
+mesh:D000605	skos:exactMatch	chebi:CHEBI:22478	Amino Alcohols	amino alcohol	orcid:0000-0001-9439-5346	CC0
+mesh:D000606	skos:exactMatch	chebi:CHEBI:28963	Amino Sugars	amino sugar	orcid:0000-0001-9439-5346	CC0
+mesh:D000609	skos:exactMatch	chebi:CHEBI:51803	Aminoacridines	aminoacridines	orcid:0000-0001-9439-5346	CC0
+mesh:D000625	skos:exactMatch	chebi:CHEBI:40823	Aminooxyacetic Acid	aminooxyacetic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D000628	skos:exactMatch	chebi:CHEBI:2659	Aminophylline	aminophylline	orcid:0000-0001-9439-5346	CC0
+mesh:D000631	skos:exactMatch	chebi:CHEBI:38207	Aminopyridines	aminopyridine	orcid:0000-0001-9439-5346	CC0
+mesh:D000634	skos:exactMatch	chebi:CHEBI:36709	Aminoquinolines	aminoquinoline	orcid:0000-0001-9439-5346	CC0
+mesh:D000639	skos:exactMatch	chebi:CHEBI:2666	Amitriptyline	amitriptyline	orcid:0000-0001-9439-5346	CC0
+mesh:D000640	skos:exactMatch	chebi:CHEBI:40036	Amitrole	amitrole	orcid:0000-0001-9439-5346	CC0
+mesh:D000641	skos:exactMatch	chebi:CHEBI:16134	Ammonia	ammonia	orcid:0000-0001-9439-5346	CC0
+mesh:D000644	skos:exactMatch	chebi:CHEBI:35273	Quaternary Ammonium Compounds	quaternary ammonium salt	orcid:0000-0001-9439-5346	CC0
+mesh:D000655	skos:exactMatch	chebi:CHEBI:2674	Amodiaquine	amodiaquine	orcid:0000-0001-9439-5346	CC0
+mesh:D000658	skos:exactMatch	chebi:CHEBI:2676	Amoxicillin	amoxicillin	orcid:0000-0001-9439-5346	CC0
+mesh:D000661	skos:exactMatch	chebi:CHEBI:2679	Amphetamine	amphetamine	orcid:0000-0001-9439-5346	CC0
+mesh:D000662	skos:exactMatch	chebi:CHEBI:35338	Amphetamines	amphetamines	orcid:0000-0001-9439-5346	CC0
+mesh:D000667	skos:exactMatch	chebi:CHEBI:28971	Ampicillin	ampicillin	orcid:0000-0001-9439-5346	CC0
+mesh:D000654	skos:exactMatch	chebi:CHEBI:2673	Amobarbital	amobarbital	orcid:0000-0001-9439-5346	CC0
+mesh:D000638	skos:exactMatch	chebi:CHEBI:2663	Amiodarone	amiodarone	orcid:0000-0001-9439-5346	CC0
+mesh:D000701	skos:exactMatch	chebi:CHEBI:35482	Analgesics, Opioid	opioid analgesic	orcid:0000-0001-9439-5346	CC0
+mesh:D000968	skos:exactMatch	chebi:CHEBI:2762	Antimycin A	antimycin A	orcid:0000-0001-9439-5346	CC0
+mesh:D000931	skos:exactMatch	chebi:CHEBI:50247	Antidotes	antidote	orcid:0000-0001-9439-5346	CC0
+mesh:D000983	skos:exactMatch	chebi:CHEBI:31225	Antipyrine	antipyrine	orcid:0000-0001-9439-5346	CC0
+mesh:D000982	skos:exactMatch	chebi:CHEBI:59683	Antipruritics	antipruritic drug	orcid:0000-0001-9439-5346	CC0
+mesh:D000981	skos:exactMatch	chebi:CHEBI:35820	Antiprotozoal Agents	antiprotozoal drug	orcid:0000-0001-9439-5346	CC0
+mesh:D000980	skos:exactMatch	chebi:CHEBI:35684	Antiplatyhelmintic Agents	antiplatyhelmintic drug	orcid:0000-0001-9439-5346	CC0
+mesh:D000935	skos:exactMatch	chebi:CHEBI:35718	Antifungal Agents	antifungal agent	orcid:0000-0001-9439-5346	CC0
+mesh:D000934	skos:exactMatch	chebi:CHEBI:77973	Antifoaming Agents	antifoaming agent	orcid:0000-0001-9439-5346	CC0
+mesh:D000933	skos:exactMatch	chebi:CHEBI:48675	Antifibrinolytic Agents	antifibrinolytic drug	orcid:0000-0001-9439-5346	CC0
+mesh:D000924	skos:exactMatch	chebi:CHEBI:35821	Anticholesteremic Agents	anticholesteremic drug	orcid:0000-0001-9439-5346	CC0
+mesh:D000897	skos:exactMatch	chebi:CHEBI:49201	Anti-Ulcer Agents	anti-ulcer drug	orcid:0000-0001-9439-5346	CC0
+mesh:D001074	skos:exactMatch	chebi:CHEBI:34938	Propoxur	propoxur	orcid:0000-0001-9439-5346	CC0
+mesh:D001059	skos:exactMatch	chebi:CHEBI:13850	Apoproteins	apoprotein	orcid:0000-0001-9439-5346	CC0
+mesh:D001052	skos:exactMatch	chebi:CHEBI:2784	Apoferritins	Apoferritin	orcid:0000-0001-9439-5346	CC0
+mesh:D000995	skos:exactMatch	chebi:CHEBI:33231	Antitubercular Agents	antitubercular agent	orcid:0000-0001-9439-5346	CC0
+mesh:D001120	skos:exactMatch	chebi:CHEBI:29016	Arginine	arginine	orcid:0000-0001-9439-5346	CC0
+mesh:D001147	skos:exactMatch	chebi:CHEBI:49477	Arsanilic Acid	arsanilic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D001151	skos:exactMatch	chebi:CHEBI:27563	Arsenic	arsenic atom	orcid:0000-0001-9439-5346	CC0
+mesh:D001153	skos:exactMatch	chebi:CHEBI:9016	Arsphenamine	arsphenamine	orcid:0000-0001-9439-5346	CC0
+mesh:D001252	skos:exactMatch	chebi:CHEBI:74783	Astringents	astringent	orcid:0000-0001-9439-5346	CC0
+mesh:D001278	skos:exactMatch	chebi:CHEBI:2913	Atractyloside	Atractyloside	orcid:0000-0001-9439-5346	CC0
+mesh:D001279	skos:exactMatch	chebi:CHEBI:2914	Atracurium	atracurium	orcid:0000-0001-9439-5346	CC0
+mesh:D001280	skos:exactMatch	chebi:CHEBI:15930	Atrazine	atrazine	orcid:0000-0001-9439-5346	CC0
+mesh:D001285	skos:exactMatch	chebi:CHEBI:16684	Atropine	atropine	orcid:0000-0001-9439-5346	CC0
+mesh:D001430	skos:exactMatch	chebi:CHEBI:48081	Bacteriocins	bacteriocin	orcid:0000-0001-9439-5346	CC0
+mesh:D001429	skos:exactMatch	chebi:CHEBI:38201	Bacteriochlorophylls	bacteriochlorophyll	orcid:0000-0001-9439-5346	CC0
+mesh:D001414	skos:exactMatch	chebi:CHEBI:28669	Bacitracin	bacitracin	orcid:0000-0001-9439-5346	CC0
+mesh:D001391	skos:exactMatch	chebi:CHEBI:37533	Azo Compounds	azo compound	orcid:0000-0001-9439-5346	CC0
+mesh:D001384	skos:exactMatch	chebi:CHEBI:38777	Azetidines	azetidines	orcid:0000-0001-9439-5346	CC0
+mesh:D001565	skos:exactMatch	chebi:CHEBI:22718	Benzoates	benzoates	orcid:0000-0001-9439-5346	CC0
+mesh:D001566	skos:exactMatch	chebi:CHEBI:116735	Benzocaine	benzocaine	orcid:0000-0001-9439-5346	CC0
+mesh:D001554	skos:exactMatch	chebi:CHEBI:16716	Benzene	benzene	orcid:0000-0001-9439-5346	CC0
+mesh:D001556	skos:exactMatch	chebi:CHEBI:24536	Hexachlorocyclohexane	hexachlorocyclohexane	orcid:0000-0001-9439-5346	CC0
+mesh:D001573	skos:exactMatch	chebi:CHEBI:17682	Benzoin	benzoin	orcid:0000-0001-9439-5346	CC0
+mesh:D001577	skos:exactMatch	chebi:CHEBI:22726	Benzophenones	benzophenones	orcid:0000-0001-9439-5346	CC0
+mesh:D001583	skos:exactMatch	chebi:CHEBI:46700	Benzoxazoles	benzoxazole	orcid:0000-0001-9439-5346	CC0
+mesh:D001589	skos:exactMatch	chebi:CHEBI:3044	Benzphetamine	benzphetamine	orcid:0000-0001-9439-5346	CC0
+mesh:D001572	skos:exactMatch	chebi:CHEBI:35259	Benzofurans	benzofurans	orcid:0000-0001-9439-5346	CC0
+mesh:D065808	skos:exactMatch	go:GO:0060134	Prepulse Inhibition	prepulse inhibition	orcid:0000-0001-9439-5346	CC0
+mesh:D065819	skos:exactMatch	chebi:CHEBI:10023	Voriconazole	voriconazole	orcid:0000-0001-9439-5346	CC0
+mesh:D065766	skos:exactMatch	doid:DOID:0080301	Atypical Hemolytic Uremic Syndrome	atypical hemolytic-uremic syndrome	orcid:0000-0001-9439-5346	CC0
+mesh:D064704	skos:exactMatch	chebi:CHEBI:63598	Levofloxacin	levofloxacin	orcid:0000-0001-9439-5346	CC0
+mesh:D064747	skos:exactMatch	chebi:CHEBI:6375	Lansoprazole	lansoprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D064748	skos:exactMatch	chebi:CHEBI:135931	Dexlansoprazole	dexlansoprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D064107	skos:exactMatch	hgnc:11390	Aurora Kinase B	AURKB	orcid:0000-0001-9439-5346	CC0
+mesh:D064098	skos:exactMatch	chebi:CHEBI:50275	Esomeprazole	esomeprazole	orcid:0000-0001-9439-5346	CC0
+mesh:D064096	skos:exactMatch	hgnc:11393	Aurora Kinase A	AURKA	orcid:0000-0001-9439-5346	CC0
+mesh:D064048	skos:exactMatch	go:GO:0005816	Spindle Pole Bodies	spindle pole body	orcid:0000-0001-9439-5346	CC0
+mesh:D061346	skos:exactMatch	efo:0009111	Laser Capture Microdissection	laser capture microdissection	orcid:0000-0001-9439-5346	CC0
+mesh:D061988	skos:exactMatch	chebi:CHEBI:52726	Proteasome Inhibitors	proteasome inhibitor	orcid:0000-0001-9439-5346	CC0
+mesh:D062556	skos:exactMatch	hgnc:10597	NAV1.7 Voltage-Gated Sodium Channel	SCN9A	orcid:0000-0001-9439-5346	CC0
+mesh:D059748	skos:exactMatch	go:GO:0006508	Proteolysis	proteolysis	orcid:0000-0001-9439-5346	CC0
+mesh:D059765	skos:exactMatch	go:GO:0035825	Homologous Recombination	homologous recombination	orcid:0000-0001-9439-5346	CC0
+mesh:D059370	skos:exactMatch	go:GO:0034337	RNA Folding	RNA folding	orcid:0000-0001-9439-5346	CC0
+mesh:D059246	skos:exactMatch	efo:0009840	Tachypnea	tachypnea	orcid:0000-0001-9439-5346	CC0
+mesh:D059390	skos:exactMatch	hp:HP:0032149	Breakthrough Pain	Breakthrough pain	orcid:0000-0001-9439-5346	CC0
+mesh:D059630	skos:exactMatch	efo:0000586	Mesenchymal Stem Cells	mesenchymal stem cell	orcid:0000-0001-9439-5346	CC0
+mesh:D058924	skos:exactMatch	chebi:CHEBI:37942	Thienopyridines	thienopyridine	orcid:0000-0001-9439-5346	CC0
+mesh:D056892	skos:exactMatch	go:GO:0016592	Mediator Complex	mediator complex	orcid:0000-0001-9439-5346	CC0
+mesh:D056850	skos:exactMatch	hgnc:1779	Cyclin-Dependent Kinase 8	CDK8	orcid:0000-0001-9439-5346	CC0
+mesh:D056743	skos:exactMatch	hgnc:1585	Cyclin D3	CCND3	orcid:0000-0001-9439-5346	CC0
+mesh:D056744	skos:exactMatch	hgnc:1579	Cyclin B1	CCNB1	orcid:0000-0001-9439-5346	CC0
+mesh:D056748	skos:exactMatch	hgnc:1594	Cyclin H	CCNH	orcid:0000-0001-9439-5346	CC0
+mesh:D056750	skos:exactMatch	hgnc:1577	Cyclin A1	CCNA1	orcid:0000-0001-9439-5346	CC0
+mesh:D056751	skos:exactMatch	hgnc:1578	Cyclin A2	CCNA2	orcid:0000-0001-9439-5346	CC0
+mesh:D056765	skos:exactMatch	hgnc:1580	Cyclin B2	CCNB2	orcid:0000-0001-9439-5346	CC0
+mesh:D056807	skos:exactMatch	hp:HP:0025630	Argininosuccinic Aciduria	Argininosuccinic aciduria	orcid:0000-0001-9439-5346	CC0
+mesh:D056833	skos:exactMatch	hp:HP:0025567	Central Serous Chorioretinopathy	Central serous chorioretinopathy	orcid:0000-0001-9439-5346	CC0
+mesh:D056849	skos:exactMatch	hgnc:1772	Cyclin-Dependent Kinase 3	CDK3	orcid:0000-0001-9439-5346	CC0
+mesh:D055531	skos:exactMatch	go:GO:0097504	Gemini of Coiled Bodies	Gemini of coiled bodies	orcid:0000-0001-9439-5346	CC0
+mesh:D055495	skos:exactMatch	go:GO:0022008	Neurogenesis	neurogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D055623	skos:exactMatch	hp:HP:0025127	Keratosis, Actinic	Actinic keratosis	orcid:0000-0001-9439-5346	CC0
+mesh:D055417	skos:exactMatch	hgnc:1072	Bone Morphogenetic Protein 5	BMP5	orcid:0000-0001-9439-5346	CC0
+mesh:D055418	skos:exactMatch	hgnc:1073	Bone Morphogenetic Protein 6	BMP6	orcid:0000-0001-9439-5346	CC0
+mesh:D055419	skos:exactMatch	hgnc:1074	Bone Morphogenetic Protein 7	BMP7	orcid:0000-0001-9439-5346	CC0
+mesh:D055427	skos:exactMatch	hgnc:4217	Growth Differentiation Factor 2	GDF2	orcid:0000-0001-9439-5346	CC0
+mesh:D055428	skos:exactMatch	hgnc:4220	Growth Differentiation Factor 5	GDF5	orcid:0000-0001-9439-5346	CC0
+mesh:D055429	skos:exactMatch	hgnc:4224	Growth Differentiation Factor 9	GDF9	orcid:0000-0001-9439-5346	CC0
+mesh:D055423	skos:exactMatch	efo:0009371	Diet, Ketogenic	ketogenic diet	orcid:0000-0001-9439-5346	CC0
+mesh:D055430	skos:exactMatch	hgnc:1068	Bone Morphogenetic Protein 15	BMP15	orcid:0000-0001-9439-5346	CC0
+mesh:D055436	skos:exactMatch	hgnc:30142	Growth Differentiation Factor 15	GDF15	orcid:0000-0001-9439-5346	CC0
+mesh:D055451	skos:exactMatch	hgnc:4218	Growth Differentiation Factor 3	GDF3	orcid:0000-0001-9439-5346	CC0
+mesh:D055415	skos:exactMatch	hgnc:1071	Bone Morphogenetic Protein 4	BMP4	orcid:0000-0001-9439-5346	CC0
+mesh:D055398	skos:exactMatch	hgnc:1070	Bone Morphogenetic Protein 3	BMP3	orcid:0000-0001-9439-5346	CC0
+mesh:D055413	skos:exactMatch	hgnc:4215	Growth Differentiation Factor 10	GDF10	orcid:0000-0001-9439-5346	CC0
+mesh:D054876	skos:exactMatch	go:GO:0097354	Prenylation	prenylation	orcid:0000-0001-9439-5346	CC0
+mesh:D054816	skos:exactMatch	chebi:CHEBI:51174	Levopropoxyphene	levopropoxyphene	orcid:0000-0001-9439-5346	CC0
+mesh:D055257	skos:exactMatch	hgnc:7516	Mucin-5B	MUC5B	orcid:0000-0001-9439-5346	CC0
+mesh:D055262	skos:exactMatch	hgnc:7512	Mucin-2	MUC2	orcid:0000-0001-9439-5346	CC0
+mesh:D055272	skos:exactMatch	hgnc:7517	Mucin-6	MUC6	orcid:0000-0001-9439-5346	CC0
+mesh:D054638	skos:exactMatch	hgnc:3064	Dual Specificity Phosphatase 1	DUSP1	orcid:0000-0001-9439-5346	CC0
+mesh:D054640	skos:exactMatch	hgnc:3069	Dual Specificity Phosphatase 3	DUSP3	orcid:0000-0001-9439-5346	CC0
+mesh:D054642	skos:exactMatch	hgnc:3072	Dual Specificity Phosphatase 6	DUSP6	orcid:0000-0001-9439-5346	CC0
+mesh:D054414	skos:exactMatch	hgnc:10615	Chemokine CCL17	CCL17	orcid:0000-0001-9439-5346	CC0
+mesh:D054415	skos:exactMatch	hgnc:10617	Chemokine CCL19	CCL19	orcid:0000-0001-9439-5346	CC0
+mesh:D054418	skos:exactMatch	hgnc:10619	Chemokine CCL20	CCL20	orcid:0000-0001-9439-5346	CC0
+mesh:D054422	skos:exactMatch	hgnc:10621	Chemokine CCL22	CCL22	orcid:0000-0001-9439-5346	CC0
+mesh:D054423	skos:exactMatch	hgnc:10623	Chemokine CCL24	CCL24	orcid:0000-0001-9439-5346	CC0
+mesh:D054425	skos:exactMatch	hgnc:10626	Chemokine CCL27	CCL27	orcid:0000-0001-9439-5346	CC0
+mesh:D054426	skos:exactMatch	hgnc:4603	Chemokine CXCL2	CXCL2	orcid:0000-0001-9439-5346	CC0
+mesh:D054427	skos:exactMatch	hgnc:10643	Chemokine CXCL6	CXCL6	orcid:0000-0001-9439-5346	CC0
+mesh:D054447	skos:exactMatch	hgnc:4474	Receptors, CCR10	CCR10	orcid:0000-0001-9439-5346	CC0
+mesh:D054377	skos:exactMatch	hgnc:10672	Chemokine CXCL12	CXCL12	orcid:0000-0001-9439-5346	CC0
+mesh:D054380	skos:exactMatch	hgnc:1060	Receptors, CXCR5	CXCR5	orcid:0000-0001-9439-5346	CC0
+mesh:D054390	skos:exactMatch	hgnc:1603	Receptors, CCR2	CCR2	orcid:0000-0001-9439-5346	CC0
+mesh:D054397	skos:exactMatch	hgnc:1604	Receptors, CCR3	CCR3	orcid:0000-0001-9439-5346	CC0
+mesh:D054405	skos:exactMatch	hgnc:10627	Chemokine CCL3	CCL3	orcid:0000-0001-9439-5346	CC0
+mesh:D054410	skos:exactMatch	hgnc:10634	Chemokine CCL7	CCL7	orcid:0000-0001-9439-5346	CC0
+mesh:D054412	skos:exactMatch	hgnc:10635	Chemokine CCL8	CCL8	orcid:0000-0001-9439-5346	CC0
+mesh:D054341	skos:exactMatch	hgnc:6338	Receptors, KIR3DL1	KIR3DL1	orcid:0000-0001-9439-5346	CC0
+mesh:D054342	skos:exactMatch	hgnc:6329	Receptors, KIR2DL1	KIR2DL1	orcid:0000-0001-9439-5346	CC0
+mesh:D054343	skos:exactMatch	hgnc:6330	Receptors, KIR2DL2	KIR2DL2	orcid:0000-0001-9439-5346	CC0
+mesh:D054344	skos:exactMatch	hgnc:6331	Receptors, KIR2DL3	KIR2DL3	orcid:0000-0001-9439-5346	CC0
+mesh:D054347	skos:exactMatch	hgnc:6339	Receptors, KIR3DL2	KIR3DL2	orcid:0000-0001-9439-5346	CC0
+mesh:D054360	skos:exactMatch	hgnc:4602	Chemokine CXCL1	CXCL1	orcid:0000-0001-9439-5346	CC0
+mesh:D053781	skos:exactMatch	hgnc:11768	Transforming Growth Factor beta2	TGFB2	orcid:0000-0001-9439-5346	CC0
+mesh:D053782	skos:exactMatch	hgnc:11769	Transforming Growth Factor beta3	TGFB3	orcid:0000-0001-9439-5346	CC0
+mesh:D054079	skos:exactMatch	efo:0006888	Vascular Malformations	vascular malformation	orcid:0000-0001-9439-5346	CC0
+mesh:D053613	skos:exactMatch	hgnc:6190	Janus Kinase 1	JAK1	orcid:0000-0001-9439-5346	CC0
+mesh:D053614	skos:exactMatch	hgnc:6192	Janus Kinase 2	JAK2	orcid:0000-0001-9439-5346	CC0
+mesh:D053616	skos:exactMatch	hgnc:6193	Janus Kinase 3	JAK3	orcid:0000-0001-9439-5346	CC0
+mesh:D053626	skos:exactMatch	chebi:CHEBI:575568	Atovaquone	atovaquone	orcid:0000-0001-9439-5346	CC0
+mesh:D053634	skos:exactMatch	hgnc:12440	TYK2 Kinase	TYK2	orcid:0000-0001-9439-5346	CC0
+mesh:D053533	skos:exactMatch	hgnc:6446	Keratin-8	KRT8	orcid:0000-0001-9439-5346	CC0
+mesh:D053535	skos:exactMatch	hgnc:6415	Keratin-13	KRT13	orcid:0000-0001-9439-5346	CC0
+mesh:D053537	skos:exactMatch	hgnc:6427	Keratin-17	KRT17	orcid:0000-0001-9439-5346	CC0
+mesh:D053538	skos:exactMatch	hgnc:6430	Keratin-18	KRT18	orcid:0000-0001-9439-5346	CC0
+mesh:D053539	skos:exactMatch	hgnc:6436	Keratin-19	KRT19	orcid:0000-0001-9439-5346	CC0
+mesh:D053179	skos:exactMatch	hgnc:1508	Caspase 7	CASP7	orcid:0000-0001-9439-5346	CC0
+mesh:D053181	skos:exactMatch	hgnc:1509	Caspase 8	CASP8	orcid:0000-0001-9439-5346	CC0
+mesh:D051526	skos:exactMatch	hgnc:3666	Fibroblast Growth Factor 10	FGF10	orcid:0000-0001-9439-5346	CC0
+mesh:D051538	skos:exactMatch	hgnc:11621	Hepatocyte Nuclear Factor 1-alpha	HNF1A	orcid:0000-0001-9439-5346	CC0
+mesh:D051539	skos:exactMatch	hgnc:11630	Hepatocyte Nuclear Factor 1-beta	HNF1B	orcid:0000-0001-9439-5346	CC0
+mesh:D051357	skos:exactMatch	hgnc:1771	Cyclin-Dependent Kinase 2	CDK2	orcid:0000-0001-9439-5346	CC0
+mesh:D051358	skos:exactMatch	hgnc:1773	Cyclin-Dependent Kinase 4	CDK4	orcid:0000-0001-9439-5346	CC0
+mesh:D051360	skos:exactMatch	hgnc:1774	Cyclin-Dependent Kinase 5	CDK5	orcid:0000-0001-9439-5346	CC0
+mesh:D051361	skos:exactMatch	hgnc:1777	Cyclin-Dependent Kinase 6	CDK6	orcid:0000-0001-9439-5346	CC0
+mesh:D051383	skos:exactMatch	hgnc:4564	GRB10 Adaptor Protein	GRB10	orcid:0000-0001-9439-5346	CC0
+mesh:D051523	skos:exactMatch	hgnc:3685	Fibroblast Growth Factor 7	FGF7	orcid:0000-0001-9439-5346	CC0
+mesh:D051524	skos:exactMatch	hgnc:3686	Fibroblast Growth Factor 8	FGF8	orcid:0000-0001-9439-5346	CC0
+mesh:C486356	skos:exactMatch	uniprot:P61328	FGF12 protein, human	FGF12	orcid:0000-0001-9439-5346	CC0
+mesh:C484724	skos:exactMatch	uniprot:O60258	FGF17 protein, human	FGF17	orcid:0000-0001-9439-5346	CC0
+mesh:C117476	skos:exactMatch	uniprot:O95750	FGF19 protein, human	FGF19	orcid:0000-0001-9439-5346	CC0
+mesh:C496444	skos:exactMatch	uniprot:P11487	FGF3 protein, human	FGF3	orcid:0000-0001-9439-5346	CC0
+mesh:C512705	skos:exactMatch	uniprot:O43320	FGF16 protein, human	FGF16	orcid:0000-0001-9439-5346	CC0
+mesh:C496445	skos:exactMatch	uniprot:P08620	FGF4 protein, human	FGF4	orcid:0000-0001-9439-5346	CC0
+mesh:C417531	skos:exactMatch	uniprot:Q8N441	FGFRL1 protein, human	FGFRL1	orcid:0000-0001-9439-5346	CC0
+mesh:C416003	skos:exactMatch	uniprot:Q9NP95	FGF20 protein, human	FGF20	orcid:0000-0001-9439-5346	CC0
+mesh:C496463	skos:exactMatch	uniprot:O15520	FGF10 protein, human	FGF10	orcid:0000-0001-9439-5346	CC0
+mesh:C496449	skos:exactMatch	uniprot:P12034	FGF5 protein, human	FGF5	orcid:0000-0001-9439-5346	CC0
+mesh:C496452	skos:exactMatch	uniprot:P10767	FGF6 protein, human	FGF6	orcid:0000-0001-9439-5346	CC0
+mesh:C496456	skos:exactMatch	uniprot:P55075	FGF8 protein, human	FGF8	orcid:0000-0001-9439-5346	CC0
+mesh:C496459	skos:exactMatch	uniprot:P31371	FGF9 protein, human	FGF9	orcid:0000-0001-9439-5346	CC0
+mesh:C496453	skos:exactMatch	uniprot:P21781	FGF7 protein, human	FGF7	orcid:0000-0001-9439-5346	CC0
+mesh:C496353	skos:exactMatch	uniprot:P21802	FGFR2 protein, human	FGFR2	orcid:0000-0001-9439-5346	CC0
+mesh:C496365	skos:exactMatch	uniprot:P22607	FGFR3 protein, human	FGFR3	orcid:0000-0001-9439-5346	CC0
+mesh:C496371	skos:exactMatch	uniprot:P22455	FGFR4 protein, human	FGFR4	orcid:0000-0001-9439-5346	CC0
+mesh:C496348	skos:exactMatch	uniprot:P11362	FGFR1 protein, human	FGFR1	orcid:0000-0001-9439-5346	CC0
+mesh:C000627735	skos:exactMatch	uniprot:Q9HCT0	FGF22 protein, human	FGF22	orcid:0000-0001-9439-5346	CC0
+mesh:C000706947	skos:exactMatch	uniprot:Q9NSA1	FGF21 protein, human	FGF21	orcid:0000-0001-9439-5346	CC0
+mesh:D016222	skos:exactMatch	hgnc:3676	Fibroblast Growth Factor 2	FGF2	orcid:0000-0001-9439-5346	CC0
+mesh:D016220	skos:exactMatch	hgnc:3665	Fibroblast Growth Factor 1	FGF1	orcid:0000-0001-9439-5346	CC0
+mesh:D042863	skos:exactMatch	hgnc:1780	Cyclin-Dependent Kinase 9	CDK9	orcid:0000-0001-9439-5346	CC0
+mesh:C000598645	skos:exactMatch	doid:DOID:0080091	Spheroid body myopathy	spheroid body myopathy	orcid:0000-0003-4423-4370	CC0
+mesh:C000596385	skos:exactMatch	doid:DOID:0111404	Jalili syndrome	Jalili syndrome	orcid:0000-0003-4423-4370	CC0
+mesh:C000626124	skos:exactMatch	doid:DOID:0060728	NGLY1 deficiency	NGLY1-deficiency	orcid:0000-0003-4423-4370	CC0
+mesh:C000656784	skos:exactMatch	doid:DOID:0050072	adiaspiromycosis	adiaspiromycosis	orcid:0000-0003-4423-4370	CC0
+mesh:C000656825	skos:exactMatch	doid:DOID:0050096	tinea barbae	tinea barbae	orcid:0000-0003-4423-4370	CC0
+mesh:C000656904	skos:exactMatch	doid:DOID:8912	tinea nigra	tinea nigra	orcid:0000-0003-4423-4370	CC0
+mesh:C535334	skos:exactMatch	doid:DOID:0050600	ABCD syndrome	ABCD syndrome	orcid:0000-0003-4423-4370	CC0
+mesh:C535358	skos:exactMatch	doid:DOID:980	Choroidal sclerosis	choroidal sclerosis	orcid:0000-0003-4423-4370	CC0
+mesh:C535388	skos:exactMatch	doid:DOID:0050647	Arts syndrome	Arts syndrome	orcid:0000-0003-4423-4370	CC0
+mesh:C535330	skos:exactMatch	doid:DOID:6691	Aagenaes syndrome	Aagenaes syndrome	orcid:0000-0003-4423-4370	CC0
+mesh:C535328	skos:exactMatch	doid:DOID:0060177	Homocarnosinosis	homocarnosinosis	orcid:0000-0003-4423-4370	CC0
+mesh:C535416	skos:exactMatch	doid:DOID:0110158	Charcot-Marie-Tooth disease, Type 2I	Charcot-Marie-Tooth disease type 2I	orcid:0000-0003-4423-4370	CC0
+mesh:C535420	skos:exactMatch	doid:DOID:0110191	Charcot-Marie-Tooth disease, Type 4B1	Charcot-Marie-Tooth disease type 4B1	orcid:0000-0003-4423-4370	CC0
+mesh:C535421	skos:exactMatch	doid:DOID:0110190	Charcot-Marie-Tooth disease, Type 4B2	Charcot-Marie-Tooth disease type 4B2	orcid:0000-0003-4423-4370	CC0
+mesh:C535436	skos:exactMatch	doid:DOID:0050663	Bethlem myopathy	Bethlem myopathy	orcid:0000-0003-4423-4370	CC0
+mesh:C535440	skos:exactMatch	doid:DOID:0050664	Bietti Crystalline Dystrophy	Bietti crystalline corneoretinal dystrophy	orcid:0000-0003-4423-4370	CC0
+mesh:C535549	skos:exactMatch	doid:DOID:3927	Pelvic lipomatosis	pelvic lipomatosis	orcid:0000-0003-4423-4370	CC0
+mesh:D066146	skos:exactMatch	go:GO:0044297	Cell Body	cell body	orcid:0000-0001-9439-5346	CC0
+mesh:C019919	skos:exactMatch	go:GO:1990143	CoA-synthesizing protein complex	CoA-synthesizing protein complex	orcid:0000-0001-9439-5346	CC0
+mesh:C035492	skos:exactMatch	go:GO:0031838	haptoglobin-hemoglobin complex	haptoglobin-hemoglobin complex	orcid:0000-0001-9439-5346	CC0
+mesh:C033727	skos:exactMatch	go:GO:0045283	fumarate reductase complex	fumarate reductase complex	orcid:0000-0001-9439-5346	CC0
+mesh:D000071218	skos:exactMatch	go:GO:0007624	Ultradian Rhythm	ultradian rhythm	orcid:0000-0001-9439-5346	CC0
+mesh:D000071437	skos:exactMatch	go:GO:0007411	Axon Guidance	axon guidance	orcid:0000-0001-9439-5346	CC0
+mesh:D000071444	skos:exactMatch	go:GO:0042331	Phototaxis	phototaxis	orcid:0000-0001-9439-5346	CC0
+mesh:D000071448	skos:exactMatch	go:GO:0007413	Axon Fasciculation	axonal fasciculation	orcid:0000-0001-9439-5346	CC0
+mesh:D000072159	skos:exactMatch	go:GO:0005869	Dynactin Complex	dynactin complex	orcid:0000-0001-9439-5346	CC0
+mesh:D000072777	skos:exactMatch	go:GO:0032537	Host-Seeking Behavior	host-seeking behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D000073398	skos:exactMatch	go:GO:0070988	Demethylation	demethylation	orcid:0000-0001-9439-5346	CC0
+mesh:D000073399	skos:exactMatch	go:GO:0080111	DNA Demethylation	DNA demethylation	orcid:0000-0001-9439-5346	CC0
+mesh:D000079403	skos:exactMatch	go:GO:0097707	Ferroptosis	ferroptosis	orcid:0000-0001-9439-5346	CC0
+mesh:D000078790	skos:exactMatch	go:GO:0030073	Insulin Secretion	insulin secretion	orcid:0000-0001-9439-5346	CC0
+mesh:D000077320	skos:exactMatch	go:GO:0110148	Biomineralization	biomineralization	orcid:0000-0001-9439-5346	CC0
+mesh:D000205	skos:exactMatch	go:GO:0042641	Actomyosin	actomyosin	orcid:0000-0001-9439-5346	CC0
+mesh:D000200	skos:exactMatch	go:GO:0001508	Action Potentials	action potential	orcid:0000-0001-9439-5346	CC0
+mesh:D000566	skos:exactMatch	go:GO:0097186	Amelogenesis	amelogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D000077743	skos:exactMatch	chebi:CHEBI:23847	Diterpene Alkaloids	diterpene alkaloid	orcid:0000-0001-9439-5346	CC0
+mesh:D000738	skos:exactMatch	chebi:CHEBI:16032	Androsterone	androsterone	orcid:0000-0001-9439-5346	CC0
+mesh:D000688	skos:exactMatch	chebi:CHEBI:28102	Amylose	amylose	orcid:0000-0001-9439-5346	CC0
+mesh:D000687	skos:exactMatch	chebi:CHEBI:28057	Amylopectin	amylopectin	orcid:0000-0001-9439-5346	CC0
+mesh:D000080549	skos:exactMatch	go:GO:0048102	Autophagic Cell Death	autophagic cell death	orcid:0000-0001-9439-5346	CC0
+mesh:D000940	skos:exactMatch	go:GO:0020033	Antigenic Variation	antigenic variation	orcid:0000-0001-9439-5346	CC0
+mesh:D001370	skos:exactMatch	go:GO:0098930	Axonal Transport	axonal transport	orcid:0000-0001-9439-5346	CC0
+mesh:D001777	skos:exactMatch	go:GO:0007596	Blood Coagulation	blood coagulation	orcid:0000-0001-9439-5346	CC0
+mesh:D002448	skos:exactMatch	go:GO:0007155	Cell Adhesion	cell adhesion	orcid:0000-0001-9439-5346	CC0
+mesh:D002449	skos:exactMatch	go:GO:0098743	Cell Aggregation	cell aggregation	orcid:0000-0001-9439-5346	CC0
+mesh:D002450	skos:exactMatch	go:GO:0007154	Cell Communication	cell communication	orcid:0000-0001-9439-5346	CC0
+mesh:D002453	skos:exactMatch	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0001-9439-5346	CC0
+mesh:D002455	skos:exactMatch	go:GO:0051301	Cell Division	cell division	orcid:0000-0001-9439-5346	CC0
+mesh:D002473	skos:exactMatch	go:GO:0005618	Cell Wall	cell wall	orcid:0000-0001-9439-5346	CC0
+mesh:D002634	skos:exactMatch	go:GO:0030595	Chemotaxis, Leukocyte	leukocyte chemotaxis	orcid:0000-0001-9439-5346	CC0
+mesh:D002837	skos:exactMatch	go:GO:0042583	Chromaffin Granules	chromaffin granule	orcid:0000-0001-9439-5346	CC0
+mesh:D003216	skos:exactMatch	go:GO:0035106	Conditioning, Operant	operant conditioning	orcid:0000-0001-9439-5346	CC0
+mesh:D003260	skos:exactMatch	go:GO:0060242	Contact Inhibition	contact inhibition	orcid:0000-0001-9439-5346	CC0
+mesh:D003307	skos:exactMatch	go:GO:0007620	Copulation	copulation	orcid:0000-0001-9439-5346	CC0
+mesh:D003341	skos:exactMatch	go:GO:0001554	Luteolysis	luteolysis	orcid:0000-0001-9439-5346	CC0
+mesh:D003595	skos:exactMatch	go:GO:0099636	Cytoplasmic Streaming	cytoplasmic streaming	orcid:0000-0001-9439-5346	CC0
+mesh:D003623	skos:exactMatch	go:GO:1990603	Dark Adaptation	dark adaptation	orcid:0000-0001-9439-5346	CC0
+mesh:D003810	skos:exactMatch	go:GO:0097187	Dentinogenesis	dentinogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D004031	skos:exactMatch	go:GO:0060207	Diestrus	diestrus	orcid:0000-0001-9439-5346	CC0
+mesh:D004063	skos:exactMatch	go:GO:0007586	Digestion	digestion	orcid:0000-0001-9439-5346	CC0
+mesh:D004327	skos:exactMatch	go:GO:0042756	Drinking Behavior	drinking behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D004455	skos:exactMatch	go:GO:0050959	Echolocation	echolocation	orcid:0000-0001-9439-5346	CC0
+mesh:D004705	skos:exactMatch	go:GO:0006897	Endocytosis	endocytosis	orcid:0000-0001-9439-5346	CC0
+mesh:D004903	skos:exactMatch	go:GO:0034117	Erythrocyte Aggregation	erythrocyte aggregation	orcid:0000-0001-9439-5346	CC0
+mesh:D004956	skos:exactMatch	go:GO:0042751	Estivation	estivation	orcid:0000-0001-9439-5346	CC0
+mesh:D005247	skos:exactMatch	go:GO:0007631	Feeding Behavior	feeding behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D005342	skos:exactMatch	go:GO:0042730	Fibrinolysis	fibrinolysis	orcid:0000-0001-9439-5346	CC0
+mesh:D005427	skos:exactMatch	go:GO:0000128	Flocculation	flocculation	orcid:0000-0001-9439-5346	CC0
+mesh:D005785	skos:exactMatch	go:GO:0035822	Gene Conversion	gene conversion	orcid:0000-0001-9439-5346	CC0
+mesh:D005786	skos:exactMatch	go:GO:0010468	Gene Expression Regulation	regulation of gene expression	orcid:0000-0001-9439-5346	CC0
+mesh:D005790	skos:exactMatch	go:GO:0051866	General Adaptation Syndrome	general adaptation syndrome	orcid:0000-0001-9439-5346	CC0
+mesh:D006031	skos:exactMatch	go:GO:0070085	Glycosylation	glycosylation	orcid:0000-0001-9439-5346	CC0
+mesh:D006605	skos:exactMatch	go:GO:0042750	Hibernation	hibernation	orcid:0000-0001-9439-5346	CC0
+mesh:D007314	skos:exactMatch	go:GO:0007320	Insemination	insemination	orcid:0000-0001-9439-5346	CC0
+mesh:D007408	skos:exactMatch	go:GO:0050892	Intestinal Absorption	intestinal absorption	orcid:0000-0001-9439-5346	CC0
+mesh:D007698	skos:exactMatch	go:GO:0042465	Kinesis	kinesis	orcid:0000-0001-9439-5346	CC0
+mesh:D007774	skos:exactMatch	go:GO:0007595	Lactation	lactation	orcid:0000-0001-9439-5346	CC0
+mesh:D008115	skos:exactMatch	go:GO:0097421	Liver Regeneration	liver regeneration	orcid:0000-0001-9439-5346	CC0
+mesh:D008247	skos:exactMatch	go:GO:0005764	Lysosomes	lysosome	orcid:0000-0001-9439-5346	CC0
+mesh:D008262	skos:exactMatch	go:GO:0042116	Macrophage Activation	macrophage activation	orcid:0000-0001-9439-5346	CC0
+mesh:D008425	skos:exactMatch	go:GO:0042711	Maternal Behavior	maternal behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D008561	skos:exactMatch	go:GO:0061025	Membrane Fusion	membrane fusion	orcid:0000-0001-9439-5346	CC0
+mesh:D008566	skos:exactMatch	go:GO:0016020	Membranes	membrane	orcid:0000-0001-9439-5346	CC0
+mesh:D008686	skos:exactMatch	go:GO:0060210	Metestrus	metestrus	orcid:0000-0001-9439-5346	CC0
+mesh:D008745	skos:exactMatch	go:GO:0032259	Methylation	methylation	orcid:0000-0001-9439-5346	CC0
+mesh:D009043	skos:exactMatch	go:GO:0003774	Motor Activity	motor activity	orcid:0000-0001-9439-5346	CC0
+mesh:D009079	skos:exactMatch	go:GO:0120197	Mucociliary Clearance	mucociliary clearance	orcid:0000-0001-9439-5346	CC0
+mesh:D009210	skos:exactMatch	go:GO:0030016	Myofibrils	myofibril	orcid:0000-0001-9439-5346	CC0
+mesh:D009469	skos:exactMatch	go:GO:0031594	Neuromuscular Junction	neuromuscular junction	orcid:0000-0001-9439-5346	CC0
+mesh:D009586	skos:exactMatch	go:GO:0009399	Nitrogen Fixation	nitrogen fixation	orcid:0000-0001-9439-5346	CC0
+mesh:D009697	skos:exactMatch	go:GO:0005731	Nucleolus Organizer Region	nucleolus organizer region	orcid:0000-0001-9439-5346	CC0
+mesh:D010058	skos:exactMatch	go:GO:0018991	Oviposition	oviposition	orcid:0000-0001-9439-5346	CC0
+mesh:D010064	skos:exactMatch	go:GO:0007566	Embryo Implantation	embryo implantation	orcid:0000-0001-9439-5346	CC0
+mesh:D010332	skos:exactMatch	go:GO:0042712	Paternal Behavior	paternal behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D010410	skos:exactMatch	go:GO:0043084	Penile Erection	penile erection	orcid:0000-0001-9439-5346	CC0
+mesh:D010452	skos:exactMatch	go:GO:0043043	Peptide Biosynthesis	peptide biosynthetic process	orcid:0000-0001-9439-5346	CC0
+mesh:D010873	skos:exactMatch	go:GO:0006907	Pinocytosis	pinocytosis	orcid:0000-0001-9439-5346	CC0
+mesh:D010974	skos:exactMatch	go:GO:0070527	Platelet Aggregation	platelet aggregation	orcid:0000-0001-9439-5346	CC0
+mesh:D010766	skos:exactMatch	go:GO:0016310	Phosphorylation	phosphorylation	orcid:0000-0001-9439-5346	CC0
+mesh:D011359	skos:exactMatch	go:GO:0060208	Proestrus	proestrus	orcid:0000-0001-9439-5346	CC0
+mesh:D011434	skos:exactMatch	go:GO:0019230	Proprioception	proprioception	orcid:0000-0001-9439-5346	CC0
+mesh:D011485	skos:exactMatch	go:GO:0005515	Protein Binding	protein binding	orcid:0000-0001-9439-5346	CC0
+mesh:D011489	skos:exactMatch	go:GO:0030164	Protein Denaturation	protein denaturation	orcid:0000-0001-9439-5346	CC0
+mesh:D011554	skos:exactMatch	go:GO:0031143	Pseudopodia	pseudopodium	orcid:0000-0001-9439-5346	CC0
+mesh:D012270	skos:exactMatch	go:GO:0005840	Ribosomes	ribosome	orcid:0000-0001-9439-5346	CC0
+mesh:D012472	skos:exactMatch	go:GO:0046541	Salivation	saliva secretion	orcid:0000-0001-9439-5346	CC0
+mesh:D012728	skos:exactMatch	go:GO:0001739	Sex Chromatin	sex chromatin	orcid:0000-0001-9439-5346	CC0
+mesh:D012733	skos:exactMatch	go:GO:0007548	Sex Differentiation	sex differentiation	orcid:0000-0001-9439-5346	CC0
+mesh:D012919	skos:exactMatch	go:GO:0035176	Social Behavior	social behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D013049	skos:exactMatch	go:GO:0008091	Spectrin	spectrin	orcid:0000-0001-9439-5346	CC0
+mesh:D013075	skos:exactMatch	go:GO:0048240	Sperm Capacitation	sperm capacitation	orcid:0000-0001-9439-5346	CC0
+mesh:D013077	skos:exactMatch	go:GO:0061827	Sperm Head	sperm head	orcid:0000-0001-9439-5346	CC0
+mesh:D013394	skos:exactMatch	go:GO:0070014	Sucrase-Isomaltase Complex	sucrase-isomaltase complex	orcid:0000-0001-9439-5346	CC0
+mesh:D013559	skos:exactMatch	go:GO:0044403	Symbiosis	symbiotic process	orcid:0000-0001-9439-5346	CC0
+mesh:D013570	skos:exactMatch	go:GO:0097060	Synaptic Membranes	synaptic membrane	orcid:0000-0001-9439-5346	CC0
+mesh:D013572	skos:exactMatch	go:GO:0008021	Synaptic Vesicles	synaptic vesicle	orcid:0000-0001-9439-5346	CC0
+mesh:D013573	skos:exactMatch	go:GO:0000795	Synaptonemal Complex	synaptonemal complex	orcid:0000-0001-9439-5346	CC0
+mesh:D014661	skos:exactMatch	go:GO:0042310	Vasoconstriction	vasoconstriction	orcid:0000-0001-9439-5346	CC0
+mesh:D014818	skos:exactMatch	go:GO:0007296	Vitellogenesis	vitellogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D016631	skos:exactMatch	go:GO:0097413	Lewy Bodies	Lewy body	orcid:0000-0001-9439-5346	CC0
+mesh:D016874	skos:exactMatch	go:GO:0097418	Neurofibrillary Tangles	neurofibrillary tangle	orcid:0000-0001-9439-5346	CC0
+mesh:D017368	skos:exactMatch	go:GO:0018342	Protein Prenylation	protein prenylation	orcid:0000-0001-9439-5346	CC0
+mesh:D015870	skos:exactMatch	go:GO:0010467	Gene Expression	gene expression	orcid:0000-0001-9439-5346	CC0
+mesh:D018087	skos:exactMatch	go:GO:0009536	Plastids	plastid	orcid:0000-0001-9439-5346	CC0
+mesh:D018271	skos:exactMatch	go:GO:0048500	Signal Recognition Particle	signal recognition particle	orcid:0000-0001-9439-5346	CC0
+mesh:D018386	skos:exactMatch	go:GO:0000776	Kinetochores	kinetochore	orcid:0000-0001-9439-5346	CC0
+mesh:D018522	skos:exactMatch	go:GO:0009630	Gravitropism	gravitropism	orcid:0000-0001-9439-5346	CC0
+mesh:D018523	skos:exactMatch	go:GO:0009606	Tropism	tropism	orcid:0000-0001-9439-5346	CC0
+mesh:D018524	skos:exactMatch	go:GO:0009638	Phototropism	phototropism	orcid:0000-0001-9439-5346	CC0
+mesh:D019175	skos:exactMatch	go:GO:0006306	DNA Methylation	DNA methylation	orcid:0000-0001-9439-5346	CC0
+mesh:D019599	skos:exactMatch	go:GO:0097457	Mossy Fibers, Hippocampal	hippocampal mossy fiber	orcid:0000-0001-9439-5346	CC0
+mesh:D019706	skos:exactMatch	go:GO:0060079	Excitatory Postsynaptic Potentials	excitatory postsynaptic potential	orcid:0000-0001-9439-5346	CC0
+mesh:D019898	skos:exactMatch	go:GO:0035425	Autocrine Communication	autocrine signaling	orcid:0000-0001-9439-5346	CC0
+mesh:D019899	skos:exactMatch	go:GO:0038001	Paracrine Communication	paracrine signaling	orcid:0000-0001-9439-5346	CC0
+mesh:D020101	skos:exactMatch	go:GO:0007340	Acrosome Reaction	acrosome reaction	orcid:0000-0001-9439-5346	CC0
+mesh:D020439	skos:exactMatch	go:GO:0030426	Growth Cones	growth cone	orcid:0000-0001-9439-5346	CC0
+mesh:D020460	skos:exactMatch	go:GO:0042470	Melanosomes	melanosome	orcid:0000-0001-9439-5346	CC0
+mesh:D020524	skos:exactMatch	go:GO:0009579	Thylakoids	thylakoid	orcid:0000-0001-9439-5346	CC0
+mesh:D020675	skos:exactMatch	go:GO:0005777	Peroxisomes	peroxisome	orcid:0000-0001-9439-5346	CC0
+mesh:D020676	skos:exactMatch	go:GO:0009514	Glyoxysomes	glyoxysome	orcid:0000-0001-9439-5346	CC0
+mesh:D020868	skos:exactMatch	go:GO:0016458	Gene Silencing	gene silencing	orcid:0000-0001-9439-5346	CC0
+mesh:D021381	skos:exactMatch	go:GO:0015031	Protein Transport	protein transport	orcid:0000-0001-9439-5346	CC0
+mesh:D021601	skos:exactMatch	go:GO:0005802	trans-Golgi Network	trans-Golgi network	orcid:0000-0001-9439-5346	CC0
+mesh:D022162	skos:exactMatch	go:GO:0031410	Cytoplasmic Vesicles	cytoplasmic vesicle	orcid:0000-0001-9439-5346	CC0
+mesh:D022163	skos:exactMatch	go:GO:0030136	Clathrin-Coated Vesicles	clathrin-coated vesicle	orcid:0000-0001-9439-5346	CC0
+mesh:D022502	skos:exactMatch	go:GO:0001725	Stress Fibers	stress fiber	orcid:0000-0001-9439-5346	CC0
+mesh:D030762	skos:exactMatch	go:GO:0044849	Estrous Cycle	estrous cycle	orcid:0000-0001-9439-5346	CC0
+mesh:D026721	skos:exactMatch	go:GO:0031123	RNA 3' End Processing	RNA 3'-end processing	orcid:0000-0001-9439-5346	CC0
+mesh:D031425	skos:exactMatch	go:GO:0009506	Plasmodesmata	plasmodesma	orcid:0000-0001-9439-5346	CC0
+mesh:D032961	skos:exactMatch	go:GO:0097225	Sperm Midpiece	sperm midpiece	orcid:0000-0001-9439-5346	CC0
+mesh:D034461	skos:exactMatch	go:GO:0001553	Luteinization	luteinization	orcid:0000-0001-9439-5346	CC0
+mesh:D036881	skos:exactMatch	go:GO:0060292	Long-Term Synaptic Depression	long-term synaptic depression	orcid:0000-0001-9439-5346	CC0
+mesh:D042003	skos:exactMatch	go:GO:0006323	DNA Packaging	DNA packaging	orcid:0000-0001-9439-5346	CC0
+mesh:D021962	skos:exactMatch	go:GO:0098857	Membrane Microdomains	membrane microdomain	orcid:0000-0001-9439-5346	CC0
+mesh:D043762	skos:exactMatch	go:GO:0019098	Reproductive Behavior	reproductive behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D044603	skos:exactMatch	go:GO:0043263	Cellulosomes	cellulosome	orcid:0000-0001-9439-5346	CC0
+mesh:D045524	skos:exactMatch	go:GO:0030089	Phycobilisomes	phycobilisome	orcid:0000-0001-9439-5346	CC0
+mesh:D046148	skos:exactMatch	go:GO:0007535	Donor Selection	donor selection	orcid:0000-0001-9439-5346	CC0
+mesh:D048648	skos:exactMatch	go:GO:0031039	Macronucleus	macronucleus	orcid:0000-0001-9439-5346	CC0
+mesh:D049229	skos:exactMatch	go:GO:0043197	Dendritic Spines	dendritic spine	orcid:0000-0001-9439-5346	CC0
+mesh:D049469	skos:exactMatch	go:GO:0007128	Meiotic Prophase I	meiotic prophase I	orcid:0000-0001-9439-5346	CC0
+mesh:D046249	skos:exactMatch	go:GO:0043039	Transfer RNA Aminoacylation	tRNA aminoacylation	orcid:0000-0001-9439-5346	CC0
+mesh:D050356	skos:exactMatch	go:GO:0006629	Lipid Metabolism	lipid metabolic process	orcid:0000-0001-9439-5346	CC0
+mesh:D053478	skos:exactMatch	go:GO:0043293	Apoptosomes	apoptosome	orcid:0000-0001-9439-5346	CC0
+mesh:D054262	skos:exactMatch	go:GO:0007369	Gastrulation	gastrulation	orcid:0000-0001-9439-5346	CC0
+mesh:D054337	skos:exactMatch	go:GO:0043697	Cell Dedifferentiation	cell dedifferentiation	orcid:0000-0001-9439-5346	CC0
+mesh:D054468	skos:exactMatch	go:GO:0005930	Axoneme	axoneme	orcid:0000-0001-9439-5346	CC0
+mesh:D054657	skos:exactMatch	go:GO:0044391	Ribosome Subunits	ribosomal subunit	orcid:0000-0001-9439-5346	CC0
+mesh:D054658	skos:exactMatch	go:GO:0015934	Ribosome Subunits, Large	large ribosomal subunit	orcid:0000-0001-9439-5346	CC0
+mesh:D054679	skos:exactMatch	go:GO:0015935	Ribosome Subunits, Small	small ribosomal subunit	orcid:0000-0001-9439-5346	CC0
+mesh:D054817	skos:exactMatch	go:GO:0009856	Pollination	pollination	orcid:0000-0001-9439-5346	CC0
+mesh:D054974	skos:exactMatch	go:GO:0043034	Costameres	costamere	orcid:0000-0001-9439-5346	CC0
+mesh:D054992	skos:exactMatch	go:GO:0001772	Immunological Synapses	immunological synapse	orcid:0000-0001-9439-5346	CC0
+mesh:D057897	skos:exactMatch	go:GO:0060013	Reflex, Righting	righting reflex	orcid:0000-0001-9439-5346	CC0
+mesh:D057900	skos:exactMatch	go:GO:0045056	Transcytosis	transcytosis	orcid:0000-0001-9439-5346	CC0
+mesh:D057907	skos:exactMatch	go:GO:0014069	Post-Synaptic Density	postsynaptic density	orcid:0000-0001-9439-5346	CC0
+mesh:D058767	skos:exactMatch	go:GO:0043335	Protein Unfolding	protein unfolding	orcid:0000-0001-9439-5346	CC0
+mesh:D058849	skos:exactMatch	go:GO:0042026	Protein Refolding	protein refolding	orcid:0000-0001-9439-5346	CC0
+mesh:D058894	skos:exactMatch	go:GO:0042151	Nematocyst	nematocyst	orcid:0000-0001-9439-5346	CC0
+mesh:D059007	skos:exactMatch	go:GO:0005700	Polytene Chromosomes	polytene chromosome	orcid:0000-0001-9439-5346	CC0
+mesh:D060049	skos:exactMatch	go:GO:0008356	Asymmetric Cell Division	asymmetric cell division	orcid:0000-0001-9439-5346	CC0
+mesh:D060449	skos:exactMatch	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0001-9439-5346	CC0
+mesh:D065608	skos:exactMatch	go:GO:0070293	Renal Reabsorption	renal absorption	orcid:0000-0001-9439-5346	CC0
+mesh:D000067128	skos:exactMatch	go:GO:1903561	Extracellular Vesicles	extracellular vesicle	orcid:0000-0001-9439-5346	CC0
+mesh:D000069292	skos:exactMatch	go:GO:0070269	Pyroptosis	pyroptosis	orcid:0000-0001-9439-5346	CC0
+mesh:D000071182	skos:exactMatch	go:GO:0005776	Autophagosomes	autophagosome	orcid:0000-0001-9439-5346	CC0
+mesh:D000705	skos:exactMatch	go:GO:0051322	Anaphase	anaphase	orcid:0000-0001-9439-5346	CC0
+mesh:D001329	skos:exactMatch	go:GO:0001896	Autolysis	autolysis	orcid:0000-0001-9439-5346	CC0
+mesh:D001343	skos:exactMatch	go:GO:0006914	Autophagy	autophagy	orcid:0000-0001-9439-5346	CC0
+mesh:D001485	skos:exactMatch	go:GO:0005604	Basement Membrane	basement membrane	orcid:0000-0001-9439-5346	CC0
+mesh:D001519	skos:exactMatch	go:GO:0007610	Behavior	behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D001775	skos:exactMatch	go:GO:0008015	Blood Circulation	blood circulation	orcid:0000-0001-9439-5346	CC0
+mesh:D002454	skos:exactMatch	go:GO:0030154	Cell Differentiation	cell differentiation	orcid:0000-0001-9439-5346	CC0
+mesh:D002462	skos:exactMatch	go:GO:0005886	Cell Membrane	plasma membrane	orcid:0000-0001-9439-5346	CC0
+mesh:D002479	skos:exactMatch	go:GO:0016234	Inclusion Bodies	inclusion body	orcid:0000-0001-9439-5346	CC0
+mesh:D002502	skos:exactMatch	go:GO:0005814	Centrioles	centriole	orcid:0000-0001-9439-5346	CC0
+mesh:D002633	skos:exactMatch	go:GO:0006935	Chemotaxis	chemotaxis	orcid:0000-0001-9439-5346	CC0
+mesh:D002736	skos:exactMatch	go:GO:0009507	Chloroplasts	chloroplast	orcid:0000-0001-9439-5346	CC0
+mesh:D002823	skos:exactMatch	go:GO:0042600	Chorion	chorion	orcid:0000-0001-9439-5346	CC0
+mesh:D002843	skos:exactMatch	go:GO:0000785	Chromatin	chromatin	orcid:0000-0001-9439-5346	CC0
+mesh:D002875	skos:exactMatch	go:GO:0005694	Chromosomes	chromosome	orcid:0000-0001-9439-5346	CC0
+mesh:D002940	skos:exactMatch	go:GO:0007623	Circadian Rhythm	circadian rhythm	orcid:0000-0001-9439-5346	CC0
+mesh:D003071	skos:exactMatch	go:GO:0050890	Cognition	cognition	orcid:0000-0001-9439-5346	CC0
+mesh:D003167	skos:exactMatch	go:GO:0006956	Complement Activation	complement activation	orcid:0000-0001-9439-5346	CC0
+mesh:D003593	skos:exactMatch	go:GO:0005737	Cytoplasm	cytoplasm	orcid:0000-0001-9439-5346	CC0
+mesh:D003599	skos:exactMatch	go:GO:0005856	Cytoskeleton	cytoskeleton	orcid:0000-0001-9439-5346	CC0
+mesh:D003600	skos:exactMatch	go:GO:0005829	Cytosol	cytosol	orcid:0000-0001-9439-5346	CC0
+mesh:D003672	skos:exactMatch	go:GO:0030421	Defecation	defecation	orcid:0000-0001-9439-5346	CC0
+mesh:D003712	skos:exactMatch	go:GO:0030425	Dendrites	dendrite	orcid:0000-0001-9439-5346	CC0
+mesh:D003896	skos:exactMatch	go:GO:0030057	Desmosomes	desmosome	orcid:0000-0001-9439-5346	CC0
+mesh:D004260	skos:exactMatch	go:GO:0006281	DNA Repair	DNA repair	orcid:0000-0001-9439-5346	CC0
+mesh:D004261	skos:exactMatch	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0001-9439-5346	CC0
+mesh:D004721	skos:exactMatch	go:GO:0005783	Endoplasmic Reticulum	endoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
+mesh:D005089	skos:exactMatch	go:GO:0006887	Exocytosis	exocytosis	orcid:0000-0001-9439-5346	CC0
+mesh:D005109	skos:exactMatch	go:GO:0031012	Extracellular Matrix	extracellular matrix	orcid:0000-0001-9439-5346	CC0
+mesh:D005110	skos:exactMatch	go:GO:0005615	Extracellular Space	extracellular space	orcid:0000-0001-9439-5346	CC0
+mesh:D005285	skos:exactMatch	go:GO:0006113	Fermentation	fermentation	orcid:0000-0001-9439-5346	CC0
+mesh:D005306	skos:exactMatch	go:GO:0009566	Fertilization	fertilization	orcid:0000-0001-9439-5346	CC0
+mesh:D005943	skos:exactMatch	go:GO:0006094	Gluconeogenesis	gluconeogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D006019	skos:exactMatch	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0001-9439-5346	CC0
+mesh:D006056	skos:exactMatch	go:GO:0005794	Golgi Apparatus	Golgi apparatus	orcid:0000-0001-9439-5346	CC0
+mesh:D006487	skos:exactMatch	go:GO:0007599	Hemostasis	hemostasis	orcid:0000-0001-9439-5346	CC0
+mesh:D006570	skos:exactMatch	go:GO:0000792	Heterochromatin	heterochromatin	orcid:0000-0001-9439-5346	CC0
+mesh:D006967	skos:exactMatch	go:GO:0002524	Hypersensitivity	hypersensitivity	orcid:0000-0001-9439-5346	CC0
+mesh:D007249	skos:exactMatch	go:GO:0006954	Inflammation	inflammatory response	orcid:0000-0001-9439-5346	CC0
+mesh:D007399	skos:exactMatch	go:GO:0051325	Interphase	interphase	orcid:0000-0001-9439-5346	CC0
+mesh:D007858	skos:exactMatch	go:GO:0007612	Learning	learning	orcid:0000-0001-9439-5346	CC0
+mesh:D008213	skos:exactMatch	go:GO:0046649	Lymphocyte Activation	lymphocyte activation	orcid:0000-0001-9439-5346	CC0
+mesh:D008409	skos:exactMatch	go:GO:0071626	Mastication	mastication	orcid:0000-0001-9439-5346	CC0
+mesh:D008572	skos:exactMatch	go:GO:0042696	Menarche	menarche	orcid:0000-0001-9439-5346	CC0
+mesh:D008593	skos:exactMatch	go:GO:0042697	Menopause	menopause	orcid:0000-0001-9439-5346	CC0
+mesh:D008597	skos:exactMatch	go:GO:0044850	Menstrual Cycle	menstrual cycle	orcid:0000-0001-9439-5346	CC0
+mesh:D008598	skos:exactMatch	go:GO:0042703	Menstruation	menstruation	orcid:0000-0001-9439-5346	CC0
+mesh:D008660	skos:exactMatch	go:GO:0008152	Metabolism	metabolic process	orcid:0000-0001-9439-5346	CC0
+mesh:D008677	skos:exactMatch	go:GO:0051323	Metaphase	metaphase	orcid:0000-0001-9439-5346	CC0
+mesh:D008830	skos:exactMatch	go:GO:0042579	Microbodies	microbody	orcid:0000-0001-9439-5346	CC0
+mesh:D008841	skos:exactMatch	go:GO:0015629	Actin Cytoskeleton	actin cytoskeleton	orcid:0000-0001-9439-5346	CC0
+mesh:D008870	skos:exactMatch	go:GO:0005874	Microtubules	microtubule	orcid:0000-0001-9439-5346	CC0
+mesh:D008928	skos:exactMatch	go:GO:0005739	Mitochondria	mitochondrion	orcid:0000-0001-9439-5346	CC0
+mesh:D009119	skos:exactMatch	go:GO:0006936	Muscle Contraction	muscle contraction	orcid:0000-0001-9439-5346	CC0
+mesh:D009186	skos:exactMatch	go:GO:0043209	Myelin Sheath	myelin sheath	orcid:0000-0001-9439-5346	CC0
+mesh:D009336	skos:exactMatch	go:GO:0070265	Necrosis	necrotic cell death	orcid:0000-0001-9439-5346	CC0
+mesh:D009685	skos:exactMatch	go:GO:0005635	Nuclear Envelope	nuclear envelope	orcid:0000-0001-9439-5346	CC0
+mesh:D009707	skos:exactMatch	go:GO:0000786	Nucleosomes	nucleosome	orcid:0000-0001-9439-5346	CC0
+mesh:D009805	skos:exactMatch	go:GO:0042476	Odontogenesis	odontogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D009866	skos:exactMatch	go:GO:0048477	Oogenesis	oogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D010060	skos:exactMatch	go:GO:0030728	Ovulation	ovulation	orcid:0000-0001-9439-5346	CC0
+mesh:D010085	skos:exactMatch	go:GO:0006119	Oxidative Phosphorylation	oxidative phosphorylation	orcid:0000-0001-9439-5346	CC0
+mesh:D010528	skos:exactMatch	go:GO:0030432	Peristalsis	peristalsis	orcid:0000-0001-9439-5346	CC0
+mesh:D010587	skos:exactMatch	go:GO:0006909	Phagocytosis	phagocytosis	orcid:0000-0001-9439-5346	CC0
+mesh:D010788	skos:exactMatch	go:GO:0015979	Photosynthesis	photosynthesis	orcid:0000-0001-9439-5346	CC0
+mesh:D010858	skos:exactMatch	go:GO:0043473	Pigmentation	pigmentation	orcid:0000-0001-9439-5346	CC0
+mesh:D011235	skos:exactMatch	go:GO:0002120	Predatory Behavior	predatory behavior	orcid:0000-0001-9439-5346	CC0
+mesh:D011418	skos:exactMatch	go:GO:0051324	Prophase	prophase	orcid:0000-0001-9439-5346	CC0
+mesh:D011992	skos:exactMatch	go:GO:0005768	Endosomes	endosome	orcid:0000-0001-9439-5346	CC0
+mesh:D012038	skos:exactMatch	go:GO:0031099	Regeneration	regeneration	orcid:0000-0001-9439-5346	CC0
+mesh:D012098	skos:exactMatch	go:GO:0000003	Reproduction	reproduction	orcid:0000-0001-9439-5346	CC0
+mesh:D012100	skos:exactMatch	go:GO:0019954	Reproduction, Asexual	asexual reproduction	orcid:0000-0001-9439-5346	CC0
+mesh:D012326	skos:exactMatch	go:GO:0008380	RNA Splicing	RNA splicing	orcid:0000-0001-9439-5346	CC0
+mesh:D012508	skos:exactMatch	go:GO:0042383	Sarcolemma	sarcolemma	orcid:0000-0001-9439-5346	CC0
+mesh:D012518	skos:exactMatch	go:GO:0030017	Sarcomeres	sarcomere	orcid:0000-0001-9439-5346	CC0
+mesh:D012519	skos:exactMatch	go:GO:0016529	Sarcoplasmic Reticulum	sarcoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
+mesh:D012730	skos:exactMatch	go:GO:0000803	Sex Chromosomes	sex chromosome	orcid:0000-0001-9439-5346	CC0
+mesh:D013081	skos:exactMatch	go:GO:0097722	Sperm Motility	sperm motility	orcid:0000-0001-9439-5346	CC0
+mesh:D013091	skos:exactMatch	go:GO:0007283	Spermatogenesis	spermatogenesis	orcid:0000-0001-9439-5346	CC0
+mesh:D013550	skos:exactMatch	go:GO:0036268	Swimming	swimming	orcid:0000-0001-9439-5346	CC0
+mesh:D013569	skos:exactMatch	go:GO:0045202	Synapses	synapse	orcid:0000-0001-9439-5346	CC0
+mesh:D013692	skos:exactMatch	go:GO:0051326	Telophase	telophase	orcid:0000-0001-9439-5346	CC0
+mesh:D014078	skos:exactMatch	go:GO:0044691	Tooth Eruption	tooth eruption	orcid:0000-0001-9439-5346	CC0
+mesh:D014617	skos:exactMatch	go:GO:0005773	Vacuoles	vacuole	orcid:0000-0001-9439-5346	CC0
+mesh:D014664	skos:exactMatch	go:GO:0042311	Vasodilation	vasodilation	orcid:0000-0001-9439-5346	CC0
+mesh:D014796	skos:exactMatch	go:GO:0007601	Visual Perception	visual perception	orcid:0000-0001-9439-5346	CC0
+mesh:D014945	skos:exactMatch	go:GO:0042060	Wound Healing	wound healing	orcid:0000-0001-9439-5346	CC0
+mesh:D014960	skos:exactMatch	go:GO:0000805	X Chromosome	X chromosome	orcid:0000-0001-9439-5346	CC0
+mesh:D014998	skos:exactMatch	go:GO:0000806	Y Chromosome	Y chromosome	orcid:0000-0001-9439-5346	CC0
+mesh:D015388	skos:exactMatch	go:GO:0043226	Organelles	organelle	orcid:0000-0001-9439-5346	CC0
+mesh:D015398	skos:exactMatch	go:GO:0007165	Signal Transduction	signal transduction	orcid:0000-0001-9439-5346	CC0
+mesh:D015530	skos:exactMatch	go:GO:0016363	Nuclear Matrix	nuclear matrix	orcid:0000-0001-9439-5346	CC0
+mesh:D015539	skos:exactMatch	go:GO:0030168	Platelet Activation	platelet activation	orcid:0000-0001-9439-5346	CC0
+mesh:D016193	skos:exactMatch	go:GO:0051318	G1 Phase	G1 phase	orcid:0000-0001-9439-5346	CC0
+mesh:D016196	skos:exactMatch	go:GO:0051320	S Phase	S phase	orcid:0000-0001-9439-5346	CC0
+mesh:D016723	skos:exactMatch	go:GO:0046849	Bone Remodeling	bone remodeling	orcid:0000-0001-9439-5346	CC0
+mesh:D016897	skos:exactMatch	go:GO:0045730	Respiratory Burst	respiratory burst	orcid:0000-0001-9439-5346	CC0
+mesh:D016922	skos:exactMatch	go:GO:0090398	Cellular Senescence	cellular senescence	orcid:0000-0001-9439-5346	CC0
+mesh:D017209	skos:exactMatch	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0001-9439-5346	CC0
+mesh:D017510	skos:exactMatch	go:GO:0006457	Protein Folding	protein folding	orcid:0000-0001-9439-5346	CC0
+mesh:D017629	skos:exactMatch	go:GO:0005921	Gap Junctions	gap junction	orcid:0000-0001-9439-5346	CC0
+mesh:D018375	skos:exactMatch	go:GO:0042119	Neutrophil Activation	neutrophil activation	orcid:0000-0001-9439-5346	CC0
+mesh:D018385	skos:exactMatch	go:GO:0005813	Centrosome	centrosome	orcid:0000-0001-9439-5346	CC0
+mesh:D018392	skos:exactMatch	go:GO:0071514	Genomic Imprinting	genetic imprinting	orcid:0000-0001-9439-5346	CC0
+mesh:D018699	skos:exactMatch	go:GO:0030135	Coated Vesicles	coated vesicle	orcid:0000-0001-9439-5346	CC0
+mesh:D018870	skos:exactMatch	go:GO:0005791	Endoplasmic Reticulum, Rough	rough endoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
+mesh:D018871	skos:exactMatch	go:GO:0005790	Endoplasmic Reticulum, Smooth	smooth endoplasmic reticulum	orcid:0000-0001-9439-5346	CC0
+mesh:D019069	skos:exactMatch	go:GO:0045333	Cell Respiration	cellular respiration	orcid:0000-0001-9439-5346	CC0
+mesh:D019108	skos:exactMatch	go:GO:0070160	Tight Junctions	tight junction	orcid:0000-0001-9439-5346	CC0
+mesh:D019154	skos:exactMatch	go:GO:0030908	Protein Splicing	protein splicing	orcid:0000-0001-9439-5346	CC0
+mesh:D019276	skos:exactMatch	go:GO:0030112	Glycocalyx	glycocalyx	orcid:0000-0001-9439-5346	CC0
+mesh:D019457	skos:exactMatch	go:GO:0031052	Chromosome Breakage	chromosome breakage	orcid:0000-0001-9439-5346	CC0
+mesh:D020090	skos:exactMatch	go:GO:0007059	Chromosome Segregation	chromosome segregation	orcid:0000-0001-9439-5346	CC0
+mesh:D020894	skos:exactMatch	go:GO:0001527	Microfibrils	microfibril	orcid:0000-0001-9439-5346	CC0
+mesh:D021941	skos:exactMatch	go:GO:0005901	Caveolae	caveola	orcid:0000-0001-9439-5346	CC0
+mesh:D022002	skos:exactMatch	go:GO:0030056	Hemidesmosomes	hemidesmosome	orcid:0000-0001-9439-5346	CC0
+mesh:D022005	skos:exactMatch	go:GO:0005912	Adherens Junctions	adherens junction	orcid:0000-0001-9439-5346	CC0
+mesh:D022022	skos:exactMatch	go:GO:0005643	Nuclear Pore	nuclear pore	orcid:0000-0001-9439-5346	CC0
+mesh:D022041	skos:exactMatch	go:GO:0000791	Euchromatin	euchromatin	orcid:0000-0001-9439-5346	CC0
+mesh:D022161	skos:exactMatch	go:GO:0030133	Transport Vesicles	transport vesicle	orcid:0000-0001-9439-5346	CC0
+mesh:D023102	skos:exactMatch	go:GO:0043276	Anoikis	anoikis	orcid:0000-0001-9439-5346	CC0
+mesh:D034443	skos:exactMatch	go:GO:0050658	RNA Transport	RNA transport	orcid:0000-0001-9439-5346	CC0
+mesh:D034622	skos:exactMatch	go:GO:0016246	RNA Interference	RNA interference	orcid:0000-0001-9439-5346	CC0
+mesh:D034881	skos:exactMatch	go:GO:0005652	Nuclear Lamina	nuclear lamina	orcid:0000-0001-9439-5346	CC0
+mesh:D036801	skos:exactMatch	go:GO:0007567	Parturition	parturition	orcid:0000-0001-9439-5346	CC0
+mesh:D048348	skos:exactMatch	go:GO:0001171	Reverse Transcription	reverse transcription	orcid:0000-0001-9439-5346	CC0
+mesh:D048749	skos:exactMatch	go:GO:0000910	Cytokinesis	cytokinesis	orcid:0000-0001-9439-5346	CC0
+mesh:D049109	skos:exactMatch	go:GO:0008283	Cell Proliferation	cell population proliferation	orcid:0000-0001-9439-5346	CC0
+mesh:D051336	skos:exactMatch	go:GO:0031966	Mitochondrial Membranes	mitochondrial membrane	orcid:0000-0001-9439-5346	CC0
+mesh:D059447	skos:exactMatch	go:GO:0000075	Cell Cycle Checkpoints	cell cycle checkpoint	orcid:0000-0001-9439-5346	CC0
+mesh:D059547	skos:exactMatch	go:GO:0032420	Stereocilia	stereocilium	orcid:0000-0001-9439-5346	CC0
+mesh:D060152	skos:exactMatch	go:GO:0033151	V(D)J Recombination	V(D)J recombination	orcid:0000-0001-9439-5346	CC0
+mesh:D007382	skos:exactMatch	go:GO:0005882	Intermediate Filaments	intermediate filament	orcid:0000-0001-9439-5346	CC0
+mesh:D008871	skos:exactMatch	go:GO:0005902	Microvilli	microvillus	orcid:0000-0001-9439-5346	CC0
+mesh:D055944	skos:exactMatch	go:GO:0110143	Magnetosomes	magnetosome	orcid:0000-0001-9439-5346	CC0
+mesh:D057646	skos:exactMatch	go:GO:0019061	Virus Uncoating	uncoating of virus	orcid:0000-0001-9439-5346	CC0
+mesh:D057465	skos:exactMatch	go:GO:0061984	Catabolite Repression	catabolite repression	orcid:0000-0001-9439-5346	CC0
+mesh:D055212	skos:exactMatch	go:GO:0032391	Photoreceptor Connecting Cilium	photoreceptor connecting cilium	orcid:0000-0001-9439-5346	CC0
+mesh:D000069396	skos:exactMatch	go:GO:0005761	Mitochondrial Ribosomes	mitochondrial ribosome	orcid:0000-0001-9439-5346	CC0
+mesh:D000071040	skos:exactMatch	go:GO:0043194	Axon Initial Segment	axon initial segment	orcid:0000-0001-9439-5346	CC0
+mesh:D000080642	skos:exactMatch	go:GO:0061684	Chaperone-Mediated Autophagy	chaperone-mediated autophagy	orcid:0000-0001-9439-5346	CC0
+mesh:D000081363	skos:exactMatch	go:GO:0039679	Occlusion Bodies, Viral	viral occlusion body	orcid:0000-0001-9439-5346	CC0
+mesh:D001846	skos:exactMatch	go:GO:0060348	Bone Development	bone development	orcid:0000-0001-9439-5346	CC0
+mesh:D001861	skos:exactMatch	go:GO:1990523	Bone Regeneration	bone regeneration	orcid:0000-0001-9439-5346	CC0
+mesh:D001862	skos:exactMatch	go:GO:0045453	Bone Resorption	bone resorption	orcid:0000-0001-9439-5346	CC0
+mesh:D000873	skos:exactMatch	chebi:CHEBI:46955	Anthracenes	anthracenes	orcid:0000-0001-9439-5346	CC0
+mesh:D001381	skos:exactMatch	chebi:CHEBI:48105	Azepines	azepine	orcid:0000-0001-9439-5346	CC0
+mesh:D001218	skos:exactMatch	chebi:CHEBI:2877	Aspartame	aspartame	orcid:0000-0001-9439-5346	CC0
+mesh:D001507	skos:exactMatch	chebi:CHEBI:3001	Beclomethasone	beclomethasone	orcid:0000-0001-9439-5346	CC0
+mesh:D001539	skos:exactMatch	chebi:CHEBI:3013	Bendroflumethiazide	bendroflumethiazide	orcid:0000-0001-9439-5346	CC0
+mesh:D001542	skos:exactMatch	chebi:CHEBI:3015	Benomyl	benomyl	orcid:0000-0001-9439-5346	CC0
+mesh:D001547	skos:exactMatch	chebi:CHEBI:22698	Benzaldehydes	benzaldehydes	orcid:0000-0001-9439-5346	CC0
+mesh:D001549	skos:exactMatch	chebi:CHEBI:22702	Benzamides	benzamides	orcid:0000-0001-9439-5346	CC0
+mesh:D001552	skos:exactMatch	chebi:CHEBI:35676	Benzazepines	benzazepine	orcid:0000-0001-9439-5346	CC0
+mesh:D001553	skos:exactMatch	chebi:CHEBI:3023	Benzbromarone	benzbromarone	orcid:0000-0001-9439-5346	CC0
+mesh:D001557	skos:exactMatch	chebi:CHEBI:53348	Benzenesulfonates	benzenesulfonates	orcid:0000-0001-9439-5346	CC0
+mesh:D001562	skos:exactMatch	chebi:CHEBI:22715	Benzimidazoles	benzimidazoles	orcid:0000-0001-9439-5346	CC0
+mesh:D001564	skos:exactMatch	chebi:CHEBI:29865	Benzo(a)pyrene	benzo[a]pyrene	orcid:0000-0001-9439-5346	CC0
+mesh:D001569	skos:exactMatch	chebi:CHEBI:22720	Benzodiazepines	benzodiazepine	orcid:0000-0001-9439-5346	CC0
+mesh:D001581	skos:exactMatch	chebi:CHEBI:50265	Benzothiadiazines	benzothiadiazine	orcid:0000-0001-9439-5346	CC0
+mesh:D001590	skos:exactMatch	chebi:CHEBI:3048	Benztropine	benzatropine	orcid:0000-0001-9439-5346	CC0
+mesh:D001592	skos:exactMatch	chebi:CHEBI:22743	Benzyl Alcohols	benzyl alcohols	orcid:0000-0001-9439-5346	CC0
+mesh:D001594	skos:exactMatch	chebi:CHEBI:3056	Benzyl Viologen	Benzyl viologen	orcid:0000-0001-9439-5346	CC0
+mesh:D001599	skos:exactMatch	chebi:CHEBI:16118	Berberine	berberine	orcid:0000-0001-9439-5346	CC0
+mesh:D001600	skos:exactMatch	chebi:CHEBI:22754	Berberine Alkaloids	berberine alkaloid	orcid:0000-0001-9439-5346	CC0
+mesh:D001640	skos:exactMatch	chebi:CHEBI:3092	Bicuculline	bicuculline	orcid:0000-0001-9439-5346	CC0
+mesh:D001645	skos:exactMatch	chebi:CHEBI:53662	Biguanides	biguanides	orcid:0000-0001-9439-5346	CC0
+mesh:D001708	skos:exactMatch	chebi:CHEBI:15373	Biopterin	biopterin	orcid:0000-0001-9439-5346	CC0
+mesh:D001710	skos:exactMatch	chebi:CHEBI:15956	Biotin	biotin	orcid:0000-0001-9439-5346	CC0
+mesh:D001726	skos:exactMatch	chebi:CHEBI:3125	Bisacodyl	Bisacodyl	orcid:0000-0001-9439-5346	CC0
+mesh:D001735	skos:exactMatch	chebi:CHEBI:3131	Bithionol	bithionol	orcid:0000-0001-9439-5346	CC0
+mesh:D001737	skos:exactMatch	chebi:CHEBI:18138	Biuret	biuret	orcid:0000-0001-9439-5346	CC0
+mesh:D001839	skos:exactMatch	chebi:CHEBI:80229	Bombesin	Bombesin	orcid:0000-0001-9439-5346	CC0
+mesh:D001865	skos:exactMatch	chebi:CHEBI:77742	Bongkrekic Acid	bongkrekic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D001880	skos:exactMatch	chebi:CHEBI:33589	Boranes	boranes	orcid:0000-0001-9439-5346	CC0
+mesh:D001881	skos:exactMatch	chebi:CHEBI:22910	Borates	borates	orcid:0000-0001-9439-5346	CC0
+mesh:D001888	skos:exactMatch	chebi:CHEBI:59765	Boric Acids	boric acids	orcid:0000-0001-9439-5346	CC0
+mesh:D001889	skos:exactMatch	chebi:CHEBI:38270	Borinic Acids	borinic acids	orcid:0000-0001-9439-5346	CC0
+mesh:D001897	skos:exactMatch	chebi:CHEBI:38269	Boronic Acids	boronic acids	orcid:0000-0001-9439-5346	CC0
+mesh:D001960	skos:exactMatch	chebi:CHEBI:31302	Bromazepam	Bromazepam	orcid:0000-0001-9439-5346	CC0
+mesh:D002027	skos:exactMatch	chebi:CHEBI:3210	Bufotenin	bufotenin	orcid:0000-0001-9439-5346	CC0
+mesh:D002040	skos:exactMatch	chebi:CHEBI:6438	Levobunolol	levobunolol	orcid:0000-0001-9439-5346	CC0
+mesh:D002045	skos:exactMatch	chebi:CHEBI:3215	Bupivacaine	bupivacaine	orcid:0000-0001-9439-5346	CC0
+mesh:D002047	skos:exactMatch	chebi:CHEBI:3216	Buprenorphine	buprenorphine	orcid:0000-0001-9439-5346	CC0
+mesh:D002049	skos:exactMatch	chebi:CHEBI:3221	Burimamide	Burimamide	orcid:0000-0001-9439-5346	CC0
+mesh:D002065	skos:exactMatch	chebi:CHEBI:3223	Buspirone	buspirone	orcid:0000-0001-9439-5346	CC0
+mesh:D002074	skos:exactMatch	chebi:CHEBI:22951	Butanones	butanone	orcid:0000-0001-9439-5346	CC0
+mesh:D002077	skos:exactMatch	chebi:CHEBI:3242	Butorphanol	butorphanol	orcid:0000-0001-9439-5346	CC0
+mesh:D002092	skos:exactMatch	chebi:CHEBI:41055	Butyrylthiocholine	butyrylthiocholine	orcid:0000-0001-9439-5346	CC0
+mesh:D002103	skos:exactMatch	chebi:CHEBI:18127	Cadaverine	cadaverine	orcid:0000-0001-9439-5346	CC0
+mesh:D002104	skos:exactMatch	chebi:CHEBI:22977	Cadmium	cadmium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D002110	skos:exactMatch	chebi:CHEBI:27732	Caffeine	caffeine	orcid:0000-0001-9439-5346	CC0
+mesh:D002164	skos:exactMatch	chebi:CHEBI:36773	Camphor	camphor	orcid:0000-0001-9439-5346	CC0
+mesh:D002166	skos:exactMatch	chebi:CHEBI:27656	Camptothecin	camptothecin	orcid:0000-0001-9439-5346	CC0
+mesh:D002174	skos:exactMatch	chebi:CHEBI:354984	Candicidin	candicidin	orcid:0000-0001-9439-5346	CC0
+mesh:D002186	skos:exactMatch	chebi:CHEBI:67194	Cannabinoids	cannabinoid	orcid:0000-0001-9439-5346	CC0
+mesh:D002187	skos:exactMatch	chebi:CHEBI:3360	Cannabinol	Cannabinol	orcid:0000-0001-9439-5346	CC0
+mesh:D002193	skos:exactMatch	chebi:CHEBI:64213	Cantharidin	cantharidin	orcid:0000-0001-9439-5346	CC0
+mesh:D002211	skos:exactMatch	chebi:CHEBI:3374	Capsaicin	capsaicin	orcid:0000-0001-9439-5346	CC0
+mesh:D002220	skos:exactMatch	chebi:CHEBI:3387	Carbamazepine	carbamazepine	orcid:0000-0001-9439-5346	CC0
+mesh:D002129	skos:exactMatch	chebi:CHEBI:60579	Calcium Oxalate	calcium oxalate	orcid:0000-0001-9439-5346	CC0
+mesh:D002261	skos:exactMatch	chebi:CHEBI:3405	Carboxin	carboxin	orcid:0000-0001-9439-5346	CC0
+mesh:D002260	skos:exactMatch	chebi:CHEBI:3403	Carboprost	carboprost	orcid:0000-0001-9439-5346	CC0
+mesh:D002323	skos:exactMatch	chebi:CHEBI:3414	Carfecillin	carfecillin	orcid:0000-0001-9439-5346	CC0
+mesh:D002328	skos:exactMatch	chebi:CHEBI:3419	Carisoprodol	carisoprodol	orcid:0000-0001-9439-5346	CC0
+mesh:D002330	skos:exactMatch	chebi:CHEBI:3423	Carmustine	carmustine	orcid:0000-0001-9439-5346	CC0
+mesh:D002336	skos:exactMatch	chebi:CHEBI:15727	Carnosine	carnosine	orcid:0000-0001-9439-5346	CC0
+mesh:D002351	skos:exactMatch	chebi:CHEBI:3435	Carrageenan	carrageenan	orcid:0000-0001-9439-5346	CC0
+mesh:D002354	skos:exactMatch	chebi:CHEBI:3437	Carteolol	carteolol	orcid:0000-0001-9439-5346	CC0
+mesh:D002395	skos:exactMatch	chebi:CHEBI:33567	Catecholamines	catecholamine	orcid:0000-0001-9439-5346	CC0
+mesh:D002396	skos:exactMatch	chebi:CHEBI:33566	Catechols	catechols	orcid:0000-0001-9439-5346	CC0
+mesh:D002412	skos:exactMatch	chebi:CHEBI:36916	Cations	cation	orcid:0000-0001-9439-5346	CC0
+mesh:D002433	skos:exactMatch	chebi:CHEBI:3478	Cefaclor	cefaclor	orcid:0000-0001-9439-5346	CC0
+mesh:D002438	skos:exactMatch	chebi:CHEBI:3493	Cefoperazone	cefoperazone	orcid:0000-0001-9439-5346	CC0
+mesh:D002440	skos:exactMatch	chebi:CHEBI:209807	Cefoxitin	cefoxitin	orcid:0000-0001-9439-5346	CC0
+mesh:D002441	skos:exactMatch	chebi:CHEBI:3507	Cefsulodin	cefsulodin	orcid:0000-0001-9439-5346	CC0
+mesh:D002444	skos:exactMatch	chebi:CHEBI:3515	Cefuroxime	cefuroxime	orcid:0000-0001-9439-5346	CC0
+mesh:D002475	skos:exactMatch	chebi:CHEBI:17057	Cellobiose	cellobiose	orcid:0000-0001-9439-5346	CC0
+mesh:D002492	skos:exactMatch	chebi:CHEBI:35488	Central Nervous System Depressants	central nervous system depressant	orcid:0000-0001-9439-5346	CC0
+mesh:D002504	skos:exactMatch	chebi:CHEBI:6712	Meclofenoxate	Meclofenoxate	orcid:0000-0001-9439-5346	CC0
+mesh:D002506	skos:exactMatch	chebi:CHEBI:3534	Cephalexin	cephalexin	orcid:0000-0001-9439-5346	CC0
+mesh:D002509	skos:exactMatch	chebi:CHEBI:3537	Cephaloridine	cefaloridine	orcid:0000-0001-9439-5346	CC0
+mesh:D002513	skos:exactMatch	chebi:CHEBI:55429	Cephamycins	cephamycin	orcid:0000-0001-9439-5346	CC0
+mesh:D002515	skos:exactMatch	chebi:CHEBI:3547	Cephradine	cephradine	orcid:0000-0001-9439-5346	CC0
+mesh:D002518	skos:exactMatch	chebi:CHEBI:17761	Ceramides	ceramide	orcid:0000-0001-9439-5346	CC0
+mesh:D002554	skos:exactMatch	chebi:CHEBI:23079	Cerebrosides	cerebroside	orcid:0000-0001-9439-5346	CC0
+mesh:D002569	skos:exactMatch	chebi:CHEBI:171741	Cerulenin	cerulenin	orcid:0000-0001-9439-5346	CC0
+mesh:D002599	skos:exactMatch	chebi:CHEBI:27618	Chalcone	chalcone	orcid:0000-0001-9439-5346	CC0
+mesh:D002606	skos:exactMatch	chebi:CHEBI:91090	Charcoal	charcoal	orcid:0000-0001-9439-5346	CC0
+mesh:D002629	skos:exactMatch	chebi:CHEBI:23092	Chemosterilants	chemosterilant	orcid:0000-0001-9439-5346	CC0
+mesh:D002635	skos:exactMatch	chebi:CHEBI:16755	Chenodeoxycholic Acid	chenodeoxycholic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D002686	skos:exactMatch	chebi:CHEBI:17029	Chitin	chitin	orcid:0000-0001-9439-5346	CC0
+mesh:D002698	skos:exactMatch	chebi:CHEBI:81902	Chloralose	Chloralose	orcid:0000-0001-9439-5346	CC0
+mesh:D002701	skos:exactMatch	chebi:CHEBI:17698	Chloramphenicol	chloramphenicol	orcid:0000-0001-9439-5346	CC0
+mesh:D002716	skos:exactMatch	chebi:CHEBI:81850	Chlormequat	chlormequat	orcid:0000-0001-9439-5346	CC0
+mesh:D002722	skos:exactMatch	chebi:CHEBI:23132	Chlorobenzenes	chlorobenzenes	orcid:0000-0001-9439-5346	CC0
+mesh:D002723	skos:exactMatch	chebi:CHEBI:23133	Chlorobenzoates	chlorobenzoate	orcid:0000-0001-9439-5346	CC0
+mesh:D002733	skos:exactMatch	chebi:CHEBI:23150	Chlorophenols	chlorophenol	orcid:0000-0001-9439-5346	CC0
+mesh:D002735	skos:exactMatch	chebi:CHEBI:38206	Chlorophyllides	chlorophyllide	orcid:0000-0001-9439-5346	CC0
+mesh:D002738	skos:exactMatch	chebi:CHEBI:3638	Chloroquine	chloroquine	orcid:0000-0001-9439-5346	CC0
+mesh:D002743	skos:exactMatch	chebi:CHEBI:3642	Chlorphenesin	chlorphenesin	orcid:0000-0001-9439-5346	CC0
+mesh:D002746	skos:exactMatch	chebi:CHEBI:3647	Chlorpromazine	chlorpromazine	orcid:0000-0001-9439-5346	CC0
+mesh:D002748	skos:exactMatch	chebi:CHEBI:34630	Chlorpropham	chlorpropham	orcid:0000-0001-9439-5346	CC0
+mesh:D002710	skos:exactMatch	chebi:CHEBI:3614	Chlorhexidine	chlorhexidine	orcid:0000-0001-9439-5346	CC0
+mesh:D009681	skos:exactMatch	go:GO:0000741	Nuclear Fusion	karyogamy	orcid:0000-0003-4423-4370	CC0
+mesh:D010588	skos:exactMatch	go:GO:0045335	Phagosomes	phagocytic vesicle	orcid:0000-0003-4423-4370	CC0
+mesh:D010863	skos:exactMatch	go:GO:0097195	Piloerection	pilomotor reflex	orcid:0000-0003-4423-4370	CC0
+mesh:D011132	skos:exactMatch	go:GO:0005844	Polyribosomes	polysome	orcid:0000-0003-4423-4370	CC0
+mesh:D011768	skos:exactMatch	go:GO:0045254	Pyruvate Dehydrogenase Complex	pyruvate dehydrogenase complex	orcid:0000-0003-4423-4370	CC0
+mesh:D010427	skos:exactMatch	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+mesh:D008893	skos:exactMatch	go:GO:0060156	Milk Ejection	milk ejection reflex	orcid:0000-0003-4423-4370	CC0
+mesh:D009411	skos:exactMatch	go:GO:0043679	Nerve Endings	axon terminus	orcid:0000-0003-4423-4370	CC0
+mesh:D008066	skos:exactMatch	go:GO:0016042	Lipolysis	lipid catabolic process	orcid:0000-0003-4423-4370	CC0
+mesh:D015922	skos:exactMatch	go:GO:0062167	Complement C1q	complement component C1q complex	orcid:0000-0003-4423-4370	CC0
+mesh:D013082	skos:exactMatch	go:GO:0036126	Sperm Tail	sperm flagellum	orcid:0000-0003-4423-4370	CC0
+mesh:D017735	skos:exactMatch	go:GO:0019042	Virus Latency	viral latency	orcid:0000-0003-4423-4370	CC0
+mesh:D019065	skos:exactMatch	go:GO:0019068	Virus Assembly	virion assembly	orcid:0000-0003-4423-4370	CC0
+mesh:D019897	skos:exactMatch	go:GO:0042597	Periplasm	periplasmic space	orcid:0000-0003-4423-4370	CC0
+mesh:D020219	skos:exactMatch	go:GO:0051216	Chondrogenesis	cartilage development	orcid:0000-0003-4423-4370	CC0
+mesh:D020541	skos:exactMatch	go:GO:0015030	Coiled Bodies	Cajal body	orcid:0000-0003-4423-4370	CC0
+mesh:D042583	skos:exactMatch	go:GO:0001946	Lymphangiogenesis	lymphangiogenesis	orcid:0000-0003-4423-4370	CC0
+mesh:D022001	skos:exactMatch	go:GO:0005925	Focal Adhesions	focal adhesion	orcid:0000-0003-4423-4370	CC0
+mesh:D022101	skos:exactMatch	go:GO:0005815	Microtubule-Organizing Center	microtubule organizing center	orcid:0000-0003-4423-4370	CC0
+mesh:D023902	skos:exactMatch	go:GO:0007129	Chromosome Pairing	synapsis	orcid:0000-0003-4423-4370	CC0
+mesh:D045346	skos:exactMatch	go:GO:0009512	Cytochrome b6f Complex	cytochrome b6f complex	orcid:0000-0003-4423-4370	CC0
+mesh:D021982	skos:exactMatch	go:GO:0030055	Cell-Matrix Junctions	cell-substrate junction	orcid:0000-0003-4423-4370	CC0
+mesh:D050261	skos:exactMatch	go:GO:0005980	Glycogenolysis	glycogen catabolic process	orcid:0000-0003-4423-4370	CC0
+mesh:D051738	skos:exactMatch	go:GO:0000808	Origin Recognition Complex	origin recognition complex	orcid:0000-0003-4423-4370	CC0
+mesh:D053038	skos:exactMatch	go:GO:0009372	Quorum Sensing	quorum sensing	orcid:0000-0003-4423-4370	CC0
+mesh:D053205	skos:exactMatch	go:GO:0090406	Pollen Tube	pollen tube	orcid:0000-0003-4423-4370	CC0
+mesh:D053298	skos:exactMatch	go:GO:0034360	Chylomicron Remnants	chylomicron remnant	orcid:0000-0003-4423-4370	CC0
+mesh:C081483	skos:exactMatch	go:GO:0070505	tryphine	pollen coat	orcid:0000-0003-4423-4370	CC0
+mesh:C118437	skos:exactMatch	go:GO:0032021	negative elongation factor	NELF complex	orcid:0000-0003-4423-4370	CC0
+mesh:D000077279	skos:exactMatch	go:GO:0046944	Protein Carbamylation	protein carbamoylation	orcid:0000-0003-4423-4370	CC0
+mesh:D000177	skos:exactMatch	go:GO:0001669	Acrosome	acrosomal vesicle	orcid:0000-0003-4423-4370	CC0
+mesh:D000917	skos:exactMatch	go:GO:0002377	Antibody Formation	immunoglobulin production	orcid:0000-0003-4423-4370	CC0
+mesh:D003214	skos:exactMatch	go:GO:0008306	Conditioning, Classical	associative learning	orcid:0000-0003-4423-4370	CC0
+mesh:D005106	skos:exactMatch	go:GO:0035640	Exploratory Behavior	exploration behavior	orcid:0000-0003-4423-4370	CC0
+mesh:D005407	skos:exactMatch	go:GO:0005929	Flagella	cilium	orcid:0000-0003-4423-4370	CC0
+mesh:D007401	skos:exactMatch	go:GO:0030325	Interrenal Gland	adrenal gland development	orcid:0000-0003-4423-4370	CC0
+mesh:D005498	skos:exactMatch	go:GO:0001541	Follicular Phase	ovarian follicle development	orcid:0000-0003-4423-4370	CC0
+mesh:D000374	skos:exactMatch	go:GO:0002118	Aggression	aggressive behavior	orcid:0000-0003-4423-4370	CC0
+mesh:D000920	skos:exactMatch	go:GO:0001788	Antibody-Dependent Cell Cytotoxicity	antibody-dependent cellular cytotoxicity	orcid:0000-0003-4423-4370	CC0
+mesh:D007113	skos:exactMatch	go:GO:0045087	Immunity, Innate	innate immune response	orcid:0000-0003-4423-4370	CC0
+mesh:D014074	skos:exactMatch	go:GO:0034505	Tooth Calcification	tooth mineralization	orcid:0000-0003-4423-4370	CC0
+mesh:D017201	skos:exactMatch	go:GO:0019076	Virus Shedding	viral release from host cell	orcid:0000-0003-4423-4370	CC0
+mesh:D055697	skos:exactMatch	go:GO:0050909	Taste Perception	sensory perception of taste	orcid:0000-0003-4423-4370	CC0
+mesh:D054261	skos:exactMatch	go:GO:0001841	Neurulation	neural tube formation	orcid:0000-0003-4423-4370	CC0
+mesh:D053444	skos:exactMatch	go:GO:0060080	Inhibitory Postsynaptic Potentials	inhibitory postsynaptic potential	orcid:0000-0003-4423-4370	CC0
+mesh:D056245	skos:exactMatch	go:GO:0016581	Mi-2 Nucleosome Remodeling and Deacetylase Complex	NuRD complex	orcid:0000-0003-4423-4370	CC0
+mesh:D056827	skos:exactMatch	go:GO:0036452	Endosomal Sorting Complexes Required for Transport	ESCRT complex	orcid:0000-0003-4423-4370	CC0
+mesh:D058207	skos:exactMatch	go:GO:0016925	Sumoylation	protein sumoylation	orcid:0000-0003-4423-4370	CC0
+mesh:D057131	skos:exactMatch	go:GO:0042783	Immune Evasion	evasion of host immune response	orcid:0000-0003-4423-4370	CC0
+mesh:D060746	skos:exactMatch	go:GO:0036503	Endoplasmic Reticulum-Associated Degradation	ERAD pathway	orcid:0000-0003-4423-4370	CC0
+mesh:D063326	skos:exactMatch	go:GO:0000178	Exosome Multienzyme Ribonuclease Complex	exosome (RNase complex)	orcid:0000-0003-4423-4370	CC0
+mesh:D064113	skos:exactMatch	go:GO:0099048	CRISPR-Cas Systems	CRISPR-cas system	orcid:0000-0003-4423-4370	CC0
+mesh:D064173	skos:exactMatch	go:GO:0005680	Anaphase-Promoting Complex-Cyclosome	anaphase-promoting complex	orcid:0000-0003-4423-4370	CC0
+mesh:D064210	skos:exactMatch	go:GO:0019748	Secondary Metabolism	secondary metabolic process	orcid:0000-0003-4423-4370	CC0
+mesh:D064527	skos:exactMatch	go:GO:0009647	Etiolation	skotomorphogenesis	orcid:0000-0003-4423-4370	CC0
+mesh:D013014	skos:exactMatch	go:GO:0009432	SOS Response (Genetics)	SOS response	orcid:0000-0003-4423-4370	CC0
+mesh:D002952	skos:exactMatch	go:GO:0006099	Citric Acid Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+mesh:D010012	skos:exactMatch	go:GO:0001503	Osteogenesis	ossification	orcid:0000-0003-4423-4370	CC0
+mesh:D011499	skos:exactMatch	go:GO:0043687	Protein Processing, Post-Translational	post-translational protein modification	orcid:0000-0003-4423-4370	CC0
+mesh:D014554	skos:exactMatch	go:GO:0060073	Urination	micturition	orcid:0000-0003-4423-4370	CC0
+mesh:D048750	skos:exactMatch	go:GO:0000280	Cell Nucleus Division	nuclear division	orcid:0000-0003-4423-4370	CC0
+mesh:D053843	skos:exactMatch	go:GO:0006298	DNA Mismatch Repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+mesh:C498714	skos:exactMatch	go:GO:0005742	TOM translocase	mitochondrial outer membrane translocase complex	orcid:0000-0003-4423-4370	CC0
+mesh:C048844	skos:exactMatch	efo:0005030	anti-IgG	anti-IgG	orcid:0000-0003-4423-4370	CC0
+mesh:C056900	skos:exactMatch	efo:0003266	neuromedin U	neuromedin U	orcid:0000-0003-4423-4370	CC0
+mesh:D056655	skos:exactMatch	hgnc:2535	Cathepsin H	CTSH	orcid:0000-0001-9439-5346	CC0
+mesh:D055312	skos:exactMatch	hgnc:2481	Cystatin A	CSTA	orcid:0000-0001-9439-5346	CC0
+mesh:D055313	skos:exactMatch	hgnc:2482	Cystatin B	CSTB	orcid:0000-0001-9439-5346	CC0
+mesh:D055316	skos:exactMatch	hgnc:2475	Cystatin C	CST3	orcid:0000-0001-9439-5346	CC0
+mesh:D055332	skos:exactMatch	hgnc:2478	Cystatin M	CST6	orcid:0000-0001-9439-5346	CC0
+kegg.pathway:map00030	skos:exactMatch	go:GO:0006098	Pentose phosphate pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00052	skos:exactMatch	go:GO:0006012	Galactose metabolism	galactose metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00061	skos:exactMatch	go:GO:0006633	Fatty acid biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00062	skos:exactMatch	go:GO:0030497	Fatty acid elongation	fatty acid elongation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00071	skos:exactMatch	go:GO:0009062	Fatty acid degradation	fatty acid catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00100	skos:exactMatch	go:GO:0006694	Steroid biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00190	skos:exactMatch	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00195	skos:exactMatch	go:GO:0015979	Photosynthesis	photosynthesis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00220	skos:exactMatch	go:GO:0006526	Arginine biosynthesis	arginine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00240	skos:exactMatch	go:GO:0006206	Pyrimidine metabolism	pyrimidine nucleobase metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00254	skos:exactMatch	go:GO:0045122	Aflatoxin biosynthesis	aflatoxin biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00281	skos:exactMatch	go:GO:1903447	Geraniol degradation	geraniol catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00300	skos:exactMatch	go:GO:0009085	Lysine biosynthesis	lysine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00310	skos:exactMatch	go:GO:0006554	Lysine degradation	lysine catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00331	skos:exactMatch	go:GO:0033050	Clavulanic acid biosynthesis	clavulanic acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00332	skos:exactMatch	go:GO:1901769	Carbapenem biosynthesis	carbapenem biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00340	skos:exactMatch	go:GO:0006547	Histidine metabolism	histidine metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00350	skos:exactMatch	go:GO:0006570	Tyrosine metabolism	tyrosine metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00362	skos:exactMatch	go:GO:0043639	Benzoate degradation	benzoate catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00380	skos:exactMatch	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00410	skos:exactMatch	go:GO:0019482	beta-Alanine metabolism	beta-alanine metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00460	skos:exactMatch	go:GO:0033052	Cyanoamino acid metabolism	cyanoamino acid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00473	skos:exactMatch	go:GO:0046436	D-Alanine metabolism	D-alanine metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00480	skos:exactMatch	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00510	skos:exactMatch	go:GO:0006487	N-Glycan biosynthesis	protein N-linked glycosylation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00521	skos:exactMatch	go:GO:0019872	Streptomycin biosynthesis	streptomycin biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00531	skos:exactMatch	go:GO:0006027	Glycosaminoglycan degradation	glycosaminoglycan catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00540	skos:exactMatch	go:GO:0009103	Lipopolysaccharide biosynthesis	lipopolysaccharide biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00550	skos:exactMatch	go:GO:0009252	Peptidoglycan biosynthesis	peptidoglycan biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04110	skos:exactMatch	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04144	skos:exactMatch	go:GO:0006897	Endocytosis	endocytosis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00561	skos:exactMatch	go:GO:0046486	Glycerolipid metabolism	glycerolipid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00562	skos:exactMatch	go:GO:0043647	Inositol phosphate metabolism	inositol phosphate metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00564	skos:exactMatch	go:GO:0006650	Glycerophospholipid metabolism	glycerophospholipid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00565	skos:exactMatch	go:GO:0046485	Ether lipid metabolism	ether lipid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00590	skos:exactMatch	go:GO:0019369	Arachidonic acid metabolism	arachidonic acid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00591	skos:exactMatch	go:GO:0043651	Linoleic acid metabolism	linoleic acid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00592	skos:exactMatch	go:GO:0036109	alpha-Linolenic acid metabolism	alpha-linolenic acid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00600	skos:exactMatch	go:GO:0006665	Sphingolipid metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00620	skos:exactMatch	go:GO:0006090	Pyruvate metabolism	pyruvate metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00622	skos:exactMatch	go:GO:0042184	Xylene degradation	xylene catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00623	skos:exactMatch	go:GO:0042203	Toluene degradation	toluene catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00626	skos:exactMatch	go:GO:1901170	Naphthalene degradation	naphthalene catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00633	skos:exactMatch	go:GO:0046263	Nitrotoluene degradation	nitrotoluene catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00640	skos:exactMatch	go:GO:0019541	Propanoate metabolism	propionate metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00643	skos:exactMatch	go:GO:0042207	Styrene degradation	styrene catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00680	skos:exactMatch	go:GO:0015947	Methane metabolism	methane metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00730	skos:exactMatch	go:GO:0006772	Thiamine metabolism	thiamine metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00740	skos:exactMatch	go:GO:0006771	Riboflavin metabolism	riboflavin metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00750	skos:exactMatch	go:GO:0042816	Vitamin B6 metabolism	vitamin B6 metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00780	skos:exactMatch	go:GO:0006768	Biotin metabolism	biotin metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00785	skos:exactMatch	go:GO:0009106	Lipoic acid metabolism	lipoate metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00790	skos:exactMatch	go:GO:0046656	Folate biosynthesis	folic acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00791	skos:exactMatch	go:GO:0019381	Atrazine degradation	atrazine catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00830	skos:exactMatch	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00901	skos:exactMatch	go:GO:0035835	Indole alkaloid biosynthesis	indole alkaloid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00902	skos:exactMatch	go:GO:0016099	Monoterpenoid biosynthesis	monoterpenoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00904	skos:exactMatch	go:GO:0016102	Diterpenoid biosynthesis	diterpenoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00905	skos:exactMatch	go:GO:0016132	Brassinosteroid biosynthesis	brassinosteroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00906	skos:exactMatch	go:GO:0016117	Carotenoid biosynthesis	carotenoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00908	skos:exactMatch	go:GO:0033398	Zeatin biosynthesis	zeatin biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00920	skos:exactMatch	go:GO:0006790	Sulfur metabolism	sulfur compound metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00930	skos:exactMatch	go:GO:0019384	Caprolactam degradation	caprolactam catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00940	skos:exactMatch	go:GO:0009699	Phenylpropanoid biosynthesis	phenylpropanoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00941	skos:exactMatch	go:GO:0009813	Flavonoid biosynthesis	flavonoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00942	skos:exactMatch	go:GO:0009718	Anthocyanin biosynthesis	anthocyanin-containing compound biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00943	skos:exactMatch	go:GO:0009717	Isoflavonoid biosynthesis	isoflavonoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00950	skos:exactMatch	go:GO:0033075	Isoquinoline alkaloid biosynthesis	isoquinoline alkaloid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00966	skos:exactMatch	go:GO:0019761	Glucosinolate biosynthesis	glucosinolate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00984	skos:exactMatch	go:GO:0006706	Steroid degradation	steroid catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map01212	skos:exactMatch	go:GO:0006631	Fatty acid metabolism	fatty acid metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04920	skos:exactMatch	go:GO:0033210	Adipocytokine signaling pathway	leptin-mediated signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map02024	skos:exactMatch	go:GO:0009372	Quorum sensing	quorum sensing	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03030	skos:exactMatch	go:GO:0006260	DNA replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03320	skos:exactMatch	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04071	skos:exactMatch	go:GO:0090520	Sphingolipid signaling pathway	sphingolipid mediated signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04012	skos:exactMatch	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04218	skos:exactMatch	go:GO:0090398	Cellular senescence	cellular senescence	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04917	skos:exactMatch	go:GO:0038161	Prolactin signaling pathway	prolactin signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04310	skos:exactMatch	go:GO:0016055	Wnt signaling pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03440	skos:exactMatch	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04390	skos:exactMatch	go:GO:0035329	Hippo signaling pathway	hippo signaling	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04210	skos:exactMatch	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04217	skos:exactMatch	go:GO:0070266	Necroptosis	necroptotic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04217	skos:exactMatch	mesh:D000079302	Necroptosis	Necroptosis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04216	skos:exactMatch	mesh:D000079403	Ferroptosis	Ferroptosis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04216	skos:exactMatch	go:GO:0097707	Ferroptosis	ferroptosis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00970	skos:exactMatch	go:GO:0043039	Aminoacyl-tRNA biosynthesis	tRNA aminoacylation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03013	skos:exactMatch	go:GO:0050658	RNA transport	RNA transport	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03018	skos:exactMatch	go:GO:0006401	RNA degradation	RNA catabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04115	skos:exactMatch	go:GO:0030330	p53 signaling pathway	DNA damage response, signal transduction by p53 class mediator	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04260	skos:exactMatch	go:GO:0060048	Cardiac muscle contraction	cardiac muscle contraction	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04270	skos:exactMatch	go:GO:0014829	Vascular smooth muscle contraction	vascular smooth muscle contraction	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04330	skos:exactMatch	go:GO:0007219	Notch signaling pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04340	skos:exactMatch	go:GO:0007224	Hedgehog signaling pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04360	skos:exactMatch	go:GO:0007411	Axon guidance	axon guidance	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04361	skos:exactMatch	go:GO:0031103	Axon regeneration	axon regeneration	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04380	skos:exactMatch	go:GO:0030316	Osteoclast differentiation	osteoclast differentiation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04611	skos:exactMatch	go:GO:0030168	Platelet activation	platelet activation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04612	skos:exactMatch	go:GO:0019882	Antigen processing and presentation	antigen processing and presentation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03430	skos:exactMatch	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04620	skos:exactMatch	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04621	skos:exactMatch	go:GO:0035872	NOD-like receptor signaling pathway	nucleotide-binding domain, leucine rich repeat containing receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04650	skos:exactMatch	go:GO:0042267	Natural killer cell mediated cytotoxicity	natural killer cell mediated cytotoxicity	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04660	skos:exactMatch	go:GO:0050852	T cell receptor signaling pathway	T cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04662	skos:exactMatch	go:GO:0050853	B cell receptor signaling pathway	B cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04710	skos:exactMatch	go:GO:0007623	Circadian rhythm	circadian rhythm	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04721	skos:exactMatch	go:GO:0099504	Synaptic vesicle cycle	synaptic vesicle cycle	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04722	skos:exactMatch	go:GO:0038179	Neurotrophin signaling pathway	neurotrophin signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04744	skos:exactMatch	go:GO:0007602	Phototransduction	phototransduction	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04911	skos:exactMatch	go:GO:0030073	Insulin secretion	insulin secretion	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04920	skos:exactMatch	go:GO:0033209	Adipocytokine signaling pathway	tumor necrosis factor-mediated signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04920	skos:exactMatch	go:GO:0033211	Adipocytokine signaling pathway	adiponectin-activated signaling pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04979	skos:exactMatch	go:GO:0008203	Cholesterol metabolism	cholesterol metabolic process	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04971	skos:exactMatch	go:GO:0001696	Gastric acid secretion	gastric acid secretion	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04714	skos:exactMatch	mesh:D022722	Thermogenesis	Thermogenesis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04720	skos:exactMatch	mesh:D017774	Long-term potentiation	Long-Term Potentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP100	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1002	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1009	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1011	speciesSpecific	go:GO:0050852	TCR Signaling Pathway	T cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1014	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1016	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1018	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1020	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1023	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1024	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1025	speciesSpecific	go:GO:0050853	B Cell Receptor Signaling Pathway	B cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP103	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1032	speciesSpecific	mesh:D000070576	NLR Proteins	NLR Proteins	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1050	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1053	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP999	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP964	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1083	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1290	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1254	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1200	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1539	speciesSpecific	go:GO:0001525	Angiogenesis	angiogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1393	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1351	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP179	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP429	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2862	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4758	speciesSpecific	mesh:D009404	Nephrotic syndrome	Nephrotic Syndrome	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1022	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1026	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1028	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1029	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1034	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1035	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1036	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1044	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1064	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1065	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1067	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1070	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1073	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1075	speciesSpecific	go:GO:0046655	Folate Metabolism	folic acid metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1086	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1101	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1105	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1119	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1126	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1135	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1142	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1148	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1152	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1153	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1141	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP116	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1186	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1189	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1203	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1204	speciesSpecific	go:GO:0006298	Mismatch Repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1079	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP109	speciesSpecific	go:GO:0006258	UDP-Glucose Conversion	UDP-glucose catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1105	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1105	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1118	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1133	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1205	speciesSpecific	go:GO:0035825	Homologous Recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1217	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1221	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1233	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1240	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1248	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1257	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1258	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1227	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1261	speciesSpecific	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1262	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1263	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1259	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1264	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1270	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1282	speciesSpecific	go:GO:0032259	Methylation	methylation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1283	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1292	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1295	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1296	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1297	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1299	speciesSpecific	go:GO:0038127	ErbB signaling pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP13	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1300	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1301	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1302	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1308	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1309	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1314	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1223	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1229	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP123	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1230	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1231	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1232	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1247	speciesSpecific	go:GO:0032259	Methylation	methylation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP125	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1316	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP132	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1331	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1331	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1331	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1335	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1339	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1343	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1345	speciesSpecific	go:GO:0050852	T Cell Receptor Signaling Pathway	T cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1348	speciesSpecific	go:GO:0030521	Androgen Receptor Signaling Pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1349	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1352	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1355	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1366	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1372	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP138	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1383	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1384	speciesSpecific	go:GO:0002224	Toll-like receptor signaling pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1387	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1388	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP14	speciesSpecific	go:GO:0005986	Sucrose Biosynthesis	sucrose biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP142	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1449	speciesSpecific	go:GO:0034121	Regulation of toll-like receptor signaling pathway	regulation of toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1453	speciesSpecific	go:GO:0040025	Vulval development	vulval development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP146	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1489	speciesSpecific	go:GO:0031929	TOR signaling	TOR signaling	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1495	speciesSpecific	go:GO:0006544	Glycine Metabolism	glycine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP150	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1518	speciesSpecific	go:GO:0006532	Aspartate Biosynthesis	aspartate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1531	speciesSpecific	go:GO:0042359	Vitamin D Metabolism	vitamin D metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1533	speciesSpecific	go:GO:0009235	Vitamin B12 Metabolism	cobalamin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1538	speciesSpecific	go:GO:0009813	Flavonoid Biosynthesis	flavonoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP154	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1541	speciesSpecific	mesh:D004734	Energy Metabolism	Energy Metabolism	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP155	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP155	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP155	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP156	speciesSpecific	go:GO:0006094	Gluconeogenesis	gluconeogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP158	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP160	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1600	speciesSpecific	go:GO:0018933	Nicotine Metabolism	nicotine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP164	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP165	speciesSpecific	go:GO:0000162	Tryptophan Biosynthesis	tryptophan biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP171	speciesSpecific	go:GO:0034355	NAD Salvage Pathway	NAD salvage	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP172	speciesSpecific	go:GO:0042213	m-cresol degradation	m-cresol catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP173	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP175	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP176	speciesSpecific	go:GO:0046655	Folate Metabolism	folic acid metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1771	speciesSpecific	go:GO:0006657	Kennedy pathway	CDP-choline pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP178	speciesSpecific	go:GO:0006550	Isoleucine Degradation	isoleucine catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP18	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP180	speciesSpecific	go:GO:0009098	Leucine Biosynthesis	leucine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP181	speciesSpecific	go:GO:0019334	P-cymene Degradation	p-cymene catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP183	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP186	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP188	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP19	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP192	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP196	speciesSpecific	go:GO:0006750	Glutathione Biosynthesis	glutathione biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2	speciesSpecific	go:GO:0009099	Valine Biosynthesis	valine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP200	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2037	speciesSpecific	go:GO:0038161	Prolactin Signaling Pathway	prolactin signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP159	speciesSpecific	go:GO:0019277	UDP-N-Acetylgalactosamine Biosynthesis	UDP-N-acetylgalactosamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1591	speciesSpecific	go:GO:0007507	Heart Development	heart development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP1596	speciesSpecific	efo:0005882	Iron Homeostasis	iron ion homeostasis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2067	speciesSpecific	go:GO:0007507	Heart Development	heart development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP208	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP211	speciesSpecific	go:GO:0030509	BMP signaling pathway	BMP signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP214	speciesSpecific	go:GO:0006086	Pyruvate Dehydrogenase Pathway	acetyl-CoA biosynthetic process from pyruvate	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP216	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2224	speciesSpecific	go:GO:1904070	Ascaroside Biosynthesis	ascaroside biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2276	speciesSpecific	go:GO:0010001	Glial Cell Differentiation	glial cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2279	speciesSpecific	go:GO:0048316	Seed Development	seed development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2316	speciesSpecific	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2318	speciesSpecific	go:GO:0019395	Fatty acid oxidation	fatty acid oxidation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP236	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP236	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP236	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP241	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2313	speciesSpecific	mesh:D000375	Aging	Aging	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2313	speciesSpecific	go:GO:0007568	Aging	aging	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP23	speciesSpecific	go:GO:0050853	B Cell Receptor Signaling Pathway	B cell receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP228	speciesSpecific	go:GO:0019692	Deoxyribose phosphate metabolism	deoxyribose phosphate metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2436	speciesSpecific	go:GO:0042417	Dopamine metabolism	dopamine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP250	speciesSpecific	go:GO:0009097	Isoleucine Biosynthesis	isoleucine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP251	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP253	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP254	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP261	speciesSpecific	go:GO:0006545	Glycine biosynthesis	glycine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2621	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP844	speciesSpecific	go:GO:0007049	Cell cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP96	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4787	speciesSpecific	go:GO:0001649	Osteoblast differentiation	osteoblast differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2863	speciesSpecific	go:GO:0006099	Krebs cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3184	speciesSpecific	go:GO:0001525	Angiogenesis	angiogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP282	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP295	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2622	speciesSpecific	go:GO:0005982	Starch Metabolism	starch metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP269	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP270	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP275	speciesSpecific	go:GO:0006526	Arginine Biosynthesis	arginine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP281	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2826	speciesSpecific	go:GO:0050783	Cocaine metabolism	cocaine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP266	speciesSpecific	go:GO:0019432	Triglyceride Biosynthesis	triglyceride biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP264	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2623	speciesSpecific	go:GO:0005985	Sucrose Metabolism	sucrose metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP224	speciesSpecific	go:GO:0019564	Aerobic Glycerol Catabolism	aerobic glycerol catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2849	speciesSpecific	go:GO:0060218	Hematopoietic Stem Cell Differentiation	hematopoietic stem cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2872	speciesSpecific	go:GO:0050872	White fat cell differentiation	white fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP29	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP301	speciesSpecific	go:GO:0006569	Tryptophan Degradation	tryptophan catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP302	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP305	speciesSpecific	go:GO:0008211	Glucocorticoid Metabolism	glucocorticoid metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP291	speciesSpecific	go:GO:0007530	Sex determination	sex determination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2912	speciesSpecific	go:GO:0014829	Vascular smooth muscle contraction	vascular smooth muscle contraction	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP290	speciesSpecific	go:GO:0006596	Polyamine Biosynthesis	polyamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP2851	speciesSpecific	go:GO:0009873	Ethylene signaling pathway	ethylene-activated signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP280	speciesSpecific	go:GO:0019415	Carbon monoxide dehydrogenase pathway	acetate biosynthetic process from carbon monoxide	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3256	speciesSpecific	go:GO:0031929	TOR Signaling	TOR signaling	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP306	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP310	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3118	speciesSpecific	go:GO:0015844	Monoamine Transport	monoamine transport	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3119	speciesSpecific	go:GO:0006974	DNA Damage Response	cellular response to DNA damage stimulus	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP312	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3132	speciesSpecific	go:GO:0034121	Regulation of toll-like receptor signaling pathway	regulation of toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3134	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3142	speciesSpecific	go:GO:0006544	Glycine Metabolism	glycine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3155	speciesSpecific	go:GO:0042417	Dopamine metabolism	dopamine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3162	speciesSpecific	go:GO:0042359	Vitamin D Metabolism	vitamin D metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3168	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3203	speciesSpecific	go:GO:0010001	Glial Cell Differentiation	glial cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3185	speciesSpecific	go:GO:0018933	Nicotine Metabolism	nicotine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP316	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3193	speciesSpecific	go:GO:0009235	Vitamin B12 Metabolism	cobalamin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3194	speciesSpecific	go:GO:0032933	SREBP signalling	SREBP signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP987	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP994	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP987	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP987	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP983	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP977	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3197	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3211	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP323	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3232	speciesSpecific	go:GO:0006665	Sphingolipid Metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3247	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3248	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP328	speciesSpecific	go:GO:0000256	Allantoin Degradation	allantoin catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3280	speciesSpecific	go:GO:0007507	Heart Development	heart development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP331	speciesSpecific	go:GO:0009088	Threonine Biosynthesis	threonine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP336	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP341	speciesSpecific	go:GO:0038092	Nodal Signaling Pathway	nodal signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP345	speciesSpecific	go:GO:0006546	Glycine Degradation	glycine catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP367	speciesSpecific	go:GO:0012501	Programmed Cell Death	programmed cell death	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP347	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP354	speciesSpecific	go:GO:0006552	Leucine Degradation	leucine catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP357	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP360	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP369	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP370	speciesSpecific	go:GO:0006665	Sphingolipid Metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP376	speciesSpecific	mesh:D012084	Renin - Angiotensin System	Renin-Angiotensin System	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP38	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3891	speciesSpecific	go:GO:0018910	Benzene metabolism	benzene metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP390	speciesSpecific	go:GO:0019496	Serine-isocitrate lyase pathway	serine-isocitrate lyase pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP3942	speciesSpecific	go:GO:0035357	PPAR signaling pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP398	speciesSpecific	go:GO:0005992	Trehalose Anabolism	trehalose biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4020	speciesSpecific	go:GO:0035357	PPAR Signaling Pathway	peroxisome proliferator activated receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4022	speciesSpecific	go:GO:0006206	Pyrimidine metabolism	pyrimidine nucleobase metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP403	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP404	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP408	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP411	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP412	speciesSpecific	mesh:D018384	Oxidative Stress	Oxidative Stress	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4149	speciesSpecific	go:GO:0050872	White fat cell differentiation	white fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP421	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP422	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4249	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4313	speciesSpecific	mesh:D000079403	Ferroptosis	Ferroptosis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4313	speciesSpecific	go:GO:0097707	Ferroptosis	ferroptosis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP432	speciesSpecific	go:GO:0006530	Asparagine degradation	asparagine catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4321	speciesSpecific	mesh:D022722	Thermogenesis	Thermogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP434	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP435	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP436	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP446	speciesSpecific	go:GO:0000165	MAPK Cascade	MAPK cascade	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4506	speciesSpecific	go:GO:0006570	Tyrosine Metabolism	tyrosine metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP451	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP46	speciesSpecific	go:GO:0009087	Methionine Degradation	methionine catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP461	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP463	speciesSpecific	go:GO:0019653	Purine Fermentation	anaerobic purine nucleobase catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP465	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP466	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP467	speciesSpecific	go:GO:0006397	mRNA processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP469	speciesSpecific	go:GO:0006749	Glutathione metabolism	glutathione metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP470	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP474	speciesSpecific	go:GO:0001958	Endochondral Ossification	endochondral ossification	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP476	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP478	speciesSpecific	go:GO:0005980	Glycogen Catabolism	glycogen catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP4784	speciesSpecific	go:GO:0030166	Proteoglycan biosynthesis	proteoglycan biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP484	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP490	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP492	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP496	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP504	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP513	speciesSpecific	go:GO:0042423	Catecholamine synthesis	catecholamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP514	speciesSpecific	go:GO:0000105	Histidine Biosynthesis	histidine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP517	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP519	speciesSpecific	go:GO:1903009	Proteasome Degradation	proteasome complex disassembly	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP522	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP528	speciesSpecific	go:GO:0008292	Acetylcholine Synthesis	acetylcholine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP529	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP533	speciesSpecific	go:GO:0009085	Lysine Biosynthesis	lysine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP538	speciesSpecific	go:GO:0006571	Tyrosine Biosynthesis	tyrosine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP54	speciesSpecific	go:GO:0006527	Arginine degradation	arginine catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP542	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP545	speciesSpecific	go:GO:0006956	Complement Activation	complement activation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP55	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP550	speciesSpecific	go:GO:0042401	Biogenic Amine Synthesis	cellular biogenic amine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP551	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP561	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP564	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP565	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP568	speciesSpecific	go:GO:0006633	Fatty Acid Biosynthesis	fatty acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP574	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP575	speciesSpecific	go:GO:0009061	Anaerobic respiration	anaerobic respiration	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP59	speciesSpecific	go:GO:0022900	Electron Transport Chain	electron transport chain	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP60	speciesSpecific	go:GO:0042203	Toluene degradation	toluene catabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP618	speciesSpecific	go:GO:0009908	Flower Development	flower development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP623	speciesSpecific	go:GO:0006119	Oxidative phosphorylation	oxidative phosphorylation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP626	speciesSpecific	go:GO:0009688	Abscisic Acid Biosynthesis	abscisic acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP627	speciesSpecific	go:GO:0019432	Triacylglycerol Biosynthesis	triglyceride biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP63	speciesSpecific	go:GO:0006098	Pentose Phosphate Pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP632	speciesSpecific	go:GO:0008203	Cholesterol metabolism	cholesterol metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP66	speciesSpecific	go:GO:0006694	Steroid Biosynthesis	steroid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP661	speciesSpecific	go:GO:0042593	Glucose Homeostasis	glucose homeostasis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP67	speciesSpecific	go:GO:0006529	Asparagine Biosynthesis	asparagine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP673	speciesSpecific	go:GO:0038127	ErbB Signaling Pathway	ERBB signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP697	speciesSpecific	go:GO:0008210	Estrogen metabolism	estrogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP699	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP7	speciesSpecific	go:GO:0000097	Sulfur Amino Acid biosynthesis	sulfur amino acid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP707	speciesSpecific	go:GO:0006974	DNA Damage Response	cellular response to DNA damage stimulus	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP727	speciesSpecific	go:GO:0015844	Monoamine Transport	monoamine transport	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP75	speciesSpecific	go:GO:0002224	Toll-like Receptor Signaling Pathway	toll-like receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP757	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP76	speciesSpecific	go:GO:0006099	TCA Cycle	tricarboxylic acid cycle	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP77	speciesSpecific	go:GO:0006537	Glutamate biosynthesis	glutamate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP785	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP787	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP79	speciesSpecific	go:GO:0006568	Tryptophan metabolism	tryptophan metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP790	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP793	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP796	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP798	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP802	speciesSpecific	go:GO:0006298	Mismatch repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP804	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP805	speciesSpecific	go:GO:0042572	Retinol metabolism	retinol metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP81	speciesSpecific	go:GO:0006958	Complement Activation, Classical Pathway	complement activation, classical pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP833	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP835	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP84	speciesSpecific	go:GO:0009435	NAD Biosynthesis	NAD biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP848	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP85	speciesSpecific	go:GO:0005925	Focal Adhesion	focal adhesion	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP86	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP865	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP869	speciesSpecific	mesh:D050156	Adipogenesis	Adipogenesis	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP869	speciesSpecific	go:GO:0045444	Adipogenesis	fat cell differentiation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP869	speciesSpecific	go:GO:0060612	Adipogenesis	adipose tissue development	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP87	speciesSpecific	go:GO:0009117	Nucleotide Metabolism	nucleotide metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP897	speciesSpecific	go:GO:0030521	Androgen receptor signaling pathway	androgen receptor signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP899	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP9	speciesSpecific	go:GO:0008654	Phospholipid Biosynthesis	phospholipid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP905	speciesSpecific	go:GO:0007224	Hedgehog Signaling Pathway	smoothened signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP906	speciesSpecific	go:GO:0006397	mRNA Processing	mRNA processing	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP909	speciesSpecific	go:GO:0006730	One Carbon Metabolism	one-carbon metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP91	speciesSpecific	go:GO:0019395	Fatty acid oxidation	fatty acid oxidation	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP912	speciesSpecific	go:GO:0007219	Notch Signaling Pathway	Notch signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP917	speciesSpecific	go:GO:0035825	Homologous recombination	homologous recombination	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP925	speciesSpecific	go:GO:0046222	Aflatoxin B1 metabolism	aflatoxin metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP952	speciesSpecific	go:GO:0006695	Cholesterol Biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP955	speciesSpecific	go:GO:0005977	Glycogen Metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP967	speciesSpecific	go:GO:0006783	Heme Biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP969	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP97	speciesSpecific	go:GO:0016055	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+wikipathways:WP391	speciesSpecific	go:GO:0140053	Mitochondrial Gene Expression	mitochondrial gene expression	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-109581	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-109582	speciesSpecific	go:GO:0007599	Hemostasis	hemostasis	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-109704	speciesSpecific	go:GO:0014065	PI3K Cascade	phosphatidylinositol 3-kinase signaling	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-114608	speciesSpecific	go:GO:0002576	Platelet degranulation	platelet degranulation	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-1187000	speciesSpecific	go:GO:0009566	Fertilization	fertilization	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-1234174	speciesSpecific	go:GO:0071456	Cellular response to hypoxia	cellular response to hypoxia	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-189451	speciesSpecific	go:GO:0006783	Heme biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-157579	speciesSpecific	go:GO:0000723	Telomere Maintenance	telomere maintenance	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-196807	speciesSpecific	go:GO:1901847	Nicotinate metabolism	nicotinate metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-196783	speciesSpecific	go:GO:0015937	Coenzyme A biosynthesis	coenzyme A biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-BTA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-CEL-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-CFA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-DDI-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-DME-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-DRE-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-GGA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-MMU-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-PFA-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-RNO-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-SCE-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-SPO-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-SSC-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-XTR-73843	speciesSpecific	go:GO:0006015	5-Phosphoribose 1-diphosphate biosynthesis	5-phosphoribose 1-diphosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9646399	speciesSpecific	go:GO:0035973	Aggrephagy	aggrephagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-109581	speciesSpecific	go:GO:0006915	Apoptosis	apoptotic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-351143	speciesSpecific	go:GO:0097055	Agmatine biosynthesis	agmatine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8964540	speciesSpecific	go:GO:0006522	Alanine metabolism	alanine metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-193048	speciesSpecific	go:GO:0006702	Androgen biosynthesis	androgen biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9612973	speciesSpecific	go:GO:0006914	Autophagy	autophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-422475	speciesSpecific	go:GO:0007411	Axon guidance	axon guidance	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73929	speciesSpecific	go:GO:0006285	Base-Excision Repair, AP Site Formation	base-excision repair, AP site formation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5576891	speciesSpecific	go:GO:0061337	Cardiac conduction	cardiac conduction	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-200425	speciesSpecific	go:GO:0009437	Carnitine metabolism	carnitine metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-71262	speciesSpecific	go:GO:0045329	Carnitine synthesis	carnitine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-209905	speciesSpecific	go:GO:0042423	Catecholamine biosynthesis	catecholamine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1640170	speciesSpecific	go:GO:0007049	Cell Cycle	cell cycle	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-69620	speciesSpecific	go:GO:0000075	Cell Cycle Checkpoints	cell cycle checkpoint	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-446728	speciesSpecific	go:GO:0034330	Cell junction organization	cell junction organization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1222541	speciesSpecific	go:GO:0045454	Cell redox homeostasis	cell redox homeostasis	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-421270	speciesSpecific	go:GO:0045216	Cell-cell junction organization	cell-cell junction organization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2559583	speciesSpecific	go:GO:0090398	Cellular Senescence	cellular senescence	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-3371556	speciesSpecific	go:GO:0034605	Cellular response to heat stress	cellular response to heat	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1234174	speciesSpecific	go:GO:0071456	Cellular response to hypoxia	cellular response to hypoxia	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9613829	speciesSpecific	mesh:D000080642	Chaperone Mediated Autophagy	Chaperone-Mediated Autophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-191273	speciesSpecific	go:GO:0006695	Cholesterol biosynthesis	cholesterol biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-6807047	speciesSpecific	go:GO:0033489	Cholesterol biosynthesis via desmosterol	cholesterol biosynthetic process via desmosterol	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-6798163	speciesSpecific	go:GO:0042426	Choline catabolism	choline catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2142753	speciesSpecific	go:GO:0019369	Arachidonic acid metabolism	arachidonic acid metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5620912	speciesSpecific	go:GO:0097711	Anchoring of the basal body to the plasma membrane	ciliary basal body-plasma membrane docking	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5617833	speciesSpecific	go:GO:0060271	Cilium Assembly	cilium assembly	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8963901	speciesSpecific	go:GO:0034371	Chylomicron remodeling	chylomicron remodeling	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8963888	speciesSpecific	go:GO:0034378	Chylomicron assembly	chylomicron assembly	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-156582	speciesSpecific	mesh:D000107	Acetylation	Acetylation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-6807062	speciesSpecific	go:GO:0033490	Cholesterol biosynthesis via lathosterol	cholesterol biosynthetic process via lathosterol	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2022870	speciesSpecific	go:GO:0030206	Chondroitin sulfate biosynthesis	chondroitin sulfate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-4839726	speciesSpecific	go:GO:0006325	Chromatin organization	chromatin organization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-400253	speciesSpecific	mesh:D057906	Circadian Clock	Circadian Clocks	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8856828	speciesSpecific	go:GO:0072583	Clathrin-mediated endocytosis	clathrin-dependent endocytosis	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-196783	speciesSpecific	go:GO:0015937	Coenzyme A biosynthesis	coenzyme A biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1442490	speciesSpecific	go:GO:0030574	Collagen degradation	collagen catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1474290	speciesSpecific	go:GO:0032964	Collagen formation	collagen biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-166658	speciesSpecific	go:GO:0006956	Complement cascade	complement activation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-71288	speciesSpecific	go:GO:0006600	Creatine metabolism	creatine metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8949613	speciesSpecific	go:GO:0042407	Cristae formation	cristae formation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73894	speciesSpecific	go:GO:0006281	DNA Repair	DNA repair	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-69306	speciesSpecific	go:GO:0006260	DNA Replication	DNA replication	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5334118	speciesSpecific	go:GO:0006306	DNA methylation	DNA methylation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-68952	speciesSpecific	go:GO:0006270	DNA replication initiation	DNA replication initiation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-69190	speciesSpecific	go:GO:0022616	DNA strand elongation	DNA strand elongation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-429914	speciesSpecific	go:GO:0000288	Deadenylation-dependent mRNA decay	nuclear-transcribed mRNA catabolic process, deadenylation-dependent decay	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73927	speciesSpecific	go:GO:0045007	Depurination	depurination	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73928	speciesSpecific	go:GO:0045008	Depyrimidination	depyrimidination	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2022923	speciesSpecific	go:GO:0030208	Dermatan sulfate biosynthesis	dermatan sulfate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5688426	speciesSpecific	go:GO:0016579	Deubiquitination	protein deubiquitination	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8935690	speciesSpecific	go:GO:0007586	Digestion	digestion	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2468052	speciesSpecific	go:GO:0034085	Establishment of Sister Chromatid Cohesion	establishment of sister chromatid cohesion	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-193144	speciesSpecific	go:GO:0006703	Estrogen biosynthesis	estrogen biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-71384	speciesSpecific	go:GO:0006069	Ethanol oxidation	ethanol oxidation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1474244	speciesSpecific	go:GO:0030198	Extracellular matrix organization	extracellular matrix organization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8978868	speciesSpecific	go:GO:0006631	Fatty acid metabolism	fatty acid metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1187000	speciesSpecific	go:GO:0009566	Fertilization	fertilization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5652227	speciesSpecific	go:GO:0046370	Fructose biosynthesis	fructose biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70350	speciesSpecific	go:GO:0006001	Fructose catabolism	fructose catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5652084	speciesSpecific	go:GO:0006000	Fructose metabolism	fructose metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-69236	speciesSpecific	go:GO:0051318	G1 Phase	G1 phase	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-69615	speciesSpecific	go:GO:0044783	G1/S DNA Damage Checkpoints	G1 DNA damage checkpoint	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-68911	speciesSpecific	go:GO:0051319	G2 Phase	G2 phase	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70370	speciesSpecific	go:GO:0019388	Galactose catabolism	galactose catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-190861	speciesSpecific	go:GO:0016264	Gap junction assembly	gap junction assembly	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-211000	speciesSpecific	go:GO:0031047	Gene Silencing by RNA	gene silencing by RNA	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70171	speciesSpecific	go:GO:0006096	Glycolysis	glycolytic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-189483	speciesSpecific	go:GO:0042167	Heme degradation	heme catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-3322077	speciesSpecific	go:GO:0005978	Glycogen synthesis	glycogen biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-194002	speciesSpecific	go:GO:0006704	Glucocorticoid biosynthesis	glucocorticoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70263	speciesSpecific	go:GO:0006094	Gluconeogenesis	gluconeogenesis	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70326	speciesSpecific	go:GO:0006006	Glucose metabolism	glucose metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1483206	speciesSpecific	go:GO:0046474	Glycerophospholipid biosynthesis	glycerophospholipid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-6814848	speciesSpecific	go:GO:0046475	Glycerophospholipid catabolism	glycerophospholipid catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-6783984	speciesSpecific	go:GO:0006546	Glycine degradation	glycine catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8982491	speciesSpecific	go:GO:0005977	Glycogen metabolism	glycogen metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1630316	speciesSpecific	go:GO:0030203	Glycosaminoglycan metabolism	glycosaminoglycan metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1660662	speciesSpecific	go:GO:0006687	Glycosphingolipid metabolism	glycosphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8963896	speciesSpecific	go:GO:0034380	HDL assembly	high-density lipoprotein particle assembly	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8964011	speciesSpecific	go:GO:0034384	HDL clearance	high-density lipoprotein particle clearance	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8964058	speciesSpecific	go:GO:0034375	HDL remodeling	high-density lipoprotein particle remodeling	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-189451	speciesSpecific	go:GO:0006783	Heme biosynthesis	heme biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-109582	speciesSpecific	go:GO:0007599	Hemostasis	hemostasis	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70921	speciesSpecific	go:GO:0006548	Histidine catabolism	histidine catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2142845	speciesSpecific	go:GO:0030212	Hyaluronan metabolism	hyaluronan metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-168256	speciesSpecific	mesh:D007107	Immune System	Immune System	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1483249	speciesSpecific	go:GO:0043647	Inositol phosphate metabolism	inositol phosphate metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-264876	speciesSpecific	go:GO:0030070	Insulin processing	insulin processing	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-77387	speciesSpecific	go:GO:0038020	Insulin receptor recycling	insulin receptor recycling	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8963676	speciesSpecific	go:GO:0050892	Intestinal absorption	intestinal absorption	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8981373	speciesSpecific	go:GO:0106001	Intestinal hexose absorption	intestinal hexose absorption	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8963678	speciesSpecific	go:GO:0098856	Intestinal lipid absorption	intestinal lipid absorption	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5620924	speciesSpecific	go:GO:0042073	Intraflagellar transport	intraciliary transport	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5578775	speciesSpecific	go:GO:0050801	Ion homeostasis	ion homeostasis	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2022854	speciesSpecific	go:GO:0018146	Keratan sulfate biosynthesis	keratan sulfate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2022857	speciesSpecific	go:GO:0042340	Keratan sulfate degradation	keratan sulfate catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-6805567	speciesSpecific	go:GO:0031424	Keratinization	keratinization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-74182	speciesSpecific	go:GO:1902224	Ketone body metabolism	ketone body metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8964038	speciesSpecific	go:GO:0034383	LDL clearance	low-density lipoprotein particle clearance	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8964041	speciesSpecific	go:GO:0034374	LDL remodeling	low-density lipoprotein particle remodeling	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5653890	speciesSpecific	go:GO:0005989	Lactose synthesis	lactose biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9615710	speciesSpecific	go:GO:0061738	Late endosomal microautophagy	late endosomal microautophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8964572	speciesSpecific	go:GO:0034389	Lipid particle organization	lipid droplet organization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9613354	speciesSpecific	go:GO:0061724	Lipophagy	lipophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9620244	speciesSpecific	mesh:D017774	Long-term potentiation	Long-Term Potentiation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-71064	speciesSpecific	go:GO:0006554	Lysine catabolism	lysine catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-68886	speciesSpecific	go:GO:0000279	M Phase	M phase	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1632852	speciesSpecific	mesh:D000080550	Macroautophagy	Macroautophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1632852	speciesSpecific	go:GO:0016236	Macroautophagy	macroautophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1500620	speciesSpecific	mesh:D008540	Meiosis	Meiosis	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1500620	speciesSpecific	go:GO:0051321	Meiosis	meiotic cell cycle	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1430728	speciesSpecific	go:GO:0008152	Metabolism	metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-156581	speciesSpecific	go:GO:0032259	Methylation	methylation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-193993	speciesSpecific	go:GO:0006705	Mineralocorticoid biosynthesis	mineralocorticoid biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5358508	speciesSpecific	go:GO:0006298	Mismatch Repair	mismatch repair	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1268020	speciesSpecific	go:GO:0006626	Mitochondrial protein import	protein targeting to mitochondrion	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-163316	speciesSpecific	go:GO:0006393	Mitochondrial transcription termination	termination of mitochondrial transcription	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5368287	speciesSpecific	go:GO:0032543	Mitochondrial translation	mitochondrial translation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5389840	speciesSpecific	go:GO:0070125	Mitochondrial translation elongation	mitochondrial translational elongation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5662702	speciesSpecific	go:GO:0042438	Melanin biosynthesis	melanin biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1237112	speciesSpecific	go:GO:0019509	Methionine salvage pathway	L-methionine salvage from methylthioadenosine	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5368286	speciesSpecific	go:GO:0070124	Mitochondrial translation initiation	mitochondrial translational initiation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5419276	speciesSpecific	go:GO:0070126	Mitochondrial translation termination	mitochondrial translational termination	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5205647	speciesSpecific	go:GO:0000423	Mitophagy	mitophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5205647	speciesSpecific	go:GO:0000422	Mitophagy	autophagy of mitochondrion	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-68882	speciesSpecific	go:GO:0000090	Mitotic Anaphase	mitotic anaphase	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-68881	speciesSpecific	go:GO:0007091	Mitotic Metaphase/Anaphase Transition	metaphase/anaphase transition of mitotic cell cycle	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-68877	speciesSpecific	go:GO:0000236	Mitotic Prometaphase	mitotic prometaphase	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-68875	speciesSpecific	go:GO:0000088	Mitotic Prophase	mitotic prophase	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-69618	speciesSpecific	go:GO:0071174	Mitotic Spindle Checkpoint	mitotic spindle checkpoint	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-397014	speciesSpecific	go:GO:0006936	Muscle contraction	muscle contraction	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-525793	speciesSpecific	go:GO:0007519	Myogenesis	skeletal muscle tissue development	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-525793	speciesSpecific	go:GO:0042692	Myogenesis	muscle cell differentiation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-389542	speciesSpecific	go:GO:0006740	NADPH regeneration	NADPH regeneration	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-167060	speciesSpecific	go:GO:0032455	NGF processing	nerve growth factor processing	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9675108	speciesSpecific	go:GO:0007399	Nervous system development	nervous system development	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-6798695	speciesSpecific	go:GO:0043312	Neutrophil degranulation	neutrophil degranulation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-196807	speciesSpecific	go:GO:1901847	Nicotinate metabolism	nicotinate metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2980766	speciesSpecific	go:GO:0051081	Nuclear Envelope Breakdown	nuclear envelope disassembly	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-72766	speciesSpecific	go:GO:0006412	Translation	translation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8956320	speciesSpecific	go:GO:0046112	Nucleobase biosynthesis	nucleobase biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8956319	speciesSpecific	go:GO:0046113	Nucleobase catabolism	nucleobase catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-774815	speciesSpecific	go:GO:0006334	Nucleosome assembly	nucleosome assembly	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8956321	speciesSpecific	go:GO:0043173	Nucleotide salvage	nucleotide salvage	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9664873	speciesSpecific	go:GO:0000425	Pexophagy	pexophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-561048	speciesSpecific	go:GO:0015711	Organic anion transport	organic anion transport	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-549127	speciesSpecific	go:GO:0015695	Organic cation transport	organic cation transport	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-109704	speciesSpecific	go:GO:0014065	PI3K Cascade	phosphatidylinositol 3-kinase signaling	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-71336	speciesSpecific	go:GO:0006098	Pentose phosphate pathway	pentose-phosphate shunt	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1483257	speciesSpecific	go:GO:0006644	Phospholipid metabolism	phospholipid metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-114608	speciesSpecific	go:GO:0002576	Platelet degranulation	platelet degranulation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-389977	speciesSpecific	go:GO:0007023	Post-chaperonin tubulin folding pathway	post-chaperonin tubulin folding pathway	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-597592	speciesSpecific	go:GO:0043687	Post-translational protein modification	post-translational protein modification	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5357801	speciesSpecific	go:GO:0012501	Programmed Cell Death	programmed cell death	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70688	speciesSpecific	go:GO:0006562	Proline catabolism	proline catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-71032	speciesSpecific	go:GO:1902859	Propionyl-CoA catabolism	propionyl-CoA catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-391251	speciesSpecific	go:GO:0006457	Protein folding	protein folding	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9609507	speciesSpecific	go:GO:0008104	Protein localization	protein localization	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8876725	speciesSpecific	go:GO:0006479	Protein methylation	protein methylation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5676934	speciesSpecific	go:GO:0030091	Protein repair	protein repair	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8852135	speciesSpecific	go:GO:0016567	Protein ubiquitination	protein ubiquitination	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73817	speciesSpecific	go:GO:0009168	Purine ribonucleoside monophosphate biosynthesis	purine ribonucleoside monophosphate biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-74217	speciesSpecific	go:GO:0043101	Purine salvage	purine-containing compound salvage	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73614	speciesSpecific	go:GO:0008655	Pyrimidine salvage	pyrimidine-containing compound salvage	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70268	speciesSpecific	go:GO:0006090	Pyruvate metabolism	pyruvate metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5213460	speciesSpecific	go:GO:0070266	RIPK1-mediated regulated necrosis	necroptotic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73863	speciesSpecific	go:GO:0006363	RNA Polymerase I Transcription Termination	termination of RNA polymerase I transcription	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73856	speciesSpecific	go:GO:0006369	RNA Polymerase II Transcription Termination	termination of RNA polymerase II transcription	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-73980	speciesSpecific	go:GO:0006386	RNA Polymerase III Transcription Termination	termination of RNA polymerase III transcription	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-977606	speciesSpecific	go:GO:0030449	Regulation of Complement cascade	regulation of complement activation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-422356	speciesSpecific	go:GO:0050796	Regulation of insulin secretion	regulation of insulin secretion	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-453276	speciesSpecific	go:GO:0007346	Regulation of mitotic cell cycle	regulation of mitotic cell cycle	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1474165	speciesSpecific	go:GO:0000003	Reproduction	reproduction	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5660526	speciesSpecific	go:GO:0010038	Response to metal ions	response to metal ion	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-69242	speciesSpecific	go:GO:0051320	S Phase	S phase	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2990846	speciesSpecific	mesh:D058207	SUMOylation	Sumoylation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2990846	speciesSpecific	go:GO:0016925	SUMOylation	protein sumoylation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9663891	speciesSpecific	go:GO:0061912	Selective autophagy	selective autophagy	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1799339	speciesSpecific	go:GO:0006614	SRP-dependent cotranslational protein targeting to membrane	SRP-dependent cotranslational protein targeting to membrane	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-2408557	speciesSpecific	go:GO:0016260	Selenocysteine synthesis	selenocysteine biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-162582	speciesSpecific	go:GO:0007165	Signal Transduction	signal transduction	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-445355	speciesSpecific	go:GO:0006939	Smooth Muscle Contraction	smooth muscle contraction	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-428157	speciesSpecific	go:GO:0006665	Sphingolipid metabolism	sphingolipid metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-390522	speciesSpecific	go:GO:0006941	Striated Muscle Contraction	striated muscle contraction	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-1614635	speciesSpecific	go:GO:0000096	Sulfur amino acid metabolism	sulfur amino acid metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-157579	speciesSpecific	go:GO:0000723	Telomere Maintenance	telomere maintenance	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8849175	speciesSpecific	go:GO:0006567	Threonine catabolism	threonine catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-75944	speciesSpecific	go:GO:0006390	Transcription from mitochondrial promoters	mitochondrial transcription	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-75109	speciesSpecific	go:GO:0019432	Triglyceride biosynthesis	triglyceride biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-163560	speciesSpecific	go:GO:0019433	Triglyceride catabolism	triglyceride catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8979227	speciesSpecific	go:GO:0006641	Triglyceride metabolism	triglyceride metabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-71240	speciesSpecific	go:GO:0006569	Tryptophan catabolism	tryptophan catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8963684	speciesSpecific	go:GO:0006572	Tyrosine catabolism	tyrosine catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-70635	speciesSpecific	go:GO:0000050	Urea cycle	urea cycle	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-77108	speciesSpecific	go:GO:0046952	Utilization of Ketone Bodies	ketone body catabolic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8866423	speciesSpecific	go:GO:0034379	VLDL assembly	very-low-density lipoprotein particle assembly	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-8964046	speciesSpecific	go:GO:0034447	VLDL clearance	very-low-density lipoprotein particle clearance	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-5653656	speciesSpecific	go:GO:0016192	Vesicle-mediated transport	vesicle-mediated transport	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-9640463	speciesSpecific	go:GO:0010025	Wax biosynthesis	wax biosynthetic process	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-72187	speciesSpecific	go:GO:0031124	mRNA 3'-end processing	mRNA 3'-end processing	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-72086	speciesSpecific	go:GO:0006370	mRNA Capping	7-methylguanosine mRNA capping	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-72312	speciesSpecific	go:GO:0006364	rRNA processing	rRNA processing	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-379724	speciesSpecific	go:GO:0043039	tRNA Aminoacylation	tRNA aminoacylation	orcid:0000-0003-4423-4370	CC0
+reactome:R-HSA-72306	speciesSpecific	go:GO:0008033	tRNA processing	tRNA processing	orcid:0000-0003-4423-4370	CC0
+mesh:D000080242	skos:exactMatch	chebi:CHEBI:40304	8-Hydroxy-2'-Deoxyguanosine	8-hydroxy-2'-deoxyguanosine	orcid:0000-0001-9439-5346	CC0
+mesh:D000317	skos:exactMatch	chebi:CHEBI:37890	Adrenergic alpha-Antagonists	alpha-adrenergic antagonist	orcid:0000-0001-9439-5346	CC0
+mesh:D000316	skos:exactMatch	chebi:CHEBI:35569	Adrenergic alpha-Agonists	alpha-adrenergic agonist	orcid:0000-0001-9439-5346	CC0
+mesh:D000318	skos:exactMatch	chebi:CHEBI:35522	Adrenergic beta-Agonists	beta-adrenergic agonist	orcid:0000-0001-9439-5346	CC0
+mesh:D000319	skos:exactMatch	chebi:CHEBI:35530	Adrenergic beta-Antagonists	beta-adrenergic antagonist	orcid:0000-0001-9439-5346	CC0
+mesh:D000433	skos:exactMatch	chebi:CHEBI:28831	1-Propanol	propan-1-ol	orcid:0000-0001-9439-5346	CC0
+mesh:D000803	skos:exactMatch	chebi:CHEBI:2718	Angiotensin I	Angiotensin I	orcid:0000-0001-9439-5346	CC0
+mesh:D000805	skos:exactMatch	chebi:CHEBI:89666	Angiotensin III	Angiotensin III	orcid:0000-0001-9439-5346	CC0
+mesh:D000779	skos:exactMatch	chebi:CHEBI:36333	Anesthetics, Local	local anaesthetic	orcid:0000-0001-9439-5346	CC0
+mesh:D000894	skos:exactMatch	chebi:CHEBI:35475	Anti-Inflammatory Agents, Non-Steroidal	non-steroidal anti-inflammatory drug	orcid:0000-0001-9439-5346	CC0
+mesh:D000988	skos:exactMatch	chebi:CHEBI:145047	Antispermatogenic Agents	antispermatogenic agent	orcid:0000-0001-9439-5346	CC0
+mesh:D000993	skos:exactMatch	chebi:CHEBI:36050	Antitreponemal Agents	antitreponemal drug	orcid:0000-0001-9439-5346	CC0
+mesh:D001378	skos:exactMatch	chebi:CHEBI:35726	Azasteroids	aza-steroid	orcid:0000-0001-9439-5346	CC0
+mesh:D001455	skos:exactMatch	chebi:CHEBI:28908	Bambermycins	bambermycin	orcid:0000-0001-9439-5346	CC0
+mesh:D001603	skos:exactMatch	chebi:CHEBI:33391	Berkelium	berkelium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D001608	skos:exactMatch	chebi:CHEBI:30501	Beryllium	beryllium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D001615	skos:exactMatch	chebi:CHEBI:10415	beta-Endorphin	beta-endorphin	orcid:0000-0001-9439-5346	CC0
+mesh:D001895	skos:exactMatch	chebi:CHEBI:27560	Boron	boron atom	orcid:0000-0001-9439-5346	CC0
+mesh:D001969	skos:exactMatch	chebi:CHEBI:37149	Bromobenzenes	bromobenzenes	orcid:0000-0001-9439-5346	CC0
+mesh:D001971	skos:exactMatch	chebi:CHEBI:3181	Bromocriptine	bromocriptine	orcid:0000-0001-9439-5346	CC0
+mesh:D001977	skos:exactMatch	chebi:CHEBI:3183	Brompheniramine	brompheniramine	orcid:0000-0001-9439-5346	CC0
+mesh:D001978	skos:exactMatch	chebi:CHEBI:59424	Bromphenol Blue	bromophenol blue	orcid:0000-0001-9439-5346	CC0
+mesh:D001993	skos:exactMatch	chebi:CHEBI:35523	Bronchodilator Agents	bronchodilator agent	orcid:0000-0001-9439-5346	CC0
+mesh:D002118	skos:exactMatch	chebi:CHEBI:22984	Calcium	calcium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D002120	skos:exactMatch	chebi:CHEBI:38807	Calcium Channel Agonists	calcium channel agonist	orcid:0000-0001-9439-5346	CC0
+mesh:D002125	skos:exactMatch	chebi:CHEBI:3309	Calcium Gluconate	Calcium Gluconate	orcid:0000-0001-9439-5346	CC0
+mesh:D002142	skos:exactMatch	chebi:CHEBI:33392	Californium	californium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D002227	skos:exactMatch	chebi:CHEBI:48513	Carbazoles	carbazoles	orcid:0000-0001-9439-5346	CC0
+mesh:D002235	skos:exactMatch	chebi:CHEBI:34611	Carbofuran	carbofuran	orcid:0000-0001-9439-5346	CC0
+mesh:D002244	skos:exactMatch	chebi:CHEBI:27594	Carbon	carbon atom	orcid:0000-0001-9439-5346	CC0
+mesh:D002245	skos:exactMatch	chebi:CHEBI:16526	Carbon Dioxide	carbon dioxide	orcid:0000-0001-9439-5346	CC0
+mesh:D002254	skos:exactMatch	chebi:CHEBI:23016	Carbonates	carbonates	orcid:0000-0001-9439-5346	CC0
+mesh:D002308	skos:exactMatch	chebi:CHEBI:28494	Cardiolipins	cardiolipin	orcid:0000-0001-9439-5346	CC0
+mesh:D002301	skos:exactMatch	chebi:CHEBI:83970	Cardiac Glycosides	cardiac glycoside	orcid:0000-0001-9439-5346	CC0
+mesh:D002298	skos:exactMatch	chebi:CHEBI:74634	Cardenolides	cardenolides	orcid:0000-0001-9439-5346	CC0
+mesh:D002273	skos:exactMatch	chebi:CHEBI:50903	Carcinogens	carcinogenic agent	orcid:0000-0001-9439-5346	CC0
+mesh:D002740	skos:exactMatch	chebi:CHEBI:3640	Chlorothiazide	chlorothiazide	orcid:0000-0001-9439-5346	CC0
+mesh:D002745	skos:exactMatch	chebi:CHEBI:3646	Chlorphentermine	Chlorphentermine	orcid:0000-0001-9439-5346	CC0
+mesh:D002491	skos:exactMatch	chebi:CHEBI:35470	Central Nervous System Agents	central nervous system drug	orcid:0000-0001-9439-5346	CC0
+mesh:D002784	skos:exactMatch	chebi:CHEBI:16113	Cholesterol	cholesterol	orcid:0000-0001-9439-5346	CC0
+mesh:D002794	skos:exactMatch	chebi:CHEBI:15354	Choline	choline	orcid:0000-0001-9439-5346	CC0
+mesh:D002857	skos:exactMatch	chebi:CHEBI:28073	Chromium	chromium atom	orcid:0000-0001-9439-5346	CC0
+mesh:D002867	skos:exactMatch	chebi:CHEBI:23238	Chromones	chromones	orcid:0000-0001-9439-5346	CC0
+mesh:D002863	skos:exactMatch	chebi:CHEBI:75050	Chromogenic Compounds	chromogenic compound	orcid:0000-0001-9439-5346	CC0
+mesh:D002801	skos:exactMatch	chebi:CHEBI:50241	Cholinesterase Reactivators	cholinesterase reactivator	orcid:0000-0001-9439-5346	CC0
+mesh:D002939	skos:exactMatch	chebi:CHEBI:100241	Ciprofloxacin	ciprofloxacin	orcid:0000-0001-9439-5346	CC0
+mesh:D002934	skos:exactMatch	chebi:CHEBI:36091	Cinnamates	cinnamates	orcid:0000-0001-9439-5346	CC0
+mesh:D002930	skos:exactMatch	chebi:CHEBI:51323	Cinchona Alkaloids	cinchona alkaloid	orcid:0000-0001-9439-5346	CC0
+mesh:D003006	skos:exactMatch	chebi:CHEBI:59115	Clopenthixol	clopenthixol	orcid:0000-0001-9439-5346	CC0
+mesh:D002997	skos:exactMatch	chebi:CHEBI:47780	Clomipramine	clomipramine	orcid:0000-0001-9439-5346	CC0
+mesh:D002996	skos:exactMatch	chebi:CHEBI:3752	Clomiphene	clomiphene	orcid:0000-0001-9439-5346	CC0
+mesh:D002994	skos:exactMatch	chebi:CHEBI:3750	Clofibrate	clofibrate	orcid:0000-0001-9439-5346	CC0
+mesh:D003022	skos:exactMatch	chebi:CHEBI:3764	Clotrimazole	clotrimazole	orcid:0000-0001-9439-5346	CC0
+mesh:D003023	skos:exactMatch	chebi:CHEBI:49566	Cloxacillin	cloxacillin	orcid:0000-0001-9439-5346	CC0
+mesh:D003024	skos:exactMatch	chebi:CHEBI:3766	Clozapine	clozapine	orcid:0000-0001-9439-5346	CC0
+mesh:D003038	skos:exactMatch	chebi:CHEBI:23341	Cobamides	cobamides	orcid:0000-0001-9439-5346	CC0
+mesh:D003042	skos:exactMatch	chebi:CHEBI:27958	Cocaine	cocaine	orcid:0000-0001-9439-5346	CC0
+mesh:D003049	skos:exactMatch	chebi:CHEBI:35818	Coccidiostats	coccidiostat	orcid:0000-0001-9439-5346	CC0
+mesh:D003061	skos:exactMatch	chebi:CHEBI:16714	Codeine	codeine	orcid:0000-0001-9439-5346	CC0
+mesh:D003065	skos:exactMatch	chebi:CHEBI:15346	Coenzyme A	coenzyme A	orcid:0000-0001-9439-5346	CC0
+mesh:D003067	skos:exactMatch	chebi:CHEBI:23354	Coenzymes	coenzyme	orcid:0000-0001-9439-5346	CC0
+mesh:D003070	skos:exactMatch	chebi:CHEBI:16213	Coformycin	coformycin	orcid:0000-0001-9439-5346	CC0
+mesh:D003084	skos:exactMatch	chebi:CHEBI:3814	Colestipol	colestipol	orcid:0000-0001-9439-5346	CC0
+mesh:D003094	skos:exactMatch	chebi:CHEBI:3815	Collagen	Collagen	orcid:0000-0001-9439-5346	CC0
+mesh:D003224	skos:exactMatch	chebi:CHEBI:34653	Congo Red	Congo Red	orcid:0000-0001-9439-5346	CC0
+mesh:D003300	skos:exactMatch	chebi:CHEBI:28694	Copper	copper atom	orcid:0000-0001-9439-5346	CC0
+mesh:D003345	skos:exactMatch	chebi:CHEBI:16827	Corticosterone	corticosterone	orcid:0000-0001-9439-5346	CC0
+mesh:D003348	skos:exactMatch	chebi:CHEBI:16962	Cortisone	cortisone	orcid:0000-0001-9439-5346	CC0
+mesh:D003358	skos:exactMatch	chebi:CHEBI:64857	Cosmetics	cosmetic	orcid:0000-0001-9439-5346	CC0
+mesh:D003366	skos:exactMatch	chebi:CHEBI:3901	Cosyntropin	cosyntropin	orcid:0000-0001-9439-5346	CC0
+mesh:D003372	skos:exactMatch	chebi:CHEBI:3903	Coumaphos	coumaphos	orcid:0000-0001-9439-5346	CC0
+mesh:D003374	skos:exactMatch	chebi:CHEBI:23403	Coumarins	coumarins	orcid:0000-0001-9439-5346	CC0
+mesh:D003375	skos:exactMatch	chebi:CHEBI:3908	Coumestrol	coumestrol	orcid:0000-0001-9439-5346	CC0
+mesh:D003401	skos:exactMatch	chebi:CHEBI:16919	Creatine	creatine	orcid:0000-0001-9439-5346	CC0
+mesh:D003404	skos:exactMatch	chebi:CHEBI:16737	Creatinine	creatinine	orcid:0000-0001-9439-5346	CC0
+mesh:D003408	skos:exactMatch	chebi:CHEBI:25399	Cresols	cresol	orcid:0000-0001-9439-5346	CC0
+mesh:D003484	skos:exactMatch	chebi:CHEBI:16698	Cyanamide	cyanamide	orcid:0000-0001-9439-5346	CC0
+mesh:D003485	skos:exactMatch	chebi:CHEBI:23420	Cyanates	cyanates	orcid:0000-0001-9439-5346	CC0
+mesh:D003486	skos:exactMatch	chebi:CHEBI:23424	Cyanides	cyanides	orcid:0000-0001-9439-5346	CC0
+mesh:D003492	skos:exactMatch	chebi:CHEBI:17074	Cycasin	cycasin	orcid:0000-0001-9439-5346	CC0
+mesh:D003494	skos:exactMatch	chebi:CHEBI:82431	Cyclamates	Cyclamate	orcid:0000-0001-9439-5346	CC0
+mesh:D003501	skos:exactMatch	chebi:CHEBI:3994	Cyclizine	cyclizine	orcid:0000-0001-9439-5346	CC0
+mesh:D003505	skos:exactMatch	chebi:CHEBI:23456	Cyclodextrins	cyclodextrin	orcid:0000-0001-9439-5346	CC0
+mesh:D003506	skos:exactMatch	chebi:CHEBI:31446	Cyclofenil	Cyclofenil	orcid:0000-0001-9439-5346	CC0
+mesh:D003511	skos:exactMatch	chebi:CHEBI:23480	Cyclohexanols	cyclohexanols	orcid:0000-0001-9439-5346	CC0
+mesh:D003512	skos:exactMatch	chebi:CHEBI:23482	Cyclohexanones	cyclohexanones	orcid:0000-0001-9439-5346	CC0
+mesh:D003513	skos:exactMatch	chebi:CHEBI:27641	Cycloheximide	cycloheximide	orcid:0000-0001-9439-5346	CC0
+mesh:D003517	skos:exactMatch	chebi:CHEBI:23493	Cyclopentanes	cyclopentanes	orcid:0000-0001-9439-5346	CC0
+mesh:D003519	skos:exactMatch	chebi:CHEBI:4024	Cyclopentolate	cyclopentolate	orcid:0000-0001-9439-5346	CC0
+mesh:D003521	skos:exactMatch	chebi:CHEBI:51454	Cyclopropanes	cyclopropanes	orcid:0000-0001-9439-5346	CC0
+mesh:D003533	skos:exactMatch	chebi:CHEBI:4046	Cyproheptadine	cyproheptadine	orcid:0000-0001-9439-5346	CC0
+mesh:D003540	skos:exactMatch	chebi:CHEBI:17755	Cystathionine	cystathionine	orcid:0000-0001-9439-5346	CC0
+mesh:D003544	skos:exactMatch	chebi:CHEBI:21260	Cysteic Acid	cysteic acid	orcid:0000-0001-9439-5346	CC0
+mesh:D003545	skos:exactMatch	chebi:CHEBI:15356	Cysteine	cysteine	orcid:0000-0001-9439-5346	CC0
+mesh:D003548	skos:exactMatch	chebi:CHEBI:81392	Cysteinyldopa	Cysteinyldopa	orcid:0000-0001-9439-5346	CC0
+mesh:D003553	skos:exactMatch	chebi:CHEBI:17376	Cystine	cystine	orcid:0000-0001-9439-5346	CC0
+mesh:D003562	skos:exactMatch	chebi:CHEBI:17562	Cytidine	cytidine	orcid:0000-0001-9439-5346	CC0
+mesh:D003571	skos:exactMatch	chebi:CHEBI:23527	Cytochalasin B	cytochalasin B	orcid:0000-0001-9439-5346	CC0
+mesh:D003596	skos:exactMatch	chebi:CHEBI:16040	Cytosine	cytosine	orcid:0000-0001-9439-5346	CC0
+mesh:D003620	skos:exactMatch	chebi:CHEBI:4317	Dantrolene	dantrolene	orcid:0000-0001-9439-5346	CC0
+ncit:C1707	skos:exactMatch	chebi:CHEBI:10023	Voriconazole	voriconazole	orcid:0000-0003-4423-4370	CC0
+chebi:CHEBI:135931	skos:exactMatch	ncit:C73192	dexlansoprazole	Dexlansoprazole	orcid:0000-0003-4423-4370	CC0
+chebi:CHEBI:6375	skos:exactMatch	ncit:C29150	lansoprazole	Lansoprazole	orcid:0000-0003-4423-4370	CC0
+chebi:CHEBI:63598	skos:exactMatch	ncit:C1586	levofloxacin	Levofloxacin	orcid:0000-0003-4423-4370	CC0
+ncit:C65538	skos:exactMatch	chebi:CHEBI:50275	Esomeprazole	esomeprazole	orcid:0000-0003-4423-4370	CC0
+ncit:C2160	skos:exactMatch	chebi:CHEBI:52726	Proteasome Inhibitor	proteasome inhibitor	orcid:0000-0003-4423-4370	CC0
+mesh:D059765	skos:exactMatch	kegg.pathway:map03440	Homologous Recombination	Homologous recombination	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04360	skos:exactMatch	mesh:D000071437	Axon guidance	Axon Guidance	orcid:0000-0003-4423-4370	CC0
+mesh:D000078790	skos:exactMatch	kegg.pathway:map04911	Insulin Secretion	Insulin secretion	orcid:0000-0003-4423-4370	CC0
+mesh:D002453	skos:exactMatch	kegg.pathway:map04110	Cell Cycle	Cell cycle	orcid:0000-0003-4423-4370	CC0
+mesh:D004705	skos:exactMatch	kegg.pathway:map04144	Endocytosis	Endocytosis	orcid:0000-0003-4423-4370	CC0
+mesh:D060449	skos:exactMatch	kegg.pathway:map04310	Wnt Signaling Pathway	Wnt signaling pathway	orcid:0000-0003-4423-4370	CC0
+go:GO:0005816	skos:exactMatch	ncit:C13365	spindle pole body	Spindle Pole Body	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04710	skos:exactMatch	mesh:D002940	Circadian rhythm	Circadian Rhythm	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03030	skos:exactMatch	mesh:D004261	DNA replication	DNA Replication	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00190	skos:exactMatch	mesh:D010085	Oxidative phosphorylation	Oxidative Phosphorylation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00195	skos:exactMatch	mesh:D010788	Photosynthesis	Photosynthesis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04611	skos:exactMatch	mesh:D015539	Platelet activation	Platelet Activation	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04218	skos:exactMatch	mesh:D016922	Cellular senescence	Cellular Senescence	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map04210	skos:exactMatch	mesh:D017209	Apoptosis	Apoptosis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03013	skos:exactMatch	mesh:D034443	RNA transport	RNA Transport	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00030	skos:exactMatch	mesh:D010427	Pentose phosphate pathway	Pentose Phosphate Pathway	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map02024	skos:exactMatch	mesh:D053038	Quorum sensing	Quorum Sensing	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map03430	skos:exactMatch	mesh:D053843	Mismatch repair	DNA Mismatch Repair	orcid:0000-0003-4423-4370	CC0
+go:GO:0070266	skos:exactMatch	mesh:D000079302	necroptotic process	Necroptosis	orcid:0000-0003-4423-4370	CC0
+kegg.pathway:map00970	skos:exactMatch	mesh:D046249	Aminoacyl-tRNA biosynthesis	Transfer RNA Aminoacylation	orcid:0000-0003-4423-4370	CC0
+mesh:D000086382	skos:exactMatch	doid:DOID:0080600	COVID-19	COVID-19	orcid:0000-0001-9439-5346	CC0
+mesh:C437905	skos:exactMatch	uniprot:Q96PH6	DEFB118 protein, human	DEFB118	orcid:0000-0001-9439-5346	CC0
+mesh:C112641	skos:exactMatch	uniprot:O43583	DENR protein, human	DENR	orcid:0000-0001-9439-5346	CC0
+mesh:C494208	skos:exactMatch	uniprot:P60880	SNAP25 protein, human	SNAP25	orcid:0000-0001-9439-5346	CC0
+mesh:C494482	skos:exactMatch	uniprot:Q8NER1	TRPV1 protein, human	TRPV1	orcid:0000-0001-9439-5346	CC0
+mesh:C495270	skos:exactMatch	uniprot:P35222	CTNNB1 protein, human	CTNNB1	orcid:0000-0001-9439-5346	CC0
+mesh:C578038	skos:exactMatch	uniprot:Q02080	MEF2B protein, human	MEF2B	orcid:0000-0001-9439-5346	CC0
+mesh:C077171	skos:exactMatch	uniprot:P31629	HIVEP2 protein, human	HIVEP2	orcid:0000-0001-9439-5346	CC0
+mesh:C414177	skos:exactMatch	uniprot:P52569	SLC7A2 protein, human	SLC7A2	orcid:0000-0001-9439-5346	CC0
+mesh:C497937	skos:exactMatch	uniprot:P61764	STXBP1 protein, human	STXBP1	orcid:0000-0001-9439-5346	CC0
+mesh:C494841	skos:exactMatch	uniprot:Q12791	KCNMA1 protein, human	KCNMA1	orcid:0000-0001-9439-5346	CC0
+mesh:C108096	skos:exactMatch	uniprot:Q99643	SDHC protein, human	SDHC	orcid:0000-0001-9439-5346	CC0
+mesh:C511268	skos:exactMatch	uniprot:P31040	SDHA protein, human	SDHA	orcid:0000-0001-9439-5346	CC0
+mesh:C102467	skos:exactMatch	uniprot:Q99470	SDF2 protein, human	SDF2	orcid:0000-0001-9439-5346	CC0
+mesh:C494881	skos:exactMatch	uniprot:O75907	DGAT1 protein, human	DGAT1	orcid:0000-0001-9439-5346	CC0
+mesh:C580923	skos:exactMatch	uniprot:O95294	RASAL1 protein, human	RASAL1	orcid:0000-0001-9439-5346	CC0
+mesh:C580922	skos:exactMatch	uniprot:Q9NTJ3	SMC4 protein, human	SMC4	orcid:0000-0001-9439-5346	CC0
+mesh:C500151	skos:exactMatch	uniprot:Q9NX95	SYBU protein, human	SYBU	orcid:0000-0001-9439-5346	CC0
+mesh:C456359	skos:exactMatch	uniprot:Q969U7	PSMG2 protein, human	PSMG2	orcid:0000-0001-9439-5346	CC0
+mesh:C513866	skos:exactMatch	uniprot:Q8NE35	CPEB3 protein, human	CPEB3	orcid:0000-0001-9439-5346	CC0
+mesh:C489108	skos:exactMatch	uniprot:P05813	CRYBA1 protein, human	CRYBA1	orcid:0000-0001-9439-5346	CC0
+mesh:C490613	skos:exactMatch	uniprot:Q12955	ANK3 protein, human	ANK3	orcid:0000-0001-9439-5346	CC0
+mesh:C491904	skos:exactMatch	uniprot:O14617	AP3D1 protein, human	AP3D1	orcid:0000-0001-9439-5346	CC0
+mesh:C510070	skos:exactMatch	uniprot:P53677	AP3M2 protein, human	AP3M2	orcid:0000-0001-9439-5346	CC0
+mesh:C497872	skos:exactMatch	uniprot:P15408	FOSL2 protein, human	FOSL2	orcid:0000-0001-9439-5346	CC0
+mesh:C498630	skos:exactMatch	uniprot:Q9Y6V0	PCLO protein, human	PCLO	orcid:0000-0001-9439-5346	CC0
+mesh:C512817	skos:exactMatch	uniprot:O75493	CA11 protein, human	CA11	orcid:0000-0001-9439-5346	CC0
+mesh:C407644	skos:exactMatch	uniprot:Q9NP60	IL1RAPL2 protein, human	IL1RAPL2	orcid:0000-0001-9439-5346	CC0
+mesh:C403492	skos:exactMatch	uniprot:Q9UK73	FEM1B protein, human	FEM1B	orcid:0000-0001-9439-5346	CC0
+mesh:C485764	skos:exactMatch	uniprot:P35372	OPRM1 protein, human	OPRM1	orcid:0000-0001-9439-5346	CC0
+mesh:C109742	skos:exactMatch	uniprot:Q14BN4	SLMAP protein, human	SLMAP	orcid:0000-0001-9439-5346	CC0
+mesh:C402222	skos:exactMatch	uniprot:Q9NZJ7	MTCH1 protein, human	MTCH1	orcid:0000-0001-9439-5346	CC0
+mesh:C488761	skos:exactMatch	uniprot:Q6H3X3	RAET1G protein, human	RAET1G	orcid:0000-0001-9439-5346	CC0
+mesh:C488760	skos:exactMatch	uniprot:Q8TD07	RAET1E protein, human	RAET1E	orcid:0000-0001-9439-5346	CC0
+mesh:C490522	skos:exactMatch	uniprot:P78406	RAE1 protein, human	RAE1	orcid:0000-0001-9439-5346	CC0
+mesh:C419389	skos:exactMatch	uniprot:Q12797	ASPH protein, human	ASPH	orcid:0000-0001-9439-5346	CC0
+mesh:C508131	skos:exactMatch	uniprot:Q8WYH8	ING5 protein, human	ING5	orcid:0000-0001-9439-5346	CC0
+mesh:C504404	skos:exactMatch	uniprot:Q92563	SPOCK2 protein, human	SPOCK2	orcid:0000-0001-9439-5346	CC0
+mesh:C578040	skos:exactMatch	uniprot:Q06413	MEF2C protein, human	MEF2C	orcid:0000-0001-9439-5346	CC0
+mesh:C502025	skos:exactMatch	uniprot:Q9BZE1	MRPL37 protein, human	MRPL37	orcid:0000-0001-9439-5346	CC0
+mesh:C556354	skos:exactMatch	uniprot:P02765	AHSG protein, human	AHSG	orcid:0000-0001-9439-5346	CC0
+mesh:C519072	skos:exactMatch	uniprot:P11230	CHRNB1 protein, human	CHRNB1	orcid:0000-0001-9439-5346	CC0
+mesh:C519156	skos:exactMatch	uniprot:Q9H2K0	MTIF3 protein, human	MTIF3	orcid:0000-0001-9439-5346	CC0
+mesh:C518505	skos:exactMatch	uniprot:O96006	ZBED1 protein, human	ZBED1	orcid:0000-0001-9439-5346	CC0
+mesh:C578043	skos:exactMatch	uniprot:Q14814	MEF2D protein, human	MEF2D	orcid:0000-0001-9439-5346	CC0
+mesh:C463459	skos:exactMatch	uniprot:Q5JY77	GPRASP1 protein, human	GPRASP1	orcid:0000-0001-9439-5346	CC0
+mesh:C417919	skos:exactMatch	uniprot:Q9NQ84	GPRC5C protein, human	GPRC5C	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449619	skos:exactMatch	ncbiprotein:YP_009725297	Host translation inhibitor nsp1	leader protein	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449620	skos:exactMatch	ncbiprotein:YP_009725298	Non-structural protein 2	nsp2	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449621	skos:exactMatch	ncbiprotein:YP_009725299	Non-structural protein 3	nsp3	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449622	skos:exactMatch	ncbiprotein:YP_009725300	Non-structural protein 4	nsp4	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449623	skos:exactMatch	ncbiprotein:YP_009725301	3C-like proteinase	3C-like proteinase	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449624	skos:exactMatch	ncbiprotein:YP_009725302	Non-structural protein 6	nsp6	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449625	skos:exactMatch	ncbiprotein:YP_009725303	Non-structural protein 7	nsp7	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449626	skos:exactMatch	ncbiprotein:YP_009725304	Non-structural protein 8	nsp8	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449627	skos:exactMatch	ncbiprotein:YP_009725305	Non-structural protein 9	nsp9	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449628	skos:exactMatch	ncbiprotein:YP_009725306	Non-structural protein 10	nsp10	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449629	skos:exactMatch	ncbiprotein:YP_009725307	RNA-directed RNA polymerase	RNA-dependent RNA polymerase	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449630	skos:exactMatch	ncbiprotein:YP_009725308	Helicase	helicase	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449631	skos:exactMatch	ncbiprotein:YP_009725309	Proofreading exoribonuclease	3'-to-5' exonuclease	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449632	skos:exactMatch	ncbiprotein:YP_009725310	Uridylate-specific endoribonuclease	endoRNAse	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449633	skos:exactMatch	ncbiprotein:YP_009725311	2'-O-methyltransferase	2'-O-ribose methyltransferase	orcid:0000-0001-9439-5346	CC0
+pr:PR:000035726	skos:exactMatch	uniprot.chain:PRO_0000396174	ubiquitin (UBB)	Ubiquitin	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449635	skos:exactMatch	ncbiprotein:YP_009742608	Host translation inhibitor nsp1	leader protein	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449636	skos:exactMatch	ncbiprotein:YP_009742609	Non-structural protein 2	nsp2	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449637	skos:exactMatch	ncbiprotein:YP_009742610	Non-structural protein 3	nsp3	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449638	skos:exactMatch	ncbiprotein:YP_009742611	Non-structural protein 4	nsp4	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449639	skos:exactMatch	ncbiprotein:YP_009742612	3C-like proteinase	3C-like proteinase	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449640	skos:exactMatch	ncbiprotein:YP_009742613	Non-structural protein 6	nsp6	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449641	skos:exactMatch	ncbiprotein:YP_009742614	Non-structural protein 7	nsp7	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449642	skos:exactMatch	ncbiprotein:YP_009742615	Non-structural protein 8	nsp8	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449643	skos:exactMatch	ncbiprotein:YP_009742616	Non-structural protein 9	nsp9	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449644	skos:exactMatch	ncbiprotein:YP_009742617	Non-structural protein 10	nsp10	orcid:0000-0001-9439-5346	CC0
+uniprot.chain:PRO_0000449645	skos:exactMatch	ncbiprotein:YP_009725312	Non-structural protein 11	nsp11	orcid:0000-0001-9439-5346	CC0

--- a/docs/_data/biomappings.sssom.yml
+++ b/docs/_data/biomappings.sssom.yml
@@ -1,0 +1,23 @@
+curie_map:
+  chebi: 'https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:'
+  doid: 'https://www.ebi.ac.uk/ols/ontologies/doid/terms?obo_id=DOID:'
+  efo: https://www.ebi.ac.uk/efo/EFO_
+  go: 'http://amigo.geneontology.org/amigo/term/GO:'
+  hgnc: https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/
+  hp: 'https://hpo.jax.org/app/browse/term/HP:'
+  kegg.pathway: https://www.kegg.jp/entry/
+  mesh: http://id.nlm.nih.gov/mesh/
+  ncbiprotein: https://www.ncbi.nlm.nih.gov/protein/
+  ncit: https://www.ebi.ac.uk/ols/ontologies/ncit/terms?short_form=NCIT_
+  pfam: https://pfam.xfam.org/family/
+  pr: 'https://www.ebi.ac.uk/ols/ontologies/pr/terms?obo_id=PR:'
+  reactome: https://reactome.org/content/detail/
+  umls: http://linkedlifedata.com/resource/umls/id/
+  uniprot: http://purl.uniprot.org/uniprot/
+  uniprot.chain: http://purl.uniprot.org/annotation/
+  wikipathways: http://www.wikipathways.org/instance/
+license: https://creativecommons.org/publicdomain/zero/1.0/
+mapping_provider: https://github.com/biomappings/biomappings
+mapping_set_group: biomappings
+mapping_set_id: biomappings
+mapping_set_title: Biomappings

--- a/src/biomappings/export_sssom.py
+++ b/src/biomappings/export_sssom.py
@@ -4,11 +4,11 @@
 
 import os
 
+import bioregistry
 import click
 import pandas as pd
 import yaml
 
-import bioregistry
 from biomappings import load_mappings, load_predictions
 from biomappings.utils import DATA, MiriamValidator
 

--- a/src/biomappings/export_sssom.py
+++ b/src/biomappings/export_sssom.py
@@ -11,7 +11,7 @@ from biomappings import load_mappings, load_predictions
 from biomappings.utils import DATA, MiriamValidator
 
 PATH = os.path.join(DATA, "biomappings.sssom.tsv")
-
+CC0_URL = "https://creativecommons.org/publicdomain/zero/1.0/"
 validator = MiriamValidator()
 
 
@@ -40,7 +40,7 @@ def get_sssom_df() -> pd.DataFrame:
                 mapping["target name"],
                 "HumanCurated",  # match type
                 mapping["source"],  # curator CURIE
-                "https://creativecommons.org/publicdomain/zero/1.0/",
+                CC0_URL,
                 None,  # no confidence necessary
                 None,  # mapping tool: none necessary for manually curated
             )
@@ -55,12 +55,14 @@ def get_sssom_df() -> pd.DataFrame:
                 mapping["target name"],
                 "LexicalEquivalenceMatch",  # match type
                 None,  # no curator CURIE
-                "https://creativecommons.org/publicdomain/zero/1.0/",
+                CC0_URL,
                 mapping['confidence'],
                 mapping['source'],  # mapping tool: source script
             )
         )
-    return pd.DataFrame(rows, columns=columns)
+    df = pd.DataFrame(rows, columns=columns)
+    del df['license']
+    return df
 
 
 @click.command()

--- a/src/biomappings/export_sssom.py
+++ b/src/biomappings/export_sssom.py
@@ -10,35 +10,45 @@ import pandas as pd
 from biomappings import load_mappings
 from biomappings.utils import DATA
 
-PATH = os.path.join(DATA, 'biomappings.sssom.tsv')
+PATH = os.path.join(DATA, "biomappings.sssom.tsv")
 
 
 def get_sssom_df() -> pd.DataFrame:
     """Get an SSSOM dataframe."""
     rows = []
     columns = [
-        'subject_id', 'predicate_id', 'object_id', 'subject_label', 'object_label', 'creator_id', 'license'
+        "subject_id",
+        "predicate_id",
+        "object_id",
+        "subject_label",
+        "object_label",
+        "match_type",
+        "creator_id",
+        "license",
     ]
     for mapping in load_mappings():
-        rows.append((
-            f'{mapping["source prefix"]}:{mapping["source identifier"]}',
-            f'{mapping["relation"]}',
-            f'{mapping["target prefix"]}:{mapping["target identifier"]}',
-            mapping["source name"],
-            mapping["target name"],
-            mapping["source"],
-            'CC0',  # TODO fix this with URL?
-        ))
+        rows.append(
+            (
+                f'{mapping["source prefix"]}:{mapping["source identifier"]}',
+                f'{mapping["relation"]}',
+                f'{mapping["target prefix"]}:{mapping["target identifier"]}',
+                mapping["source name"],
+                mapping["target name"],
+                "sssom:HumanCurated",  # match type
+                mapping["source"],  # curator CURIE
+                "https://creativecommons.org/publicdomain/zero/1.0/",
+            )
+        )
     return pd.DataFrame(rows, columns=columns)
 
 
 @click.command()
-@click.option('--path', default=PATH)
+@click.option("--path", default=PATH)
 def main(path):
     """Export SSSOM."""
     df = get_sssom_df()
-    df.to_csv(path, sep='\t', index=False)
+    df.to_csv(path, sep="\t", index=False)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/biomappings/export_sssom.py
+++ b/src/biomappings/export_sssom.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""Export Biomappings as SSSOM."""
+
+import os
+
+import click
+import pandas as pd
+
+from biomappings import load_mappings
+from biomappings.utils import DATA
+
+PATH = os.path.join(DATA, 'biomappings.sssom.tsv')
+
+
+def get_sssom_df() -> pd.DataFrame:
+    """Get an SSSOM dataframe."""
+    rows = []
+    columns = [
+        'subject_id', 'predicate_id', 'object_id', 'subject_label', 'object_label', 'creator_id', 'license'
+    ]
+    for mapping in load_mappings():
+        rows.append((
+            f'{mapping["source prefix"]}:{mapping["source identifier"]}',
+            f'{mapping["relation"]}',
+            f'{mapping["target prefix"]}:{mapping["target identifier"]}',
+            mapping["source name"],
+            mapping["target name"],
+            mapping["source"],
+            'CC0',  # TODO fix this with URL?
+        ))
+    return pd.DataFrame(rows, columns=columns)
+
+
+@click.command()
+@click.option('--path', default=PATH)
+def main(path):
+    """Export SSSOM."""
+    df = get_sssom_df()
+    df.to_csv(path, sep='\t', index=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR creates an [SSSOM](https://github.com/mapping-commons/SSSOM/blob/master/SSSOM.md) export of biomappings. It can include not only curated mappings, but also predicted ones and their metadata.

See: https://github.com/biomappings/biomappings/blob/add-sssom-export/docs/_data/biomappings.sssom.tsv

Tasks:
- [x] Add manual mappings 
- [x] Correct licensing (everything in this repo is CC0 by definition)
- [x] Get match types right with SSSOM vocabulary
- [x] Add predicted mappings

Follow-up in future PR:

- [ ] Add manual negative mappings (blocked by https://github.com/mapping-commons/SSSOM/issues/40)
- [ ] Add SSSOM validation (blocked by https://github.com/mapping-commons/sssom-py/issues/73)