### PR TITLE
Update Gilda pipeline and add CCLE predictions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,7 @@ ignore =
     S404
     S603
     E203
+    W503
 exclude =
     .tox,
     .git,

--- a/scripts/generate_ccle_mappings.py
+++ b/scripts/generate_ccle_mappings.py
@@ -17,7 +17,7 @@ def main():
     provenance = get_script_url(__file__)
     custom_filter = generate_custom_filter()
     append_gilda_predictions(
-        "ccle",
+        "ccle.cell",
         ["depmap", "efo", "cellosaurus", "cl", "bto"],
         provenance=provenance,
         relation="skos:exactMatch",

--- a/scripts/generate_ccle_mappings.py
+++ b/scripts/generate_ccle_mappings.py
@@ -3,9 +3,9 @@
 """Generate mappings to Gilda from given PyOBO prefixes."""
 
 import click
+import pyobo
 from more_click import verbose_option
 
-import pyobo
 from biomappings.gilda_utils import CMapping, append_gilda_predictions
 from biomappings.utils import get_script_url
 

--- a/scripts/generate_ccle_mappings.py
+++ b/scripts/generate_ccle_mappings.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+"""Generate mappings to Gilda from given PyOBO prefixes."""
+
+import click
+from more_click import verbose_option
+
+import pyobo
+from biomappings.gilda_utils import CMapping, append_gilda_predictions
+from biomappings.utils import get_script_url
+
+
+@click.command()
+@verbose_option
+def main():
+    """Generate CCLE mappings."""
+    provenance = get_script_url(__file__)
+    custom_filter = generate_custom_filter()
+    append_gilda_predictions(
+        "ccle",
+        ["depmap", "efo", "cellosaurus", "cl", "bto"],
+        provenance=provenance,
+        relation="skos:exactMatch",
+        custom_filter=custom_filter,
+        identifiers_are_names=True,
+    )
+
+
+def generate_custom_filter() -> CMapping:
+    """Get custom CCLE->X mappings."""
+    ccle_depmap = pyobo.get_filtered_xrefs("ccle", "depmap")
+    ccle_cellosaurus = _cdict(
+        (ccle_id, pyobo.get_xref("depmap", depmap_id, "cellosaurus"))
+        for ccle_id, depmap_id in ccle_depmap.items()
+    )
+    ccle_efo = _cdict(
+        (ccle_id, pyobo.get_xref("cellosaurus", cvcl_id, "efo"))
+        for ccle_id, cvcl_id in ccle_cellosaurus.items()
+    )
+    ccle_bto = _cdict(
+        (ccle_id, pyobo.get_xref("cellosaurus", cvcl_id, "bto"))
+        for ccle_id, cvcl_id in ccle_cellosaurus.items()
+    )
+    return {
+        "ccle": {
+            "depmap": ccle_depmap,
+            "cellosaurus": ccle_cellosaurus,
+            "efo": ccle_efo,
+            "ccle_bto": ccle_bto,
+        }
+    }
+
+
+def _cdict(x):
+    return {k: v for k, v in x if v}
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_mondo_mappings.py
+++ b/scripts/generate_mondo_mappings.py
@@ -10,8 +10,11 @@ from biomappings.utils import get_script_url
 @click.command()
 @verbose_option
 def main():
-    fname = get_script_url(__file__)
-    append_gilda_predictions("mondo", ["doid", "efo"], provenance=fname, rel="skos:exactMatch")
+    """Generate MONDO mappings."""
+    provenance = get_script_url(__file__)
+    append_gilda_predictions(
+        "mondo", ["doid", "efo"], provenance=provenance, relation="skos:exactMatch"
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/generate_mondo_mappings.py
+++ b/scripts/generate_mondo_mappings.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+import click
+from more_click import verbose_option
+
+from biomappings.gilda_utils import append_gilda_predictions
+from biomappings.utils import get_script_url
+
+
+@click.command()
+@verbose_option
+def main():
+    fname = get_script_url(__file__)
+    append_gilda_predictions("mondo", ["doid", "efo"], provenance=fname, rel="skos:exactMatch")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_mondo_mappings.py
+++ b/scripts/generate_mondo_mappings.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""Generate mappings to Gilda from given PyOBO prefixes."""
+
 import click
 from more_click import verbose_option
 

--- a/scripts/generate_pathway_mappings.py
+++ b/scripts/generate_pathway_mappings.py
@@ -2,44 +2,17 @@
 
 """Generate mappings to Gilda from given PyOBO prefixes."""
 
-import itertools as itt
-from typing import Iterable
-
-import gilda
-import gilda.grounder
-import pyobo
-from tqdm import tqdm
-
-from biomappings.resources import PredictionTuple, append_prediction_tuples
+from biomappings.gilda_utils import append_gilda_predictions
 from biomappings.utils import get_script_url
 
 
-def iter_gilda_prediction_tuples(prefix: str, relation: str) -> Iterable[PredictionTuple]:
-    """Iterate over prediction tuples for a given prefix."""
-    provenance = get_script_url(__file__)
-    id_name_mapping = pyobo.get_id_name_mapping(prefix)
-    for identifier, name in tqdm(id_name_mapping.items(), desc=f"Mapping {prefix}"):
-        for scored_match in gilda.ground(name):
-            yield PredictionTuple(
-                prefix,
-                identifier,
-                name,
-                relation,
-                scored_match.term.db.lower(),
-                scored_match.term.id,
-                scored_match.term.entry_name,
-                "lexical",
-                scored_match.score,
-                provenance,
-            )
+def main():
+    """Make species specific groundings from reactome to wikipathways."""
+    to = ["reactome", "wikipathways", "pw"]
+    fname = get_script_url(__file__)
+    for prefix in ["reactome", "wikipathways"]:
+        append_gilda_predictions(prefix, to, provenance=fname, rel="speciesSpecific")
 
 
 if __name__ == "__main__":
-    append_prediction_tuples(
-        itt.chain.from_iterable(
-            sorted(
-                iter_gilda_prediction_tuples(prefix, "speciesSpecific"), key=lambda t: (t[0], t[2])
-            )
-            for prefix in ["reactome", "wikipathways"]
-        )
-    )
+    main()

--- a/scripts/generate_pathway_mappings.py
+++ b/scripts/generate_pathway_mappings.py
@@ -8,10 +8,12 @@ from biomappings.utils import get_script_url
 
 def main():
     """Make species specific groundings from reactome to wikipathways."""
-    to = ["reactome", "wikipathways", "pw"]
-    fname = get_script_url(__file__)
+    target_prefixes = ["reactome", "wikipathways", "pw"]
+    provenance = get_script_url(__file__)
     for prefix in ["reactome", "wikipathways"]:
-        append_gilda_predictions(prefix, to, provenance=fname, rel="speciesSpecific")
+        append_gilda_predictions(
+            prefix, target_prefixes, provenance=provenance, relation="speciesSpecific"
+        )
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     pyyaml
     tqdm
     pystow>=0.1.7
-    bioregistry>=0.2.2
+    bioregistry>=0.2.4
 
 zip_safe = false
 include_package_data = True

--- a/src/biomappings/gilda_utils.py
+++ b/src/biomappings/gilda_utils.py
@@ -9,6 +9,26 @@ from pyobo.gilda_utils import get_grounder, iter_gilda_prediction_tuples
 logger = logging.getLogger(__name__)
 
 
+def append_gilda_predictions(
+    prefix: str,
+    target_prefixes: Union[str, Iterable[str]],
+    provenance: str,
+    relation: str = "skos:exactMatch",
+) -> None:
+    """Add gilda predictions to the Biomappings predictions.tsv file.
+
+    :param prefix: The source prefix
+    :param target_prefixes: The target prefix or prefixes
+    :param provenance: The provenance text. Typically generated with ``biomappings.utils.get_script_url(__file__)``.
+    :param relation: The relationship. Defaults to ``skos:exactMatch``.
+    """
+    grounder = get_grounder(target_prefixes)
+    it = iter_prediction_tuples(prefix, relation=relation, grounder=grounder, provenance=provenance)
+    it = filter_premapped(it, prefix, target_prefixes)
+    it = sorted(it, key=_key)
+    append_prediction_tuples(it)
+
+
 def iter_prediction_tuples(
     prefix: str,
     relation: str,
@@ -20,15 +40,12 @@ def iter_prediction_tuples(
         yield PredictionTuple(*t, provenance)
 
 
-def has_mapping(prefix: str, identifier: str, target_prefix: str) -> bool:
-    return get_xref(prefix, identifier, target_prefix) is not None
-
-
 def filter_premapped(
-    tups: Iterable[PredictionTuple],
+    predictions: Iterable[PredictionTuple],
     source_prefixes: Union[str, Iterable[str]],
     target_prefixes: Union[str, Iterable[str]],
 ) -> Iterable[PredictionTuple]:
+    """Filter pre-mapped predictions."""
     source_prefixes = (
         {source_prefixes} if isinstance(source_prefixes, str) else set(source_prefixes)
     )
@@ -36,26 +53,23 @@ def filter_premapped(
         {target_prefixes} if isinstance(target_prefixes, str) else set(target_prefixes)
     )
     counter = 0
-    for t in tups:
+    for prediction in predictions:
         if (
-            t.source_prefix in source_prefixes
-            and t.target_prefix in target_prefixes
-            and has_mapping(t.source_prefix, t.source_id, t.target_prefix)
+            prediction.source_prefix in source_prefixes
+            and prediction.target_prefix in target_prefixes
+            and has_mapping(
+                prediction.source_prefix, prediction.source_id, prediction.target_prefix
+            )
         ):
             counter += 1
             continue
-        yield t
+        yield prediction
     logger.info("filtered out %d pre-mapped matches", counter)
 
 
-def append_gilda_predictions(
-    prefix: str, target_prefixes: Union[str, Iterable[str]], provenance, rel="skos:exactMatch"
-) -> None:
-    grounder = get_grounder(target_prefixes)
-    it = iter_prediction_tuples(prefix, relation=rel, grounder=grounder, provenance=provenance)
-    it = filter_premapped(it, prefix, target_prefixes)
-    it = sorted(it, key=_key)
-    append_prediction_tuples(it)
+def has_mapping(prefix: str, identifier: str, target_prefix: str) -> bool:
+    """Check if there's already a mapping available for this entity in a target namespace."""
+    return get_xref(prefix, identifier, target_prefix) is not None
 
 
 def _key(t: PredictionTuple) -> Tuple[str, str]:

--- a/src/biomappings/gilda_utils.py
+++ b/src/biomappings/gilda_utils.py
@@ -1,10 +1,15 @@
+# -*- coding: utf-8 -*-
+
+"""Utilities for generating predictions with pyobo/gilda."""
+
 import logging
 from typing import Iterable, Optional, Tuple, Union
 
-from biomappings.resources import PredictionTuple, append_prediction_tuples
 from gilda.grounder import Grounder
 from pyobo import get_xref
 from pyobo.gilda_utils import get_grounder, iter_gilda_prediction_tuples
+
+from biomappings.resources import PredictionTuple, append_prediction_tuples
 
 logger = logging.getLogger(__name__)
 

--- a/src/biomappings/gilda_utils.py
+++ b/src/biomappings/gilda_utils.py
@@ -29,8 +29,12 @@ def filter_premapped(
     source_prefixes: Union[str, Iterable[str]],
     target_prefixes: Union[str, Iterable[str]],
 ) -> Iterable[PredictionTuple]:
-    source_prefixes = {source_prefixes} if isinstance(source_prefixes, str) else set(source_prefixes)
-    target_prefixes = {target_prefixes} if isinstance(target_prefixes, str) else set(target_prefixes)
+    source_prefixes = (
+        {source_prefixes} if isinstance(source_prefixes, str) else set(source_prefixes)
+    )
+    target_prefixes = (
+        {target_prefixes} if isinstance(target_prefixes, str) else set(target_prefixes)
+    )
     counter = 0
     for t in tups:
         if (
@@ -41,16 +45,14 @@ def filter_premapped(
             counter += 1
             continue
         yield t
-    logger.info('filtered out %d pre-mapped matches', counter)
+    logger.info("filtered out %d pre-mapped matches", counter)
 
 
 def append_gilda_predictions(
     prefix: str, target_prefixes: Union[str, Iterable[str]], provenance, rel="skos:exactMatch"
 ) -> None:
     grounder = get_grounder(target_prefixes)
-    it = iter_prediction_tuples(
-        prefix, relation=rel, grounder=grounder, provenance=provenance
-    )
+    it = iter_prediction_tuples(prefix, relation=rel, grounder=grounder, provenance=provenance)
     it = filter_premapped(it, prefix, target_prefixes)
     it = sorted(it, key=_key)
     append_prediction_tuples(it)

--- a/src/biomappings/gilda_utils.py
+++ b/src/biomappings/gilda_utils.py
@@ -1,0 +1,60 @@
+import logging
+from typing import Iterable, Optional, Tuple, Union
+
+from biomappings.resources import PredictionTuple, append_prediction_tuples
+from gilda.grounder import Grounder
+from pyobo import get_xref
+from pyobo.gilda_utils import get_grounder, iter_gilda_prediction_tuples
+
+logger = logging.getLogger(__name__)
+
+
+def iter_prediction_tuples(
+    prefix: str,
+    relation: str,
+    provenance: str,
+    grounder: Optional[Grounder] = None,
+) -> Iterable[PredictionTuple]:
+    """Iterate over prediction tuples for a given prefix."""
+    for t in iter_gilda_prediction_tuples(prefix=prefix, relation=relation, grounder=grounder):
+        yield PredictionTuple(*t, provenance)
+
+
+def has_mapping(prefix: str, identifier: str, target_prefix: str) -> bool:
+    return get_xref(prefix, identifier, target_prefix) is not None
+
+
+def filter_premapped(
+    tups: Iterable[PredictionTuple],
+    source_prefixes: Union[str, Iterable[str]],
+    target_prefixes: Union[str, Iterable[str]],
+) -> Iterable[PredictionTuple]:
+    source_prefixes = {source_prefixes} if isinstance(source_prefixes, str) else set(source_prefixes)
+    target_prefixes = {target_prefixes} if isinstance(target_prefixes, str) else set(target_prefixes)
+    counter = 0
+    for t in tups:
+        if (
+            t.source_prefix in source_prefixes
+            and t.target_prefix in target_prefixes
+            and has_mapping(t.source_prefix, t.source_id, t.target_prefix)
+        ):
+            counter += 1
+            continue
+        yield t
+    logger.info('filtered out %d pre-mapped matches', counter)
+
+
+def append_gilda_predictions(
+    prefix: str, target_prefixes: Union[str, Iterable[str]], provenance, rel="skos:exactMatch"
+) -> None:
+    grounder = get_grounder(target_prefixes)
+    it = iter_prediction_tuples(
+        prefix, relation=rel, grounder=grounder, provenance=provenance
+    )
+    it = filter_premapped(it, prefix, target_prefixes)
+    it = sorted(it, key=_key)
+    append_prediction_tuples(it)
+
+
+def _key(t: PredictionTuple) -> Tuple[str, str]:
+    return t.source_prefix, t.source_name

--- a/src/biomappings/gilda_utils.py
+++ b/src/biomappings/gilda_utils.py
@@ -23,6 +23,7 @@ def append_gilda_predictions(
     relation: str = "skos:exactMatch",
     custom_filter: Optional[CMapping] = None,
     unnamed: Optional[Iterable[str]] = None,
+    identifiers_are_names: bool = False,
 ) -> None:
     """Add gilda predictions to the Biomappings predictions.tsv file.
 
@@ -33,7 +34,11 @@ def append_gilda_predictions(
     """
     grounder = get_grounder(target_prefixes, unnamed=unnamed)
     predictions = iter_prediction_tuples(
-        prefix, relation=relation, grounder=grounder, provenance=provenance
+        prefix,
+        relation=relation,
+        grounder=grounder,
+        provenance=provenance,
+        identifiers_are_names=identifiers_are_names,
     )
     if custom_filter is not None:
         predictions = filter_custom(predictions, custom_filter)
@@ -47,9 +52,15 @@ def iter_prediction_tuples(
     relation: str,
     provenance: str,
     grounder: Optional[Grounder] = None,
+    identifiers_are_names: bool = False,
 ) -> Iterable[PredictionTuple]:
     """Iterate over prediction tuples for a given prefix."""
-    for t in iter_gilda_prediction_tuples(prefix=prefix, relation=relation, grounder=grounder):
+    for t in iter_gilda_prediction_tuples(
+        prefix=prefix,
+        relation=relation,
+        grounder=grounder,
+        identifiers_are_names=identifiers_are_names,
+    ):
         yield PredictionTuple(*t, provenance)
 
 

--- a/src/biomappings/gilda_utils.py
+++ b/src/biomappings/gilda_utils.py
@@ -3,7 +3,7 @@
 """Utilities for generating predictions with pyobo/gilda."""
 
 import logging
-from typing import Iterable, Mapping, Optional, Set, Tuple, Union
+from typing import Iterable, Mapping, Optional, Tuple, Union
 
 from gilda.grounder import Grounder
 from pyobo import get_xref
@@ -31,6 +31,10 @@ def append_gilda_predictions(
     :param target_prefixes: The target prefix or prefixes
     :param provenance: The provenance text. Typically generated with ``biomappings.utils.get_script_url(__file__)``.
     :param relation: The relationship. Defaults to ``skos:exactMatch``.
+    :param custom_filter: A triple nested dictionary from source prefix to target prefix to source id to target id.
+        Any source prefix, target prefix, source id combinations in this dictionary will be filtered.
+    :param unnamed: An optional list of prefixes whose identifiers should be considered as names (e.g., CCLE, FPLX)
+    :param identifiers_are_names: The source prefix's identifiers should be considered as names
     """
     grounder = get_grounder(target_prefixes, unnamed=unnamed)
     predictions = iter_prediction_tuples(

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -3701,3 +3701,16 @@ mesh	C580365	Pdgfrb-Associated Chronic Eosinophilic Leukemia	skos:exactMatch	doi
 mesh	C567578	Frontootopalatodigital Osteodysplasia	skos:exactMatch	doid	DOID:0111782	otopalatodigital syndrome spectrum disorder	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D014005	Tinea	skos:exactMatch	doid	DOID:8913	dermatophytosis	manually_reviewed	orcid:0000-0003-1307-2508
 mesh	D015840	Oculomotor Nerve Diseases	skos:exactMatch	doid	DOID:562	third cranial nerve disease	manually_reviewed	orcid:0000-0003-1307-2508
+ccle.cell	KMS12BM_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE	KMS-12-BM	skos:exactMatch	cellosaurus	CVCL_1334	KMS-12-BM	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	KMS12BM_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE	KMS-12-BM	skos:exactMatch	efo	0006612	KMS-12-BM	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	KMS12BM_HAEMATOPOIETIC_AND_LYMPHOID_TISSUE	KMS-12-BM	skos:exactMatch	bto	BTO:0006459	KMS-12-BM cell	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	YH13_CENTRAL_NERVOUS_SYSTEM	YH-13	skos:exactMatch	cellosaurus	CVCL_1795	YH-13	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	YKG1_CENTRAL_NERVOUS_SYSTEM	YKG1	skos:exactMatch	cellosaurus	CVCL_1796	YKG-1	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	YMB1_BREAST	YMB-1	skos:exactMatch	cellosaurus	CVCL_2814	YMB-1	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	YMB1_BREAST	YMB-1	skos:exactMatch	efo	0006779	YMB-1	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	ZR751_BREAST	ZR-75-1	skos:exactMatch	efo	0001262	ZR751	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	ZR751_BREAST	ZR-75-1	skos:exactMatch	cellosaurus	CVCL_0588	ZR-75-1	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	ZR7530_BREAST	ZR-75-30	skos:exactMatch	cellosaurus	CVCL_1661	ZR-75-30	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	ZR7530_BREAST	ZR-75-30	skos:exactMatch	efo	0001263	ZR7530	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	HUH1_LIVER	huH-1	skos:exactMatch	efo	0006445	huH-1	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	HUH1_LIVER	huH-1	skos:exactMatch	cellosaurus	CVCL_2956	HuH-1	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/resources/mappings.tsv
+++ b/src/biomappings/resources/mappings.tsv
@@ -3714,3 +3714,4 @@ ccle.cell	ZR7530_BREAST	ZR-75-30	skos:exactMatch	cellosaurus	CVCL_1661	ZR-75-30	
 ccle.cell	ZR7530_BREAST	ZR-75-30	skos:exactMatch	efo	0001263	ZR7530	manually_reviewed	orcid:0000-0003-4423-4370
 ccle.cell	HUH1_LIVER	huH-1	skos:exactMatch	efo	0006445	huH-1	manually_reviewed	orcid:0000-0003-4423-4370
 ccle.cell	HUH1_LIVER	huH-1	skos:exactMatch	cellosaurus	CVCL_2956	HuH-1	manually_reviewed	orcid:0000-0003-4423-4370
+ccle.cell	LNCAPCLONEFGC_PROSTATE	LNCaP clone FGC	skos:exactMatch	bto	BTO:0006095	LNCaP clone FGC	manually_reviewed	orcid:0000-0003-4423-4370

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -114,11 +114,11 @@ class MiriamValidator:
             entry = self.entries[prefix]
             if not re.match(entry["pattern"], identifier):
                 raise InvalidIdentifier(prefix, identifier)
+        elif bioregistry.get(prefix) is None:
+            raise InvalidPrefix(prefix)
         elif bioregistry.get_pattern(prefix) is None:
             if bioregistry.validate(prefix, identifier):
                 raise InvalidIdentifier(prefix, identifier)
-        else:
-            raise InvalidPrefix(prefix)
 
     def get_curie(self, prefix: str, identifier: str) -> str:
         """Return CURIE for a given prefix and identifier."""

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -110,11 +110,15 @@ class MiriamValidator:
 
     def check_valid_prefix_id(self, prefix, identifier):
         """Check the prefix/identifier pair is valid."""
-        if prefix not in self.entries:
+        if prefix in self.entries:
+            entry = self.entries[prefix]
+            if not re.match(entry["pattern"], identifier):
+                raise InvalidIdentifier(prefix, identifier)
+        elif bioregistry.get_pattern(prefix) is None:
+            if bioregistry.validate(prefix, identifier):
+                raise InvalidIdentifier(prefix, identifier)
+        else:
             raise InvalidPrefix(prefix)
-        entry = self.entries[prefix]
-        if not re.match(entry["pattern"], identifier):
-            raise InvalidIdentifier(identifier)
 
     def get_curie(self, prefix: str, identifier: str) -> str:
         """Return CURIE for a given prefix and identifier."""

--- a/src/biomappings/utils.py
+++ b/src/biomappings/utils.py
@@ -104,7 +104,9 @@ class MiriamValidator:
 
     def namespace_embedded(self, prefix: str) -> bool:
         """Return True if the namespace is embedded for the given prefix."""
-        return self.entries[prefix]["namespace_embedded"]
+        if prefix in self.entries:
+            return self.entries[prefix]["namespace_embedded"]
+        return bioregistry.namespace_in_lui(prefix)
 
     def check_valid_prefix_id(self, prefix, identifier):
         """Check the prefix/identifier pair is valid."""


### PR DESCRIPTION
This PR refactors the PyOBO + Gilda prediction code. 

1. Support optionally using identifiers as names when generating Gilda terms. This is necessary for CCLE, FPLX, etc.
2. Support filtering out predictions for (source prefix, source id, target prefix) 3-tuples that are already in mappings loadable through PyOBO
3. Support filtering out custom sets, which I demonstrate by building up mappings for CCLE based on transitivities through DepMap, Cellosaurus, BTO, EFO, and CL. I also updated some of the code in PyOBO and Bioregistry to support this.

This PR also runs the CCLE mapping and generates plenty of novel curation opportunities. I added a few curations as examples. @ALHoyt can try doing the rest in the next few days.

CC @bgyori @stirlin6 these mappings will provide additional context for the INDRA context graph's cBioPortal import.